### PR TITLE
Configures health check services

### DIFF
--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -11,9 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.6" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
+      <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.7" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     </ItemGroup>
 

--- a/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
+++ b/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
@@ -16,7 +16,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.3.0" />
+        <PackageReference Include="FluentAssertions" Version="8.5.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
         <PackageReference Include="MockQueryable.Moq" Version="7.0.3" />
         <PackageReference Include="Moq" Version="4.20.72" />

--- a/OpenVPNGateMonitor/Configurations/HealthCheckServicesConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/HealthCheckServicesConfiguration.cs
@@ -1,22 +1,21 @@
-﻿using OpenVPNGateMonitor.Models;
-using OpenVPNGateMonitor.Services.HealthChecks;
+﻿using OpenVPNGateMonitor.Services.HealthChecks;
 
 namespace OpenVPNGateMonitor.Configurations;
 
 public static class HealthCheckServicesConfiguration
 {
-    public static void ConfigureHealthCheckServices(this WebApplicationBuilder builder)
+    public static void ConfigureHealthCheckServices(this IServiceCollection services, IConfiguration configuration)
     {
-        builder.Services.AddHealthChecks()
+        services.AddHealthChecks()
             .AddNpgSql(
-                connectionString: (builder.Configuration.GetConnectionString("DefaultConnection")
+                connectionString: (configuration.GetConnectionString("DefaultConnection")
                                    ?? Environment.GetEnvironmentVariable("DB_CONNECTION_STRING_DATAGATE")) ??
                                   throw new InvalidOperationException(
                                       "Could not get DB connection string for health checks"),
                 name: "postgresql",
                 tags: ["ready"]);
         
-        builder.Services.AddHealthChecks()
+        services.AddHealthChecks()
             .AddCheck<CustomServiceHealthCheck>("custom_service", tags: ["ready"]);
     }
 }

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -5,35 +5,35 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.2.37</AssemblyVersion>
-        <FileVersion>1.0.2.37</FileVersion>
+        <AssemblyVersion>1.0.2.38</AssemblyVersion>
+        <FileVersion>1.0.2.38</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.0.6" />
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.0.7" />
         <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
         <PackageReference Include="MaxMind.GeoIP2" Version="5.3.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.6" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.12.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.12.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
         <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.32" />
@@ -42,9 +42,9 @@
         <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="8.1.4" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="9.0.3" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor/Program.cs
+++ b/OpenVPNGateMonitor/Program.cs
@@ -24,6 +24,7 @@ builder.Services.ConfigureAuthServices();
 builder.Services.DataBaseServices(builder.Configuration, logger);
 builder.Services.ConfigureJwt(builder.Configuration);
 builder.Services.ConfigureMapster();
+builder.Services.ConfigureHealthCheckServices(builder.Configuration);
 
 builder.ConfigureWebHost();
 builder.ConfigureExternalIpServices();

--- a/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnEventBackgroundService.cs
+++ b/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnEventBackgroundService.cs
@@ -9,7 +9,7 @@ namespace OpenVPNGateMonitor.Services.BackgroundServices;
 public class OpenVpnEventBackgroundService(
     ILogger<OpenVpnEventBackgroundService> logger,
     IOpenVpnEventClientFactory eventClientFactory,
-    IUnitOfWork unitOfWork)
+    IServiceScopeFactory scopeFactory)
     : BackgroundService, IOpenVpnEventBackgroundService
 {
     private static int _instanceCount = 0;
@@ -40,15 +40,19 @@ public class OpenVpnEventBackgroundService(
 
         try
         {
+            using var scope = scopeFactory.CreateScope();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
             var servers = await unitOfWork.GetQuery<OpenVpnServer>()
-                .AsQueryable().ToListAsync(cancellationToken);
+                .AsQueryable()
+                .ToListAsync(cancellationToken);
 
             foreach (var server in servers)
             {
                 try
                 {
                     var client = eventClientFactory.Create(server);
-                    await client. StartListeningAsync(cancellationToken);
+                    await client.StartListeningAsync(cancellationToken);
                     logger.LogInformation("Started listening to events from OpenVPN server {ServerId}", server.Id);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Configures health check services to monitor application dependencies and custom services.

- Enables health checks for PostgreSQL database using connection string from configuration or environment variables.
- Adds a custom service health check.

This provides insight into the application's health and the status of its dependencies, enabling proactive monitoring and issue detection.