### PR TITLE
Adds API URL to OpenVPN server configuration

### DIFF
--- a/OpenVPNGateMonitor.DataBase/ConfigurationModels/OpenVpnServerConfiguration.cs
+++ b/OpenVPNGateMonitor.DataBase/ConfigurationModels/OpenVpnServerConfiguration.cs
@@ -24,6 +24,8 @@ public class OpenVpnServerConfiguration : BaseEntityConfiguration<OpenVpnServer>
             .HasMaxLength(50);
         entity.Property(e => e.IsOnline);
         entity.Property(e => e.IsDefault);
+        entity.Property(e => e.ApiUrl)
+            .HasMaxLength(255);
         
         entity.HasData(OpenVpnServerSeedData.Data);
     }

--- a/OpenVPNGateMonitor.DataBase/ConfigurationModels/Seeds/OpenVpnServerSeedData.cs
+++ b/OpenVPNGateMonitor.DataBase/ConfigurationModels/Seeds/OpenVpnServerSeedData.cs
@@ -14,6 +14,9 @@ public static class OpenVpnServerSeedData
             ManagementPort = 5092,
             IsOnline = false,
             IsDefault = true,
+            ApiUrl = "http://openvpn_udp:5000/",
+            Login = "",
+            Password = ""
         },
         new OpenVpnServer
         {
@@ -23,6 +26,9 @@ public static class OpenVpnServerSeedData
             ManagementPort = 5093,
             IsOnline = false,
             IsDefault = false,
+            ApiUrl = "http://openvpn_tcp:5000/",
+            Login = "",
+            Password = ""
         },
     };
 }

--- a/OpenVPNGateMonitor.DataBase/Migrations/20250505165705_OpenVpnServer_ApiUrl.Designer.cs
+++ b/OpenVPNGateMonitor.DataBase/Migrations/20250505165705_OpenVpnServer_ApiUrl.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OpenVPNGateMonitor.DataBase.Contexts;
@@ -11,9 +12,11 @@ using OpenVPNGateMonitor.DataBase.Contexts;
 namespace OpenVPNGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250505165705_OpenVpnServer_ApiUrl")]
+    partial class OpenVpnServer_ApiUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OpenVPNGateMonitor.DataBase/Migrations/20250505165705_OpenVpnServer_ApiUrl.cs
+++ b/OpenVPNGateMonitor.DataBase/Migrations/20250505165705_OpenVpnServer_ApiUrl.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OpenVPNGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class OpenVpnServer_ApiUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ApiUrl",
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.UpdateData(
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "ApiUrl",
+                value: "http://openvpn_udp:5000/");
+
+            migrationBuilder.UpdateData(
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "ApiUrl",
+                value: "http://openvpn_tcp:5000/");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ApiUrl",
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers");
+        }
+    }
+}

