### PR TITLE
Implements paginated message log retrieval

### DIFF
--- a/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IIncomingMessageLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IIncomingMessageLogQueryService.cs
@@ -7,6 +7,7 @@ public interface IIncomingMessageLogQueryService
 {
     Task<List<IncomingMessageLog>> GetAllAsync(CancellationToken ct);
     Task<IncomingMessageLog?> GetByIdAsync(int id, CancellationToken ct);
-    Task<List<IncomingMessageLog>> GetByTelegramIdAsync(long telegramId, CancellationToken ct);
+    Task<IPagedResult<IncomingMessageLog>> GetPageByTelegramIdAsync(long telegramId, int page, int pageSize,
+        CancellationToken ct);
     Task<IPagedResult<IncomingMessageLog>> GetPageAsync(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IncomingMessageLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IncomingMessageLogQueryService.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using OpenVPNGateMonitor.Models;
+﻿using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace OpenVPNGateMonitor.DataBase.Services.Query.IncomingMessageLogTable;
@@ -12,10 +11,15 @@ public class IncomingMessageLogQueryService(IQueryService<IncomingMessageLog, in
     public Task<IncomingMessageLog?> GetByIdAsync(int id, CancellationToken ct)
         => q.FindByIdAsync(id, ct: ct);
 
-    public Task<List<IncomingMessageLog>> GetByTelegramIdAsync(long telegramId, CancellationToken ct)
-        => q.Query()
-            .Where(x => x.TelegramId == telegramId)
-            .ToListAsync(ct);
+    public Task<IPagedResult<IncomingMessageLog>> GetPageByTelegramIdAsync(long telegramId, int page, int pageSize, 
+        CancellationToken ct)
+    {
+        return q.PageAsync(
+            page: page,
+            pageSize: pageSize,
+            predicate: x => x.TelegramId == telegramId,
+            ct: ct);
+    }
 
     public Task<IPagedResult<IncomingMessageLog>> GetPageAsync(int page, int pageSize, CancellationToken ct)
         => q.PageAsync(page, pageSize, ct: ct);

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Mapster" Version="7.4.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.62" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.63" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.62" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.63" />
     </ItemGroup>
 
 </Project>

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Requests/GetAllMessagesRequest.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Requests/GetAllMessagesRequest.cs
@@ -3,13 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Requests;
 
-public class GetAllByTelegramIdMessagesRequest
+public class GetAllMessagesRequest
 {
-    [Required(ErrorMessage = "telegramId is required.")]
-    [Range(1, long.MaxValue, ErrorMessage = "telegramId must be greater than 0.")]
-    [FromRoute(Name = "telegramId")]
-    public long TelegramId { get; set; }
-    
     [Range(1, int.MaxValue, ErrorMessage = "page must be greater than 0.")]
     public int Page { get; set; } = 1;
 

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Responses/GetAllMessagesResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Responses/GetAllMessagesResponse.cs
@@ -1,8 +1,9 @@
 ﻿using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Dto;
+using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Responses;
 
 public class GetAllMessagesResponse
 {
-    public List<MessageDto> Messages { get; set; } = [];
+    public PagedResponse<MessageDto> Messages { get; set; } = new();
 }

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Responses/GetByTelegramIdMessagesResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Responses/GetByTelegramIdMessagesResponse.cs
@@ -1,8 +1,9 @@
 ﻿using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Dto;
+using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Responses;
 
 public class GetByTelegramIdMessagesResponse
 {
-    public List<MessageDto> Messages { get; set; } = [];
+    public PagedResponse<MessageDto> Messages { get; set; } = new();
 }

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,9 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.61</Version>
-        <AssemblyVersion>1.0.62.0</AssemblyVersion>
-        <FileVersion>1.0.62.0</FileVersion>
+        <Version>1.0.63</Version>
+        <AssemblyVersion>1.0.63.0</AssemblyVersion>
+        <FileVersion>1.0.63.0</FileVersion>
 
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/OpenVPNGateMonitor/Controllers/TelegramBotIncomingMessageLogController.cs
+++ b/OpenVPNGateMonitor/Controllers/TelegramBotIncomingMessageLogController.cs
@@ -1,7 +1,9 @@
 ﻿using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.DataBase.Services.Query.IncomingMessageLogTable;
 using OpenVPNGateMonitor.Services.TelegramBot.Interfaces;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Dto;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Requests;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Responses;
 using OpenVPNGateMonitor.SharedModels.Responses;
@@ -12,7 +14,8 @@ namespace OpenVPNGateMonitor.Controllers;
 [Route("api/tgbot-incoming-message-logs")]
 [Authorize]
 public class TelegramBotIncomingMessageLogController(
-    IIncomingMessageLogService incomingMessageLogService) : BaseController
+    IIncomingMessageLogService incomingMessageLogService,
+    IIncomingMessageLogQueryService incomingMessageLogQueryService) : BaseController
 {
     [HttpPost("add")]
     public async Task<ActionResult<ApiResponse<AddMessageResponse>>> AddMessage(
@@ -26,13 +29,14 @@ public class TelegramBotIncomingMessageLogController(
     
     [HttpGet("get-all")]
     public async Task<ActionResult<ApiResponse<GetAllMessagesResponse>>> GetAllMessages(
-        CancellationToken cancellationToken)
+        [FromQuery] GetAllMessagesRequest request, CancellationToken cancellationToken)
     {
-        var messages = await incomingMessageLogService.GetAllAsync(cancellationToken);
+        var messages = await incomingMessageLogQueryService.GetPageAsync(
+            request.Page, request.PageSize, cancellationToken);
 
         var response = new GetAllMessagesResponse
         {
-            Messages = messages
+            Messages = messages.Adapt<PagedResponse<MessageDto>>()
         };
 
         return Ok(ApiResponse<GetAllMessagesResponse>.SuccessResponse(response));
@@ -42,9 +46,15 @@ public class TelegramBotIncomingMessageLogController(
     public async Task<ActionResult<ApiResponse<GetByTelegramIdMessagesResponse>>> GetAllMessages(
         [FromRoute] GetAllByTelegramIdMessagesRequest request, CancellationToken ct)
     {
-        var response = await incomingMessageLogService.GetByTelegramIdAsync(request.TelegramId, ct);
-        return Ok(ApiResponse<GetByTelegramIdMessagesResponse>.SuccessResponse(
-            response.Adapt<GetByTelegramIdMessagesResponse>()));
+        var messages= await incomingMessageLogQueryService.GetPageByTelegramIdAsync(
+            request.TelegramId, request.Page, request.PageSize, ct);
+        
+        var response = new GetByTelegramIdMessagesResponse
+        {
+            Messages = messages.Adapt<PagedResponse<MessageDto>>()
+        };
+
+        return Ok(ApiResponse<GetByTelegramIdMessagesResponse>.SuccessResponse(response));
     }
     
     [HttpGet("get-by-id")]

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -5,8 +5,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.2.74</AssemblyVersion>
-        <FileVersion>1.0.2.74</FileVersion>
+        <AssemblyVersion>1.0.2.75</AssemblyVersion>
+        <FileVersion>1.0.2.75</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -36,7 +36,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.62" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.63" />
         <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />

--- a/OpenVPNGateMonitor/Services/TelegramBot/IncomingMessageLogService.cs
+++ b/OpenVPNGateMonitor/Services/TelegramBot/IncomingMessageLogService.cs
@@ -32,13 +32,6 @@ public class IncomingMessageLogService(ILogger<IncomingMessageLogService> logger
             Message = messageDto
         };
     }
-    
-    public async Task<List<MessageDto>> GetAllAsync(CancellationToken ct)
-    {
-        var messages = await incomingMessageLogQueryService.GetAllAsync(ct);
-
-        return messages.Adapt<List<MessageDto>>();
-    }
 
     public async Task<MessageDto?> GetByIdAsync(int id, CancellationToken ct)
     {
@@ -48,13 +41,5 @@ public class IncomingMessageLogService(ILogger<IncomingMessageLogService> logger
 
 
         return message.Adapt<MessageDto>();
-    }
-    
-    public async Task<List<MessageDto>> GetByTelegramIdAsync(long telegramId, CancellationToken ct)
-    {
-        var messages = await incomingMessageLogQueryService.GetByTelegramIdAsync(telegramId, ct);
-
-
-        return messages.Adapt<List<MessageDto>>();
     }
 }

--- a/OpenVPNGateMonitor/Services/TelegramBot/Interfaces/IIncomingMessageLogService.cs
+++ b/OpenVPNGateMonitor/Services/TelegramBot/Interfaces/IIncomingMessageLogService.cs
@@ -8,7 +8,5 @@ public interface IIncomingMessageLogService
 {
     Task<AddMessageResponse> SaveMessageAsync(AddMessageRequest request, 
         CancellationToken cancellationToken);
-    Task<List<MessageDto>> GetAllAsync(CancellationToken ct);
     Task<MessageDto?> GetByIdAsync(int id, CancellationToken ct);
-    Task<List<MessageDto>> GetByTelegramIdAsync(long telegramId, CancellationToken ct);
 }


### PR DESCRIPTION
Implements pagination for retrieving Telegram bot incoming message logs.

This change enhances the performance and usability of the message log functionality by retrieving messages in smaller, manageable chunks.

- Introduces a `GetPageByTelegramIdAsync` method to fetch messages by Telegram ID with pagination.
- Updates the `GetAllMessages` endpoint to support pagination.
- Modifies the shared models to include page and page size parameters.