### PR TITLE
Makes Content property nullable

### DIFF
--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnFiles/Responses/DownloadFileResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnFiles/Responses/DownloadFileResponse.cs
@@ -6,5 +6,5 @@ public class DownloadFileResponse
 {
     public IssuedOvpnFileDto IssuedOvpn { get; set; } = new();
     public long FileSizeBytes { get; set; }
-    public byte[] Content { get; set; } = [];
+    public byte[]? Content { get; set; }
 }

--- a/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/OvpnFile/Responses/OvpnFileDownload.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/OvpnFile/Responses/OvpnFileDownload.cs
@@ -9,5 +9,5 @@ public class OvpnFileDownload
 
     public string FileName { get; set; } = null!;
 
-    public byte[] Content { get; set; } = [];
+    public byte[]? Content { get; set; }
 }

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,9 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.64</Version>
-        <AssemblyVersion>1.0.66.0</AssemblyVersion>
-        <FileVersion>1.0.66.0</FileVersion>
+        <Version>1.0.67</Version>
+        <AssemblyVersion>1.0.67.0</AssemblyVersion>
+        <FileVersion>1.0.67.0</FileVersion>
 
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>


### PR DESCRIPTION
Updates the Content property in DownloadFileResponse and OvpnFileDownload to be nullable.

This allows for scenarios where the content might be absent or not yet available,
preventing potential issues with default empty byte arrays.

Updates the shared models project version.