--- a/OpenVPNGateMonitor.Models/Helpers/DataGateCertManager/AddOvpnFileRequest.cs
+++ b/OpenVPNGateMonitor.Models/Helpers/DataGateCertManager/AddOvpnFileRequest.cs
@@ -4,6 +4,7 @@ namespace OpenVPNGateMonitor.Models.Helpers.DataGateCertManager;
 
 public class AddOvpnFileRequest
 {
+    public int ServerId {get; set;}
     [DefaultValue("")]
     public string CommonName { get; set; } = string.Empty;
 

--- a/OpenVPNGateMonitor.Models/Helpers/DataGateCertManager/DownloadOvpnFileRequest.cs
+++ b/OpenVPNGateMonitor.Models/Helpers/DataGateCertManager/DownloadOvpnFileRequest.cs
@@ -2,6 +2,7 @@
 
 public class DownloadOvpnFileRequest
 {
+    public int ServerId {get; set;}
     public string CommonName { get; set; } = string.Empty;
     public string FileName { get; set; } = string.Empty;
     public string FilePath { get; set; } = string.Empty;

--- a/OpenVPNGateMonitor.Models/Helpers/DataGateCertManager/RevokeOvpnFileRequest.cs
+++ b/OpenVPNGateMonitor.Models/Helpers/DataGateCertManager/RevokeOvpnFileRequest.cs
@@ -2,6 +2,7 @@
 
 public class RevokeOvpnFileRequest
 {
+    public int ServerId {get; set;}
     public string CommonName { get; set; } = string.Empty;
     public string OvpnFileName { get; set; } = string.Empty;
     public string OvpnFilePath { get; set; } = string.Empty;

--- a/OpenVPNGateMonitor.Models/OpenVpnServer.cs
+++ b/OpenVPNGateMonitor.Models/OpenVpnServer.cs
@@ -9,4 +9,5 @@ public class OpenVpnServer : BaseEntity<int>
     public string Password { get; set; } = string.Empty;
     public bool IsOnline { get; set; } = false;
     public bool IsDefault { get; set; } = false;
+    public string ApiUrl { get; set; } = string.Empty;
 }

--- a/OpenVPNGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/ServiceConfiguration.cs
@@ -58,18 +58,9 @@ public static class ServiceConfiguration
 
         #region DataGateCertManager
 
-        var baseUrl = configuration["DataGateCertManager:BaseUrl"]
-                      ?? throw new InvalidOperationException("DataGateCertManager:BaseUrl not configured");
-
-        static void ConfigureDataGateClient(HttpClient client, string baseUrl)
-        {
-            client.BaseAddress = new Uri(baseUrl);
-            client.Timeout = TimeSpan.FromSeconds(30);
-        }
-
-        services.AddHttpClient<ICertApiClient, CertApiClient>(client => ConfigureDataGateClient(client, baseUrl));
-        services.AddHttpClient<IOvpnFileApiClient, OvpnFileApiClient>(client => ConfigureDataGateClient(client, baseUrl));
-
+        services.AddHttpClient();
+        services.AddScoped<ICertApiClient, CertApiClient>();
+        services.AddScoped<IOvpnFileApiClient, OvpnFileApiClient>();
 
         #endregion
     }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -25,7 +25,8 @@ public class OpenVpnFilesController(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to add OVPN file for {CommonName}", request.CommonName);
+            logger.LogError(ex, "Failed to add OVPN file for {CommonName} on server {ServerId}", 
+                request.CommonName, request.ServerId);
             return BadRequest(new { error = "Failed to add OVPN file", message = ex.Message });
         }
     }
@@ -42,8 +43,8 @@ public class OpenVpnFilesController(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to revoke OVPN file {FileName} for {CommonName}", 
-                request.OvpnFileName, request.CommonName);
+            logger.LogError(ex, "Failed to revoke OVPN file {FileName} for {CommonName} on server {ServerId}", 
+                request.OvpnFileName, request.CommonName, request.ServerId);
             return BadRequest(new { error = "Failed to revoke OVPN file", message = ex.Message });
         }
     }
@@ -60,8 +61,8 @@ public class OpenVpnFilesController(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to download OVPN file {FileName} for {CommonName}", 
-                request.FileName, request.CommonName);
+            logger.LogError(ex, "Failed to download OVPN file {FileName} for {CommonName} on server {ServerId}", 
+                request.FileName, request.CommonName, request.ServerId);
             return BadRequest(new { error = "Failed to download OVPN file", message = ex.Message });
         }
     }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServerCertsController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServerCertsController.cs
@@ -13,68 +13,76 @@ public class OpenVpnServerCertsController(
     ICertApiClient certApiClient,
     ILogger<OpenVpnServerCertsController> logger) : ControllerBase
 {
-    [HttpGet("GetAllCertificates")]
-    public async Task<ActionResult<List<CertificateCaInfo>>> GetAllCertificates(CancellationToken cancellationToken)
+    [HttpGet("{serverId}/GetAllCertificates")]
+    public async Task<ActionResult<List<CertificateCaInfo>>> GetAllCertificates(
+        int serverId,
+        CancellationToken cancellationToken)
     {
         try
         {
-            var certificates = await certApiClient.GetAllCertificatesAsync(cancellationToken);
+            var certificates = await certApiClient.GetAllCertificatesAsync(serverId, cancellationToken);
             return Ok(certificates);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get all certificates");
+            logger.LogError(ex, "Failed to get certificates from server {ServerId}", serverId);
             return BadRequest(new { error = "Failed to retrieve certificates", message = ex.Message });
         }
     }
 
-    [HttpPost("BuildCertificate")]
+    [HttpPost("{serverId}/BuildCertificate")]
     public async Task<ActionResult<CertificateBuildResult>> BuildCertificate(
+        int serverId,
         [FromBody] string commonName,
         CancellationToken cancellationToken)
     {
         try
         {
-            var result = await certApiClient.BuildCertificateAsync(commonName, cancellationToken);
+            var result = await certApiClient.BuildCertificateAsync(serverId, commonName, cancellationToken);
             return Ok(result);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to build certificate for {CommonName}", commonName);
+            logger.LogError(ex, "Failed to build certificate for {CommonName} on server {ServerId}", 
+                commonName, serverId);
             return BadRequest(new { error = "Failed to build certificate", message = ex.Message });
         }
     }
 
-    [HttpPost("RevokeCertificate/{commonName}")]
+    [HttpPost("{serverId}/RevokeCertificate/{commonName}")]
     public async Task<ActionResult<CertificateRevokeResult>> RevokeCertificate(
+        int serverId,
         string commonName,
         CancellationToken cancellationToken)
     {
         try
         {
-            var result = await certApiClient.RevokeCertificateAsync(commonName, cancellationToken);
+            var result = await certApiClient.RevokeCertificateAsync(serverId, commonName, cancellationToken);
             return Ok(result);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to revoke certificate for {CommonName}", commonName);
+            logger.LogError(ex, "Failed to revoke certificate for {CommonName} on server {ServerId}", 
+                commonName, serverId);
             return BadRequest(new { error = "Failed to revoke certificate", message = ex.Message });
         }
     }
 
-    [HttpGet("GetPemContent/{filePath}")]
+    [HttpGet("{serverId}/GetPemContent/{filePath}")]
     public async Task<ActionResult<string>> GetPemContent(
+        int serverId,
         string filePath,
         CancellationToken cancellationToken)
     {
         try
         {
-            var content = await certApiClient.GetPemContentAsync(filePath, cancellationToken);
+            var content = await certApiClient.GetPemContentAsync(serverId, filePath, cancellationToken);
             return Ok(content);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get PEM content for {FilePath}", filePath);
+            logger.LogError(ex, "Failed to get PEM content for {FilePath} from server {ServerId}", 
+                filePath, serverId);
             return BadRequest(new { error = "Failed to get PEM content", message = ex.Message });
         }
     }

--- a/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerService.cs
+++ b/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerService.cs
@@ -3,7 +3,6 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using OpenVPNGateMonitor.DataBase.UnitOfWork;
 using OpenVPNGateMonitor.Models;
-using OpenVPNGateMonitor.Models.Helpers.Api;
 using OpenVPNGateMonitor.Models.Helpers.Services;
 using OpenVPNGateMonitor.Services.BackgroundServices.Interfaces;
 using OpenVPNGateMonitor.Services.Helpers;

--- a/OpenVPNGateMonitor/Services/DataGateCertManager/CertApiClient.cs
+++ b/OpenVPNGateMonitor/Services/DataGateCertManager/CertApiClient.cs
@@ -1,17 +1,31 @@
 ﻿using System.Text.Json;
 using OpenVPNGateMonitor.Models.Helpers;
 using OpenVPNGateMonitor.Models.Helpers.DataGateCertManager;
+using OpenVPNGateMonitor.Services.Api.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateCertManager.Interfaces;
 
 namespace OpenVPNGateMonitor.Services.DataGateCertManager;
 
-public class CertApiClient(HttpClient httpClient, ILogger<CertApiClient> logger) : ICertApiClient
+public class CertApiClient(
+    IHttpClientFactory httpClientFactory,
+    IVpnDataService vpnDataService,
+    ILogger<CertApiClient> logger)
+    : ICertApiClient
 {
-    public async Task<List<CertificateCaInfo>> GetAllCertificatesAsync(CancellationToken cancellationToken)
+    private async Task<HttpClient> GetClientForServerAsync(int serverId, CancellationToken cancellationToken)
+    {
+        var server = await vpnDataService.GetOpenVpnServer(serverId, cancellationToken);
+        var client = httpClientFactory.CreateClient();
+        client.BaseAddress = new Uri(server.ApiUrl);
+        return client;
+    }
+
+    public async Task<List<CertificateCaInfo>> GetAllCertificatesAsync(int serverId, CancellationToken cancellationToken)
     {
         try
         {
-            var response = await httpClient.GetAsync("api/EasyRsa/GetAllCertificates", cancellationToken);
+            using var client = await GetClientForServerAsync(serverId, cancellationToken);
+            var response = await client.GetAsync("api/EasyRsa/GetAllCertificates", cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var certificates = await response.Content.ReadFromJsonAsync<List<CertificateCaInfo>>(
@@ -21,26 +35,27 @@ public class CertApiClient(HttpClient httpClient, ILogger<CertApiClient> logger)
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError(ex, "HTTP request failed while getting certificates");
+            logger.LogError(ex, "HTTP request failed while getting certificates from server {ServerId}", serverId);
             throw;
         }
         catch (JsonException ex)
         {
-            logger.LogError(ex, "Failed to deserialize certificates response");
+            logger.LogError(ex, "Failed to deserialize certificates response from server {ServerId}", serverId);
             throw;
         }
     }
     
-    public async Task<CertificateBuildResult> BuildCertificateAsync(string commonName, CancellationToken cancellationToken)
+    public async Task<CertificateBuildResult> BuildCertificateAsync(int serverId, string commonName, CancellationToken cancellationToken)
     {
         try
         {
+            using var client = await GetClientForServerAsync(serverId, cancellationToken);
             var request = new CertificateBuildRequest
             {
                 CommonName = commonName
             };
 
-            var response = await httpClient.PostAsJsonAsync("api/EasyRsa/BuildCertificate", request, cancellationToken);
+            var response = await client.PostAsJsonAsync("api/EasyRsa/BuildCertificate", request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var result = await response.Content.ReadFromJsonAsync<CertificateBuildResult>(
@@ -51,26 +66,30 @@ public class CertApiClient(HttpClient httpClient, ILogger<CertApiClient> logger)
                 throw new InvalidOperationException("Received null response when building certificate");
             }
 
-            logger.LogInformation("Successfully built certificate for {CommonName}", commonName);
+            logger.LogInformation("Successfully built certificate for {CommonName} on server {ServerId}", 
+                commonName, serverId);
             return result;
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError(ex, "HTTP request failed while building certificate for {CommonName}", commonName);
+            logger.LogError(ex, "HTTP request failed while building certificate for {CommonName} on server {ServerId}", 
+                commonName, serverId);
             throw;
         }
         catch (JsonException ex)
         {
-            logger.LogError(ex, "Failed to deserialize build certificate response for {CommonName}", commonName);
+            logger.LogError(ex, "Failed to deserialize build certificate response for {CommonName} on server {ServerId}", 
+                commonName, serverId);
             throw;
         }
     }
     
-    public async Task<CertificateRevokeResult> RevokeCertificateAsync(string commonName, CancellationToken cancellationToken)
+    public async Task<CertificateRevokeResult> RevokeCertificateAsync(int serverId, string commonName, CancellationToken cancellationToken)
     {
         try
         {
-            var response = await httpClient.PostAsync(
+            using var client = await GetClientForServerAsync(serverId, cancellationToken);
+            var response = await client.PostAsync(
                 $"api/EasyRsa/RevokeCertificate/{Uri.EscapeDataString(commonName)}", 
                 null, 
                 cancellationToken);
@@ -86,8 +105,9 @@ public class CertApiClient(HttpClient httpClient, ILogger<CertApiClient> logger)
             }
 
             logger.LogInformation(
-                "Certificate revocation completed for {CommonName}. IsRevoked: {IsRevoked}, Message: {Message}", 
+                "Certificate revocation completed for {CommonName} on server {ServerId}. IsRevoked: {IsRevoked}, Message: {Message}", 
                 commonName, 
+                serverId,
                 result.IsRevoked,
                 result.Message);
 
@@ -95,21 +115,24 @@ public class CertApiClient(HttpClient httpClient, ILogger<CertApiClient> logger)
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError(ex, "HTTP request failed while revoking certificate for {CommonName}", commonName);
+            logger.LogError(ex, "HTTP request failed while revoking certificate for {CommonName} on server {ServerId}", 
+                commonName, serverId);
             throw;
         }
         catch (JsonException ex)
         {
-            logger.LogError(ex, "Failed to deserialize revoke certificate response for {CommonName}", commonName);
+            logger.LogError(ex, "Failed to deserialize revoke certificate response for {CommonName} on server {ServerId}", 
+                commonName, serverId);
             throw;
         }
     }
     
-    public async Task<string> GetPemContentAsync(string filePath, CancellationToken cancellationToken)
+    public async Task<string> GetPemContentAsync(int serverId, string filePath, CancellationToken cancellationToken)
     {
         try
         {
-            var response = await httpClient.GetAsync(
+            using var client = await GetClientForServerAsync(serverId, cancellationToken);
+            var response = await client.GetAsync(
                 $"api/EasyRsa/GetPemContent/{Uri.EscapeDataString(filePath)}", 
                 cancellationToken);
             
@@ -123,17 +146,20 @@ public class CertApiClient(HttpClient httpClient, ILogger<CertApiClient> logger)
                 throw new InvalidOperationException($"Empty PEM content received for file: {filePath}");
             }
 
-            logger.LogDebug("Successfully retrieved PEM content from {FilePath}", filePath);
+            logger.LogDebug("Successfully retrieved PEM content from {FilePath} on server {ServerId}", 
+                filePath, serverId);
             return content;
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError(ex, "HTTP request failed while getting PEM content from {FilePath}", filePath);
+            logger.LogError(ex, "HTTP request failed while getting PEM content from {FilePath} on server {ServerId}", 
+                filePath, serverId);
             throw;
         }
         catch (JsonException ex)
         {
-            logger.LogError(ex, "Failed to deserialize PEM content response from {FilePath}", filePath);
+            logger.LogError(ex, "Failed to deserialize PEM content response from {FilePath} on server {ServerId}", 
+                filePath, serverId);
             throw;
         }
     }

--- a/OpenVPNGateMonitor/Services/DataGateCertManager/Interfaces/ICertApiClient.cs
+++ b/OpenVPNGateMonitor/Services/DataGateCertManager/Interfaces/ICertApiClient.cs
@@ -5,8 +5,8 @@ namespace OpenVPNGateMonitor.Services.DataGateCertManager.Interfaces;
 
 public interface ICertApiClient
 {
-    Task<List<CertificateCaInfo>> GetAllCertificatesAsync(CancellationToken cancellationToken);
-    Task<CertificateBuildResult> BuildCertificateAsync(string commonName, CancellationToken cancellationToken);
-    Task<CertificateRevokeResult> RevokeCertificateAsync(string commonName, CancellationToken cancellationToken);
-    Task<string> GetPemContentAsync(string filePath, CancellationToken cancellationToken);
+    Task<List<CertificateCaInfo>> GetAllCertificatesAsync(int serverId, CancellationToken cancellationToken);
+    Task<CertificateBuildResult> BuildCertificateAsync(int serverId, string commonName, CancellationToken cancellationToken);
+    Task<CertificateRevokeResult> RevokeCertificateAsync(int serverId, string commonName, CancellationToken cancellationToken);
+    Task<string> GetPemContentAsync(int serverId, string filePath, CancellationToken cancellationToken);
 }

--- a/OpenVPNGateMonitor/Services/DataGateCertManager/OvpnFileApiClient.cs
+++ b/OpenVPNGateMonitor/Services/DataGateCertManager/OvpnFileApiClient.cs
@@ -1,17 +1,31 @@
 ﻿using System.Text.Json;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.Models.Helpers.DataGateCertManager;
+using OpenVPNGateMonitor.Services.Api.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateCertManager.Interfaces;
 
 namespace OpenVPNGateMonitor.Services.DataGateCertManager;
 
-public class OvpnFileApiClient(HttpClient httpClient, ILogger<OvpnFileApiClient> logger) : IOvpnFileApiClient
+public class OvpnFileApiClient(
+    IHttpClientFactory httpClientFactory,
+    IVpnDataService vpnDataService,
+    ILogger<OvpnFileApiClient> logger)
+    : IOvpnFileApiClient
 {
+    private async Task<HttpClient> GetClientForServerAsync(int serverId, CancellationToken cancellationToken)
+    {
+        var server = await vpnDataService.GetOpenVpnServer(serverId, cancellationToken);
+        var client = httpClientFactory.CreateClient();
+        client.BaseAddress = new Uri(server.ApiUrl);
+        return client;
+    }
+
     public async Task<IssuedOvpnFile> AddOvpnFileAsync(AddOvpnFileRequest request, CancellationToken cancellationToken)
     {
         try
         {
-            var response = await httpClient.PostAsJsonAsync("api/OvpnFile/AddOvpnFile", request, cancellationToken);
+            using var client = await GetClientForServerAsync(request.ServerId, cancellationToken);
+            var response = await client.PostAsJsonAsync("api/OvpnFile/AddOvpnFile", request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var result = await response.Content.ReadFromJsonAsync<IssuedOvpnFile>(cancellationToken: cancellationToken);
@@ -21,17 +35,20 @@ public class OvpnFileApiClient(HttpClient httpClient, ILogger<OvpnFileApiClient>
                 throw new InvalidOperationException("Received null response when adding OVPN file");
             }
 
-            logger.LogInformation("Successfully added OVPN file for {CommonName}", request.CommonName);
+            logger.LogInformation("Successfully added OVPN file for {CommonName} on server {ServerUrl}", 
+                request.CommonName, client.BaseAddress);
             return result;
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError(ex, "HTTP request failed while adding OVPN file for {CommonName}", request.CommonName);
+            logger.LogError(ex, "HTTP request failed while adding OVPN file for {CommonName} on server {ServerId}", 
+                request.CommonName, request.ServerId);
             throw;
         }
         catch (JsonException ex)
         {
-            logger.LogError(ex, "Failed to deserialize add OVPN file response for {CommonName}", request.CommonName);
+            logger.LogError(ex, "Failed to deserialize add OVPN file response for {CommonName} on server {ServerId}", 
+                request.CommonName, request.ServerId);
             throw;
         }
     }
@@ -40,22 +57,26 @@ public class OvpnFileApiClient(HttpClient httpClient, ILogger<OvpnFileApiClient>
     {
         try
         {
-            var response = await httpClient.PostAsJsonAsync("api/OvpnFile/RevokeOvpnFile", request, cancellationToken);
+            using var client = await GetClientForServerAsync(request.ServerId, cancellationToken);
+            var response = await client.PostAsJsonAsync("api/OvpnFile/RevokeOvpnFile", request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var result = await response.Content.ReadFromJsonAsync<bool>(cancellationToken: cancellationToken);
             
-            logger.LogInformation("OVPN file revocation completed for {CommonName}", request.CommonName);
+            logger.LogInformation("OVPN file revocation completed for {CommonName} on server {ServerUrl}", 
+                request.CommonName, client.BaseAddress);
             return result;
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError(ex, "HTTP request failed while revoking OVPN file for {CommonName}", request.CommonName);
+            logger.LogError(ex, "HTTP request failed while revoking OVPN file for {CommonName} on server {ServerId}", 
+                request.CommonName, request.ServerId);
             throw;
         }
         catch (JsonException ex)
         {
-            logger.LogError(ex, "Failed to deserialize revoke OVPN file response for {CommonName}", request.CommonName);
+            logger.LogError(ex, "Failed to deserialize revoke OVPN file response for {CommonName} on server {ServerId}", 
+                request.CommonName, request.ServerId);
             throw;
         }
     }
@@ -64,7 +85,8 @@ public class OvpnFileApiClient(HttpClient httpClient, ILogger<OvpnFileApiClient>
     {
         try
         {
-            var response = await httpClient.PostAsJsonAsync("api/OvpnFile/DownloadOvpnFile", request, cancellationToken);
+            using var client = await GetClientForServerAsync(request.ServerId, cancellationToken);
+            var response = await client.PostAsJsonAsync("api/OvpnFile/DownloadOvpnFile", request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadFromJsonAsync<string>(cancellationToken: cancellationToken);
@@ -74,20 +96,20 @@ public class OvpnFileApiClient(HttpClient httpClient, ILogger<OvpnFileApiClient>
                 throw new InvalidOperationException($"Empty OVPN content received for file: {request.FileName}");
             }
 
-            logger.LogDebug("Successfully downloaded OVPN file {FileName} for {CommonName}", 
-                request.FileName, request.CommonName);
+            logger.LogDebug("Successfully downloaded OVPN file {FileName} for {CommonName} on server {ServerUrl}", 
+                request.FileName, request.CommonName, client.BaseAddress);
             return content;
         }
         catch (HttpRequestException ex)
         {
-            logger.LogError(ex, "HTTP request failed while downloading OVPN file {FileName} for {CommonName}", 
-                request.FileName, request.CommonName);
+            logger.LogError(ex, "HTTP request failed while downloading OVPN file {FileName} for {CommonName} on server {ServerId}", 
+                request.FileName, request.CommonName, request.ServerId);
             throw;
         }
         catch (JsonException ex)
         {
-            logger.LogError(ex, "Failed to deserialize OVPN file content for {FileName} and {CommonName}", 
-                request.FileName, request.CommonName);
+            logger.LogError(ex, "Failed to deserialize OVPN file content for {FileName} and {CommonName} on server {ServerId}", 
+                request.FileName, request.CommonName, request.ServerId);
             throw;
         }
     }


### PR DESCRIPTION
Adds the ApiUrl property to the OpenVpnServer entity and configuration, allowing to specify the base URL for the DataGateCertManager API calls for each server.

This change ensures that API requests are routed to the correct OpenVPN server instance.
It modifies the CertApiClient and OvpnFileApiClient to use IHttpClientFactory to dynamically create HttpClients with the correct base address based on the server's ApiUrl.
Also includes a database migration to add the new column and seed data with default values.
