### PR TITLE
Removes Async suffix from method names

### DIFF
--- a/OpenVPNGateMonitor.DataBase/Services/Command/EfCommandService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Command/EfCommandService.cs
@@ -11,7 +11,7 @@ public class EfCommandService<TEntity, TKey>(IUnitOfWork uow) : ICommandService<
     where TEntity : BaseEntity<TKey>
 {
     // Create
-    public async Task<TEntity> AddAsync(TEntity entity, bool saveChanges = true, CancellationToken ct = default)
+    public async Task<TEntity> Add(TEntity entity, bool saveChanges = true, CancellationToken ct = default)
     {
         var repo = uow.GetRepository<TEntity>();
         await repo.AddAsync(entity, ct);
@@ -19,7 +19,7 @@ public class EfCommandService<TEntity, TKey>(IUnitOfWork uow) : ICommandService<
         return entity;
     }
 
-    public async Task<int> AddRangeAsync(IEnumerable<TEntity> entities, bool saveChanges = true, CancellationToken ct = default)
+    public async Task<int> AddRange(IEnumerable<TEntity> entities, bool saveChanges = true, CancellationToken ct = default)
     {
         var list = entities as IList<TEntity> ?? entities.ToList();
         if (list.Count == 0) return 0;
@@ -31,7 +31,7 @@ public class EfCommandService<TEntity, TKey>(IUnitOfWork uow) : ICommandService<
     }
 
     // Update tracked entity (full)
-    public async Task<int> UpdateAsync(TEntity entity, bool saveChanges = true, CancellationToken ct = default)
+    public async Task<int> Update(TEntity entity, bool saveChanges = true, CancellationToken ct = default)
     {
         var repo = uow.GetRepository<TEntity>();
         repo.Update(entity);
@@ -39,7 +39,7 @@ public class EfCommandService<TEntity, TKey>(IUnitOfWork uow) : ICommandService<
         return await uow.SaveChangesAsync(ct);
     }
 
-    public Task<int> UpdateWhereAsync(
+    public Task<int> UpdateWhere(
         Expression<Func<TEntity, bool>> predicate,
         Action<UpdateSettersBuilder<TEntity>> set,
         CancellationToken ct = default)
@@ -49,7 +49,7 @@ public class EfCommandService<TEntity, TKey>(IUnitOfWork uow) : ICommandService<
             .ExecuteUpdateAsync(set, ct);
 
     // Delete
-    public async Task<int> DeleteAsync(TEntity entity, bool saveChanges = true, CancellationToken ct = default)
+    public async Task<int> Delete(TEntity entity, bool saveChanges = true, CancellationToken ct = default)
     {
         var repo = uow.GetRepository<TEntity>();
         repo.Delete(entity);
@@ -57,19 +57,19 @@ public class EfCommandService<TEntity, TKey>(IUnitOfWork uow) : ICommandService<
         return await uow.SaveChangesAsync(ct);
     }
 
-    public Task<int> DeleteByIdAsync(TKey id, CancellationToken ct = default)
+    public Task<int> DeleteById(TKey id, CancellationToken ct = default)
         => uow.GetQuery<TEntity>()
               .AsQueryable()
               .Where(e => e.Id!.Equals(id))
               .ExecuteDeleteAsync(ct);
 
     // Bulk delete on server (EF Core 7+)
-    public Task<int> DeleteWhereAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken ct = default)
+    public Task<int> DeleteWhere(Expression<Func<TEntity, bool>> predicate, CancellationToken ct = default)
         => uow.GetQuery<TEntity>()
               .AsQueryable()
               .Where(predicate)
               .ExecuteDeleteAsync(ct);
 
-    public Task<int> SaveChangesAsync(CancellationToken ct = default)
+    public Task<int> SaveChanges(CancellationToken ct = default)
         => uow.SaveChangesAsync(ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Command/Interfaces/ICommandService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Command/Interfaces/ICommandService.cs
@@ -7,25 +7,25 @@ namespace OpenVPNGateMonitor.DataBase.Services.Command.Interfaces;
 public interface ICommandService<TEntity, TKey> where TEntity : BaseEntity<TKey>
 {
     // Create
-    Task<TEntity> AddAsync(TEntity entity, bool saveChanges = true, CancellationToken ct = default);
-    Task<int> AddRangeAsync(IEnumerable<TEntity> entities, bool saveChanges = true, CancellationToken ct = default);
+    Task<TEntity> Add(TEntity entity, bool saveChanges = true, CancellationToken ct = default);
+    Task<int> AddRange(IEnumerable<TEntity> entities, bool saveChanges = true, CancellationToken ct = default);
 
     // Update tracked entity (full)
-    Task<int> UpdateAsync(TEntity entity, bool saveChanges = true, CancellationToken ct = default);
+    Task<int> Update(TEntity entity, bool saveChanges = true, CancellationToken ct = default);
 
     // Bulk update by predicate (server-side)
-    Task<int> UpdateWhereAsync(
+    Task<int> UpdateWhere(
         Expression<Func<TEntity, bool>> predicate,
         Action<UpdateSettersBuilder<TEntity>> set,
         CancellationToken ct = default);
 
     // Delete by entity / by id
-    Task<int> DeleteAsync(TEntity entity, bool saveChanges = true, CancellationToken ct = default);
-    Task<int> DeleteByIdAsync(TKey id, CancellationToken ct = default);
+    Task<int> Delete(TEntity entity, bool saveChanges = true, CancellationToken ct = default);
+    Task<int> DeleteById(TKey id, CancellationToken ct = default);
 
     // Bulk delete by predicate (server-side)
-    Task<int> DeleteWhereAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken ct = default);
+    Task<int> DeleteWhere(Expression<Func<TEntity, bool>> predicate, CancellationToken ct = default);
 
     // Explicit save (if you pass saveChanges=false above)
-    Task<int> SaveChangesAsync(CancellationToken ct = default);
+    Task<int> SaveChanges(CancellationToken ct = default);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/ClientApplicationTable/ClientApplicationQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/ClientApplicationTable/ClientApplicationQueryService.cs
@@ -6,26 +6,26 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.ClientApplicationTable;
 
 public class ClientApplicationQueryService(IQueryService<ClientApplication, int> q) : IClientApplicationQueryService
 {
-    public Task<List<ClientApplication>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<ClientApplication>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
     
-    public Task<List<ClientApplication>> GetAllIsNotRevokedAsync(CancellationToken ct)
-        => q.Query().Where(x => x.IsRevoked == false).ToListAsync(ct);
+    public Task<List<ClientApplication>> GetAllIsNotRevoked(CancellationToken ct)
+        => q.Where(x => x.IsRevoked == false, ct: ct);
 
-    public Task<ClientApplication?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<ClientApplication?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<ClientApplication?> GetByNameAsync(string name, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.Name == name, ct);
+    public Task<ClientApplication?> GetByName(string name, CancellationToken ct)
+        => q.FirstOrDefault(x => x.Name == name, ct: ct);
 
-    public Task<ClientApplication?> GetByClientIdAsync(string clientId, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.ClientId == clientId, ct);
+    public Task<ClientApplication?> GetByClientId(string clientId, CancellationToken ct)
+        => q.FirstOrDefault(x => x.ClientId == clientId, ct: ct);
 
-    public Task<ClientApplication?> GetBySystemByClientIdAsync(string clientId, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => 
-            x.ClientId == clientId && x.IsSystem && x.IsRevoked == false, ct);
-    public Task<ClientApplication?> IsSystemConfiguredAsync(CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.IsSystem, ct);
-    public Task<IPagedResult<ClientApplication>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<ClientApplication?> GetBySystemByClientId(string clientId, CancellationToken ct)
+        => q.FirstOrDefault(x => 
+            x.ClientId == clientId && x.IsSystem && x.IsRevoked == false, ct: ct);
+    public Task<ClientApplication?> IsSystemConfigured(CancellationToken ct)
+        => q.FirstOrDefault(x => x.IsSystem, ct: ct);
+    public Task<IPagedResult<ClientApplication>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/ClientApplicationTable/ClientApplicationQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/ClientApplicationTable/ClientApplicationQueryService.cs
@@ -10,22 +10,28 @@ public class ClientApplicationQueryService(IQueryService<ClientApplication, int>
         => q.GetAll(ct: ct);
     
     public Task<List<ClientApplication>> GetAllIsNotRevoked(CancellationToken ct)
-        => q.Where(x => x.IsRevoked == false, ct: ct);
+        => q.Query()
+            .Where(x => x.IsRevoked == false)
+            .ToListAsync(ct);
 
     public Task<ClientApplication?> GetById(int id, CancellationToken ct)
         => q.FindById(id, ct: ct);
 
     public Task<ClientApplication?> GetByName(string name, CancellationToken ct)
-        => q.FirstOrDefault(x => x.Name == name, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.Name == name, ct);
 
     public Task<ClientApplication?> GetByClientId(string clientId, CancellationToken ct)
-        => q.FirstOrDefault(x => x.ClientId == clientId, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.ClientId == clientId, ct);
 
     public Task<ClientApplication?> GetBySystemByClientId(string clientId, CancellationToken ct)
-        => q.FirstOrDefault(x => 
-            x.ClientId == clientId && x.IsSystem && x.IsRevoked == false, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x =>
+                x.ClientId == clientId && x.IsSystem && x.IsRevoked == false, ct);
     public Task<ClientApplication?> IsSystemConfigured(CancellationToken ct)
-        => q.FirstOrDefault(x => x.IsSystem, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.IsSystem, ct);
     public Task<IPagedResult<ClientApplication>> GetPage(int page, int pageSize, CancellationToken ct)
         => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/ClientApplicationTable/IClientApplicationQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/ClientApplicationTable/IClientApplicationQueryService.cs
@@ -5,12 +5,12 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.ClientApplicationTable;
 
 public interface IClientApplicationQueryService
 {
-    Task<List<ClientApplication>> GetAllAsync(CancellationToken ct);
-    Task<List<ClientApplication>> GetAllIsNotRevokedAsync(CancellationToken ct);
-    Task<ClientApplication?> GetByIdAsync(int id, CancellationToken ct);
-    Task<ClientApplication?> GetByNameAsync(string name, CancellationToken ct);
-    Task<ClientApplication?> GetByClientIdAsync(string clientId, CancellationToken ct);
-    Task<ClientApplication?> GetBySystemByClientIdAsync(string clientId, CancellationToken ct);
-    Task<ClientApplication?> IsSystemConfiguredAsync(CancellationToken ct);
-    Task<IPagedResult<ClientApplication>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<List<ClientApplication>> GetAll(CancellationToken ct);
+    Task<List<ClientApplication>> GetAllIsNotRevoked(CancellationToken ct);
+    Task<ClientApplication?> GetById(int id, CancellationToken ct);
+    Task<ClientApplication?> GetByName(string name, CancellationToken ct);
+    Task<ClientApplication?> GetByClientId(string clientId, CancellationToken ct);
+    Task<ClientApplication?> GetBySystemByClientId(string clientId, CancellationToken ct);
+    Task<ClientApplication?> IsSystemConfigured(CancellationToken ct);
+    Task<IPagedResult<ClientApplication>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/EfQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/EfQueryService.cs
@@ -6,37 +6,33 @@ using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace OpenVPNGateMonitor.DataBase.Services.Query;
 
-public class EfQueryService<TEntity, TKey> : IQueryService<TEntity, TKey>
+public class EfQueryService<TEntity, TKey>(IUnitOfWork uow) : IQueryService<TEntity, TKey>
     where TEntity : BaseEntity<TKey>
 {
-    private readonly IUnitOfWork _uow;
-
-    public EfQueryService(IUnitOfWork uow) => _uow = uow;
-
-    public async Task<List<TEntity>> GetAllAsync(bool asNoTracking = true, CancellationToken ct = default)
-        => await ApplyTracking(_uow.GetQuery<TEntity>().AsQueryable(), asNoTracking)
+    public async Task<List<TEntity>> GetAll(bool asNoTracking = true, CancellationToken ct = default)
+        => await ApplyTracking(uow.GetQuery<TEntity>().AsQueryable(), asNoTracking)
             .OrderBy(e => e.Id)
             .ToListAsync(ct);
 
-    public async Task<TEntity?> FindByIdAsync(
+    public async Task<TEntity?> FindById(
         TKey id,
         bool asNoTracking = true,
         CancellationToken ct = default,
         params Expression<Func<TEntity, object>>[] includes)
     {
-        var q = ApplyIncludes(_uow.GetQuery<TEntity>().AsQueryable(), includes);
+        var q = ApplyIncludes(uow.GetQuery<TEntity>().AsQueryable(), includes);
         q = ApplyTracking(q, asNoTracking);
         return await q.FirstOrDefaultAsync(e => e.Id!.Equals(id), ct);
     }
 
-    public async Task<List<TEntity>> WhereAsync(
+    public async Task<List<TEntity>> Where(
         Expression<Func<TEntity, bool>> predicate,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         bool asNoTracking = true,
         CancellationToken ct = default,
         params Expression<Func<TEntity, object>>[] includes)
     {
-        var q = ApplyIncludes(_uow.GetQuery<TEntity>().AsQueryable(), includes)
+        var q = ApplyIncludes(uow.GetQuery<TEntity>().AsQueryable(), includes)
             .Where(predicate);
 
         q = ApplyTracking(q, asNoTracking);
@@ -45,7 +41,7 @@ public class EfQueryService<TEntity, TKey> : IQueryService<TEntity, TKey>
         return await q.ToListAsync(ct);
     }
 
-    public async Task<IPagedResult<TEntity>> PageAsync(
+    public async Task<IPagedResult<TEntity>> Page(
         int page,
         int pageSize,
         Expression<Func<TEntity, bool>>? predicate = null,
@@ -57,7 +53,7 @@ public class EfQueryService<TEntity, TKey> : IQueryService<TEntity, TKey>
         if (page < 1) page = 1;
         if (pageSize < 1) pageSize = 10;
 
-        var baseQuery = ApplyIncludes(_uow.GetQuery<TEntity>().AsQueryable(), includes);
+        var baseQuery = ApplyIncludes(uow.GetQuery<TEntity>().AsQueryable(), includes);
         if (predicate != null) baseQuery = baseQuery.Where(predicate);
 
         var total = await baseQuery.CountAsync(ct);
@@ -76,29 +72,29 @@ public class EfQueryService<TEntity, TKey> : IQueryService<TEntity, TKey>
         };
     }
 
-    public async Task<int> CountAsync(
+    public async Task<int> Count(
         Expression<Func<TEntity, bool>>? predicate = null,
         CancellationToken ct = default)
     {
-        var q = _uow.GetQuery<TEntity>().AsQueryable();
+        var q = uow.GetQuery<TEntity>().AsQueryable();
         if (predicate != null) q = q.Where(predicate);
         return await q.CountAsync(ct);
     }
 
-    public async Task<bool> AnyAsync(
+    public async Task<bool> Any(
         Expression<Func<TEntity, bool>> predicate,
         CancellationToken ct = default)
-        => await _uow.GetQuery<TEntity>().AsQueryable().AnyAsync(predicate, ct);
+        => await uow.GetQuery<TEntity>().AsQueryable().AnyAsync(predicate, ct);
 
     public IQueryable<TEntity> Query(
         bool asNoTracking = true,
         params Expression<Func<TEntity, object>>[] includes)
     {
-        var q = ApplyIncludes(_uow.GetQuery<TEntity>().AsQueryable(), includes);
+        var q = ApplyIncludes(uow.GetQuery<TEntity>().AsQueryable(), includes);
         return ApplyTracking(q, asNoTracking);
     }
     
-    public async Task<TEntity?> FirstOrDefaultAsync(
+    public async Task<TEntity?> FirstOrDefault(
         Expression<Func<TEntity, bool>>? predicate = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         bool asNoTracking = true,

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IQueryService.cs
@@ -4,24 +4,24 @@ using OpenVPNGateMonitor.SharedModels.Responses;
 
 public interface IQueryService<TEntity, TKey> where TEntity : BaseEntity<TKey>
 {
-    Task<List<TEntity>> GetAllAsync(
+    Task<List<TEntity>> GetAll(
         bool asNoTracking = true,
         CancellationToken ct = default);
 
-    Task<TEntity?> FindByIdAsync(
+    Task<TEntity?> FindById(
         TKey id,
         bool asNoTracking = true,
         CancellationToken ct = default,
         params Expression<Func<TEntity, object>>[] includes);
 
-    Task<List<TEntity>> WhereAsync(
+    Task<List<TEntity>> Where(
         Expression<Func<TEntity, bool>> predicate,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         bool asNoTracking = true,
         CancellationToken ct = default,
         params Expression<Func<TEntity, object>>[] includes);
 
-    Task<IPagedResult<TEntity>> PageAsync(
+    Task<IPagedResult<TEntity>> Page(
         int page,
         int pageSize,
         Expression<Func<TEntity, bool>>? predicate = null,
@@ -30,11 +30,11 @@ public interface IQueryService<TEntity, TKey> where TEntity : BaseEntity<TKey>
         CancellationToken ct = default,
         params Expression<Func<TEntity, object>>[] includes);
 
-    Task<int> CountAsync(
+    Task<int> Count(
         Expression<Func<TEntity, bool>>? predicate = null,
         CancellationToken ct = default);
 
-    Task<bool> AnyAsync(
+    Task<bool> Any(
         Expression<Func<TEntity, bool>> predicate,
         CancellationToken ct = default);
 
@@ -42,7 +42,7 @@ public interface IQueryService<TEntity, TKey> where TEntity : BaseEntity<TKey>
         bool asNoTracking = true,
         params Expression<Func<TEntity, object>>[] includes);
 
-    Task<TEntity?> FirstOrDefaultAsync(
+    Task<TEntity?> FirstOrDefault(
         Expression<Func<TEntity, bool>>? predicate = null,
         Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null,
         bool asNoTracking = true,

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IIncomingMessageLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IIncomingMessageLogQueryService.cs
@@ -5,9 +5,9 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.IncomingMessageLogTable;
 
 public interface IIncomingMessageLogQueryService
 {
-    Task<List<IncomingMessageLog>> GetAllAsync(CancellationToken ct);
-    Task<IncomingMessageLog?> GetByIdAsync(int id, CancellationToken ct);
-    Task<IPagedResult<IncomingMessageLog>> GetPageByTelegramIdAsync(long telegramId, int page, int pageSize,
+    Task<List<IncomingMessageLog>> GetAll(CancellationToken ct);
+    Task<IncomingMessageLog?> GetById(int id, CancellationToken ct);
+    Task<IPagedResult<IncomingMessageLog>> GetPageByTelegramId(long telegramId, int page, int pageSize,
         CancellationToken ct);
-    Task<IPagedResult<IncomingMessageLog>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<IncomingMessageLog>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IncomingMessageLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IncomingMessageLogTable/IncomingMessageLogQueryService.cs
@@ -5,16 +5,16 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.IncomingMessageLogTable;
 
 public class IncomingMessageLogQueryService(IQueryService<IncomingMessageLog, int> q) : IIncomingMessageLogQueryService
 {
-    public Task<List<IncomingMessageLog>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<IncomingMessageLog>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<IncomingMessageLog?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<IncomingMessageLog?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<IPagedResult<IncomingMessageLog>> GetPageByTelegramIdAsync(long telegramId, int page, int pageSize, 
+    public Task<IPagedResult<IncomingMessageLog>> GetPageByTelegramId(long telegramId, int page, int pageSize, 
         CancellationToken ct)
     {
-        return q.PageAsync(
+        return q.Page(
             page: page,
             pageSize: pageSize,
             predicate: x => x.TelegramId == telegramId,
@@ -23,8 +23,8 @@ public class IncomingMessageLogQueryService(IQueryService<IncomingMessageLog, in
             ct: ct);
     }
 
-    public Task<IPagedResult<IncomingMessageLog>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(
+    public Task<IPagedResult<IncomingMessageLog>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(
             page,
             pageSize,
             null,

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
@@ -18,6 +18,9 @@ public interface IIssuedOvpnFileQueryService
     Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndIsRevoked(int id, int vpnServerId, bool isRevoked,
         CancellationToken ct);
 
+    Task<IssuedOvpnFile?> GetByCommonNameAndVpnServerIdAndIsRevoked(string commonName, int vpnServerId,
+        bool isRevoked, CancellationToken ct);
+
     Task<string?> GetExternalIdByCommonName(string commonName, int vpnServerId, CancellationToken ct);
     
     Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndCommonNameAndIsRevoked(

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
@@ -5,28 +5,28 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 
 public interface IIssuedOvpnFileQueryService
 {
-    Task<List<IssuedOvpnFile>> GetAllAsync(CancellationToken ct);
+    Task<List<IssuedOvpnFile>> GetAll(CancellationToken ct);
     Task<List<IssuedOvpnFile>> GetAllByVpnServerId(int vpnServerId, CancellationToken ct);
     Task<List<IssuedOvpnFile>> GetAllByExternalId(string externalId, CancellationToken ct);
 
     Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAndIsRevoked(int vpnServerId, bool isRevoked, CancellationToken ct);
     Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAndExternalIdAndIsRevoked(int vpnServerId, string externalId,
         bool isRevoked, CancellationToken ct);
-    Task<IssuedOvpnFile?> GetByIdAsync(int id, CancellationToken ct);
-    Task<IssuedOvpnFile?> GetByIdAndIsRevokedAsync(int id, bool isRevoked, CancellationToken ct);
+    Task<IssuedOvpnFile?> GetById(int id, CancellationToken ct);
+    Task<IssuedOvpnFile?> GetByIdAndIsRevoked(int id, bool isRevoked, CancellationToken ct);
 
-    Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndIsRevokedAsync(int id, int vpnServerId, bool isRevoked,
+    Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndIsRevoked(int id, int vpnServerId, bool isRevoked,
         CancellationToken ct);
 
     Task<string?> GetExternalIdByCommonName(string commonName, int vpnServerId, CancellationToken ct);
     
-    Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndCommonNameAndIsRevokedAsync(
+    Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndCommonNameAndIsRevoked(
         int vpnServerId, int ovpnFileId, string commonName, bool isRevoked, CancellationToken ct);
     
-    Task<IssuedOvpnFile?> GetByVpnServerIdAndCommonNameAsync(int id, int vpnServerId, string commonName, 
+    Task<IssuedOvpnFile?> GetByVpnServerIdAndCommonName(int id, int vpnServerId, string commonName, 
         CancellationToken ct);
     
-    Task<bool> ExistsActiveByVpnServerIdAndCommonNameAsync(int vpnServerId, string commonName, CancellationToken ct);
+    Task<bool> ExistsActiveByVpnServerIdAndCommonName(int vpnServerId, string commonName, CancellationToken ct);
 
-    Task<IPagedResult<IssuedOvpnFile>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<IssuedOvpnFile>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
@@ -39,6 +39,13 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
             .FirstOrDefaultAsync(x => 
                 x.Id == id && x.VpnServerId == vpnServerId && x.IsRevoked == isRevoked, ct);
     
+    public Task<IssuedOvpnFile?> GetByCommonNameAndVpnServerIdAndIsRevoked(string commonName, int vpnServerId, 
+        bool isRevoked, CancellationToken ct)
+        => q.Query()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => 
+                x.CommonName == commonName && x.VpnServerId == vpnServerId && x.IsRevoked == isRevoked, ct);
+    
     public Task<string?> GetExternalIdByCommonName(string commonName, int vpnServerId, CancellationToken ct) =>
         q.Query()
             .AsNoTracking()

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
@@ -6,33 +6,33 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 
 public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : IIssuedOvpnFileQueryService
 {
-    public Task<List<IssuedOvpnFile>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<IssuedOvpnFile>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
     public Task<List<IssuedOvpnFile>> GetAllByVpnServerId(int vpnServerId, CancellationToken ct)
-        => q.WhereAsync(x => x.VpnServerId == vpnServerId, ct: ct);
+        => q.Where(x => x.VpnServerId == vpnServerId, ct: ct);
     
     public Task<List<IssuedOvpnFile>> GetAllByExternalId(string externalId, CancellationToken ct)
-        => q.WhereAsync(x => x.ExternalId == externalId, ct: ct);
+        => q.Where(x => x.ExternalId == externalId, ct: ct);
 
     public Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAndIsRevoked(int vpnServerId, bool isRevoked, 
         CancellationToken ct)
-        => q.WhereAsync(x => x.VpnServerId == vpnServerId && x.IsRevoked == isRevoked, ct: ct);
+        => q.Where(x => x.VpnServerId == vpnServerId && x.IsRevoked == isRevoked, ct: ct);
 
     public Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAndExternalIdAndIsRevoked(int vpnServerId, string externalId,
         bool isRevoked, CancellationToken ct)
-        => q.WhereAsync(x => x.VpnServerId == vpnServerId
+        => q.Where(x => x.VpnServerId == vpnServerId
                                            && x.ExternalId == externalId && x.IsRevoked == isRevoked, ct: ct);
 
-    public Task<IssuedOvpnFile?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<IssuedOvpnFile?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<IssuedOvpnFile?> GetByIdAndIsRevokedAsync(int id, bool isRevoked, CancellationToken ct)
+    public Task<IssuedOvpnFile?> GetByIdAndIsRevoked(int id, bool isRevoked, CancellationToken ct)
         => q.Query()
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == id && x.IsRevoked == isRevoked, ct);
 
-    public Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndIsRevokedAsync(int id, int vpnServerId, bool isRevoked, 
+    public Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndIsRevoked(int id, int vpnServerId, bool isRevoked, 
         CancellationToken ct)
         => q.Query()
             .AsNoTracking()
@@ -48,7 +48,7 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
             .Select(x => x.ExternalId)
             .FirstOrDefaultAsync(ct);
 
-    public Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndCommonNameAndIsRevokedAsync(int vpnServerId, int ovpnFileId,
+    public Task<IssuedOvpnFile?> GetByIdAndVpnServerIdAndCommonNameAndIsRevoked(int vpnServerId, int ovpnFileId,
         string commonName, bool isRevoked,
         CancellationToken ct)
         => q.Query()
@@ -58,7 +58,7 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
                                    && x.VpnServerId == vpnServerId 
                                    && x.IsRevoked == isRevoked, ct);
 
-    public Task<IssuedOvpnFile?> GetByVpnServerIdAndCommonNameAsync(int id, int vpnServerId, string commonName, 
+    public Task<IssuedOvpnFile?> GetByVpnServerIdAndCommonName(int id, int vpnServerId, string commonName, 
         CancellationToken ct)
         => q.Query()
             .AsNoTracking()
@@ -67,7 +67,7 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
                 x.CommonName == commonName 
                 && x.VpnServerId == vpnServerId, ct);
 
-    public Task<IssuedOvpnFile?> GetActiveByIdVpnServerAndCommonNameAndIsRevokedAAsync(
+    public Task<IssuedOvpnFile?> GetActiveByIdVpnServerAndCommonNameAndIsRevokedA(
         int vpnServerId, int ovpnFileId, string commonName, bool isRevoked, CancellationToken ct)
         => q.Query()
             .AsNoTracking()
@@ -77,7 +77,7 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
                 && x.CommonName == commonName
                 && x.IsRevoked == isRevoked, ct);
     
-    public Task<bool> ExistsActiveByVpnServerIdAndCommonNameAsync(int vpnServerId, string commonName, CancellationToken ct)
+    public Task<bool> ExistsActiveByVpnServerIdAndCommonName(int vpnServerId, string commonName, CancellationToken ct)
         => q.Query()
             .AsNoTracking()
             .AnyAsync(x =>
@@ -85,6 +85,6 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
                 && x.CommonName == commonName
                 && !x.IsRevoked, ct);
     
-    public Task<IPagedResult<IssuedOvpnFile>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<IssuedOvpnFile>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTokenTable/IIssuedOvpnFileTokenQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTokenTable/IIssuedOvpnFileTokenQueryService.cs
@@ -5,12 +5,12 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.IssuedOvpnFileTokenTable;
 
 public interface IIssuedOvpnFileTokenQueryService
 {
-    Task<List<IssuedOvpnFileToken>> GetAllAsync(CancellationToken ct);
-    Task<IssuedOvpnFileToken?> GetByIdAsync(int id, CancellationToken ct);
-    Task<IPagedResult<IssuedOvpnFileToken>> GetPageAsync(int page, int pageSize, CancellationToken ct);
-    Task<List<IssuedOvpnFileToken>> GetByIssuedFileIdsAsync(IEnumerable<int> fileIds, CancellationToken ct);
-    Task<IssuedOvpnFileToken?> GetByTokenAsync(string token, CancellationToken ct);
+    Task<List<IssuedOvpnFileToken>> GetAll(CancellationToken ct);
+    Task<IssuedOvpnFileToken?> GetById(int id, CancellationToken ct);
+    Task<IPagedResult<IssuedOvpnFileToken>> GetPage(int page, int pageSize, CancellationToken ct);
+    Task<List<IssuedOvpnFileToken>> GetByIssuedFileIds(IEnumerable<int> fileIds, CancellationToken ct);
+    Task<IssuedOvpnFileToken?> GetByToken(string token, CancellationToken ct);
 
     // Optional: throws if not found
-    Task<IssuedOvpnFileToken> GetRequiredByTokenAsync(string token, CancellationToken ct);
+    Task<IssuedOvpnFileToken> GetRequiredByToken(string token, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTokenTable/IssuedOvpnFileTokenQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/IssuedOvpnFileTokenTable/IssuedOvpnFileTokenQueryService.cs
@@ -6,16 +6,16 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.IssuedOvpnFileTokenTable;
 
 public class IssuedOvpnFileTokenQueryService(IQueryService<IssuedOvpnFileToken, int> q) : IIssuedOvpnFileTokenQueryService
 {
-    public Task<List<IssuedOvpnFileToken>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<IssuedOvpnFileToken>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<IssuedOvpnFileToken?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<IssuedOvpnFileToken?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
     
-    public Task<IPagedResult<IssuedOvpnFileToken>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<IssuedOvpnFileToken>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
     
-    public Task<List<IssuedOvpnFileToken>> GetByIssuedFileIdsAsync(IEnumerable<int> fileIds, CancellationToken ct)
+    public Task<List<IssuedOvpnFileToken>> GetByIssuedFileIds(IEnumerable<int> fileIds, CancellationToken ct)
     {
         // Avoid IN () when the list is empty
         var ids = fileIds?.Distinct().ToList();
@@ -28,15 +28,15 @@ public class IssuedOvpnFileTokenQueryService(IQueryService<IssuedOvpnFileToken, 
             .ToListAsync(ct);
     }
 
-    public Task<IssuedOvpnFileToken?> GetByTokenAsync(string token, CancellationToken ct)
+    public Task<IssuedOvpnFileToken?> GetByToken(string token, CancellationToken ct)
         => q.Query()
             .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Token == token, ct);
 
     // Optional: fetch by token and fail if missing
-    public async Task<IssuedOvpnFileToken> GetRequiredByTokenAsync(string token, CancellationToken ct)
+    public async Task<IssuedOvpnFileToken> GetRequiredByToken(string token, CancellationToken ct)
     {
-        var entity = await GetByTokenAsync(token, ct);
+        var entity = await GetByToken(token, ct);
         return entity ?? throw new InvalidOperationException($"IssuedOvpnFileToken '{token}' not found");
     }
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/LocalizationTextTable/ILocalizationTextQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/LocalizationTextTable/ILocalizationTextQueryService.cs
@@ -6,10 +6,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.LocalizationTextTable;
 
 public interface ILocalizationTextQueryService
 {
-    Task<List<LocalizationText>> GetAllAsync(CancellationToken ct);
-    Task<LocalizationText?> GetByIdAsync(int id, CancellationToken ct);
-    Task<string?> GetTextValueByKeyAndLanguageAsync(string key, Language language, CancellationToken ct);
-    Task<IPagedResult<LocalizationText>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<List<LocalizationText>> GetAll(CancellationToken ct);
+    Task<LocalizationText?> GetById(int id, CancellationToken ct);
+    Task<string?> GetTextValueByKeyAndLanguage(string key, Language language, CancellationToken ct);
+    Task<IPagedResult<LocalizationText>> GetPage(int page, int pageSize, CancellationToken ct);
     
     
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/LocalizationTextTable/LocalizationTextQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/LocalizationTextTable/LocalizationTextQueryService.cs
@@ -7,18 +7,18 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.LocalizationTextTable;
 
 public class LocalizationTextQueryService(IQueryService<LocalizationText, int> q) : ILocalizationTextQueryService
 {
-    public Task<List<LocalizationText>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<LocalizationText>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<LocalizationText?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<LocalizationText?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<string?> GetTextValueByKeyAndLanguageAsync(string key, Language language, CancellationToken ct)
+    public Task<string?> GetTextValueByKeyAndLanguage(string key, Language language, CancellationToken ct)
         => q.Query()
             .Where(x => x.Key == key && x.Language == language)
             .Select(x => x.Text)
             .FirstOrDefaultAsync(ct);
 
-    public Task<IPagedResult<LocalizationText>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<LocalizationText>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/IOpenVpnServerClientQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/IOpenVpnServerClientQueryService.cs
@@ -5,9 +5,9 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerClientTable;
 
 public interface IOpenVpnServerClientQueryService
 {
-    Task<List<OpenVpnServerClient>> GetAllAsync(CancellationToken ct);
-    Task<List<OpenVpnServerClient>> GetAllConnectedByVpnServerIdAsync(int vpnServerId, CancellationToken ct);
-    Task<OpenVpnServerClient?> GetByIdAsync(int id, CancellationToken ct);
-    Task<OpenVpnServerClient?> GetBySessionAndServerIdAsync(Guid session, int vpnServerId, CancellationToken ct);
-    Task<IPagedResult<OpenVpnServerClient>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<List<OpenVpnServerClient>> GetAll(CancellationToken ct);
+    Task<List<OpenVpnServerClient>> GetAllConnectedByVpnServerId(int vpnServerId, CancellationToken ct);
+    Task<OpenVpnServerClient?> GetById(int id, CancellationToken ct);
+    Task<OpenVpnServerClient?> GetBySessionAndServerId(Guid session, int vpnServerId, CancellationToken ct);
+    Task<IPagedResult<OpenVpnServerClient>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientOverviewQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientOverviewQuery.cs
@@ -110,7 +110,7 @@ public class OpenVpnServerClientOverviewQuery(
         var users = new Dictionary<string, User?>();
         foreach (var extId in externalIds)
         {
-            var user = await userQueryService.GetByExternalIdAsync(extId, ct);
+            var user = await userQueryService.GetByExternalId(extId, ct);
             users[extId] = user;
         }
 

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientQueryService.cs
@@ -16,8 +16,8 @@ public class OpenVpnServerClientQueryService(IQueryService<OpenVpnServerClient, 
         => q.FindById(id, ct: ct);
 
     public Task<OpenVpnServerClient?> GetBySessionAndServerId(Guid session, int vpnServerId, CancellationToken ct)
-    => q.FirstOrDefault(x=>x.SessionId == session && x.VpnServerId == vpnServerId, 
-        asNoTracking: true, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.SessionId == session && x.VpnServerId == vpnServerId, ct);
 
     public Task<IPagedResult<OpenVpnServerClient>> GetPage(int page, int pageSize, CancellationToken ct)
         => q.Page(page, pageSize, ct: ct);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientQueryService.cs
@@ -6,19 +6,19 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerClientTable;
 
 public class OpenVpnServerClientQueryService(IQueryService<OpenVpnServerClient, int> q) : IOpenVpnServerClientQueryService
 {
-    public Task<List<OpenVpnServerClient>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<OpenVpnServerClient>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<List<OpenVpnServerClient>> GetAllConnectedByVpnServerIdAsync(int vpnServerId, CancellationToken ct)
-        => q.WhereAsync(x => x.IsConnected && x.VpnServerId == vpnServerId, ct: ct);
+    public Task<List<OpenVpnServerClient>> GetAllConnectedByVpnServerId(int vpnServerId, CancellationToken ct)
+        => q.Where(x => x.IsConnected && x.VpnServerId == vpnServerId, ct: ct);
 
-    public Task<OpenVpnServerClient?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<OpenVpnServerClient?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<OpenVpnServerClient?> GetBySessionAndServerIdAsync(Guid session, int vpnServerId, CancellationToken ct)
-    => q.Query().AsNoTracking().FirstOrDefaultAsync(
-        x=>x.SessionId == session && x.VpnServerId == vpnServerId, ct);
+    public Task<OpenVpnServerClient?> GetBySessionAndServerId(Guid session, int vpnServerId, CancellationToken ct)
+    => q.FirstOrDefault(x=>x.SessionId == session && x.VpnServerId == vpnServerId, 
+        asNoTracking: true, ct: ct);
 
-    public Task<IPagedResult<OpenVpnServerClient>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<OpenVpnServerClient>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerEventLogTable/IOpenVpnServerEventLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerEventLogTable/IOpenVpnServerEventLogQueryService.cs
@@ -5,10 +5,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerEventLogTable;
 
 public interface IOpenVpnServerEventLogQueryService
 {
-    Task<List<OpenVpnServerEventLog>> GetAllAsync(CancellationToken ct);
-    Task<OpenVpnServerEventLog?> GetByIdAsync(int id, CancellationToken ct);
+    Task<List<OpenVpnServerEventLog>> GetAll(CancellationToken ct);
+    Task<OpenVpnServerEventLog?> GetById(int id, CancellationToken ct);
 
-    Task<IPagedResult<OpenVpnServerEventLog>> GetByVpnServerIdAsync(int vpnServerId, int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<OpenVpnServerEventLog>> GetByVpnServerId(int vpnServerId, int page, int pageSize, CancellationToken ct);
 
-    Task<IPagedResult<OpenVpnServerEventLog>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<OpenVpnServerEventLog>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerEventLogTable/OpenVpnServerEventLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerEventLogTable/OpenVpnServerEventLogQueryService.cs
@@ -7,13 +7,13 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerEventLogTable;
 public class OpenVpnServerEventLogQueryService(IQueryService<OpenVpnServerEventLog, int> q)
     : IOpenVpnServerEventLogQueryService
 {
-    public Task<List<OpenVpnServerEventLog>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<OpenVpnServerEventLog>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<OpenVpnServerEventLog?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<OpenVpnServerEventLog?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public async Task<IPagedResult<OpenVpnServerEventLog>> GetByVpnServerIdAsync(
+    public async Task<IPagedResult<OpenVpnServerEventLog>> GetByVpnServerId(
         int vpnServerId, int page, int pageSize, CancellationToken ct)
     {
         if (page < 1) page = 1;
@@ -40,6 +40,6 @@ public class OpenVpnServerEventLogQueryService(IQueryService<OpenVpnServerEventL
         };
     }
 
-    public async Task<IPagedResult<OpenVpnServerEventLog>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => await q.PageAsync(page, pageSize, ct: ct);
+    public async Task<IPagedResult<OpenVpnServerEventLog>> GetPage(int page, int pageSize, CancellationToken ct)
+        => await q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/IOpenVpnServerOvpnFileConfigQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/IOpenVpnServerOvpnFileConfigQueryService.cs
@@ -5,9 +5,9 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerOvpnFileConfig
 
 public interface IOpenVpnServerOvpnFileConfigQueryService
 {
-    Task<List<OpenVpnServerOvpnFileConfig>> GetAllAsync(CancellationToken ct);
-    Task<OpenVpnServerOvpnFileConfig?> GetByIdAsync(int id, CancellationToken ct);
-    Task<OpenVpnServerOvpnFileConfig?> GetByVpnServerIdIdAsync(int vpnServerId, CancellationToken ct);
+    Task<List<OpenVpnServerOvpnFileConfig>> GetAll(CancellationToken ct);
+    Task<OpenVpnServerOvpnFileConfig?> GetById(int id, CancellationToken ct);
+    Task<OpenVpnServerOvpnFileConfig?> GetByVpnServerIdId(int vpnServerId, CancellationToken ct);
     Task<bool> AnyByVpnServerId(int vpnServerId, CancellationToken ct);
-    Task<IPagedResult<OpenVpnServerOvpnFileConfig>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<OpenVpnServerOvpnFileConfig>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/OpenVpnServerOvpnFileConfigQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/OpenVpnServerOvpnFileConfigQueryService.cs
@@ -7,15 +7,17 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerOvpnFileConfig
 public class OpenVpnServerOvpnFileConfigQueryService(
     IQueryService<OpenVpnServerOvpnFileConfig, int> q) : IOpenVpnServerOvpnFileConfigQueryService
 {
-    public Task<List<OpenVpnServerOvpnFileConfig>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
-    public Task<OpenVpnServerOvpnFileConfig?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
-    public Task<OpenVpnServerOvpnFileConfig?> GetByVpnServerIdIdAsync(int vpnServerId, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.VpnServerId == vpnServerId, ct);
+    public Task<List<OpenVpnServerOvpnFileConfig>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
+    public Task<OpenVpnServerOvpnFileConfig?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
+    public Task<OpenVpnServerOvpnFileConfig?> GetByVpnServerIdId(
+        int vpnServerId,
+        CancellationToken ct)
+        => q.FirstOrDefault(x => x.VpnServerId == vpnServerId, ct: ct);
     
     public Task<bool> AnyByVpnServerId(int vpnServerId, CancellationToken ct)
-        => q.AnyAsync(x => x.VpnServerId == vpnServerId, ct: ct);
-    public Task<IPagedResult<OpenVpnServerOvpnFileConfig>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+        => q.Any(x => x.VpnServerId == vpnServerId, ct: ct);
+    public Task<IPagedResult<OpenVpnServerOvpnFileConfig>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/OpenVpnServerOvpnFileConfigQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/OpenVpnServerOvpnFileConfigQueryService.cs
@@ -14,7 +14,8 @@ public class OpenVpnServerOvpnFileConfigQueryService(
     public Task<OpenVpnServerOvpnFileConfig?> GetByVpnServerIdId(
         int vpnServerId,
         CancellationToken ct)
-        => q.FirstOrDefault(x => x.VpnServerId == vpnServerId, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.VpnServerId == vpnServerId, ct);
     
     public Task<bool> AnyByVpnServerId(int vpnServerId, CancellationToken ct)
         => q.Any(x => x.VpnServerId == vpnServerId, ct: ct);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerStatusLogTable/IOpenVpnServerStatusLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerStatusLogTable/IOpenVpnServerStatusLogQueryService.cs
@@ -5,10 +5,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerStatusLogTable
 
 public interface IOpenVpnServerStatusLogQueryService
 {
-    Task<List<OpenVpnServerStatusLog>> GetAllAsync(CancellationToken ct);
+    Task<List<OpenVpnServerStatusLog>> GetAll(CancellationToken ct);
     Task<List<OpenVpnServerStatusLog>> GetAllByVpnServerId(int vpnServerId, CancellationToken ct);
-    Task<OpenVpnServerStatusLog?> GetByIdAndVpnServerIdAsync(int id, int vpnServerId, CancellationToken ct);
-    Task<OpenVpnServerStatusLog?> GetBySessionIdAndVpnServerIdAsync(Guid session, int vpnServerId, CancellationToken ct);
-    Task<OpenVpnServerStatusLog?> GetByIdAsync(int id, CancellationToken ct);
-    Task<IPagedResult<OpenVpnServerStatusLog>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<OpenVpnServerStatusLog?> GetByIdAndVpnServerId(int id, int vpnServerId, CancellationToken ct);
+    Task<OpenVpnServerStatusLog?> GetBySessionIdAndVpnServerId(Guid session, int vpnServerId, CancellationToken ct);
+    Task<OpenVpnServerStatusLog?> GetById(int id, CancellationToken ct);
+    Task<IPagedResult<OpenVpnServerStatusLog>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerStatusLogTable/OpenVpnServerStatusLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerStatusLogTable/OpenVpnServerStatusLogQueryService.cs
@@ -13,14 +13,15 @@ public class OpenVpnServerStatusLogQueryService(IQueryService<OpenVpnServerStatu
         => q.Where(x => x.VpnServerId == vpnServerId, ct: ct);
 
     public Task<OpenVpnServerStatusLog?> GetBySessionIdAndVpnServerId(Guid sessionId, int vpnServerId, CancellationToken ct)
-        => q.FirstOrDefault(x => x.SessionId == sessionId && x.VpnServerId == vpnServerId, 
-            asNoTracking: true, ct:ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.SessionId == sessionId && x.VpnServerId == vpnServerId, ct);
 
     public Task<OpenVpnServerStatusLog?> GetById(int id, CancellationToken ct)
         => q.FindById(id, ct: ct);
     
     public Task<OpenVpnServerStatusLog?> GetByIdAndVpnServerId(int id, int vpnServerId, CancellationToken ct)
-        => q.FirstOrDefault(x => x.Id == id && x.VpnServerId == vpnServerId, asNoTracking: true, ct:ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.Id == id && x.VpnServerId == vpnServerId, ct);
     
     public Task<IPagedResult<OpenVpnServerStatusLog>> GetPage(int page, int pageSize, CancellationToken ct)
         => q.Page(page, pageSize, ct: ct);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerStatusLogTable/OpenVpnServerStatusLogQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerStatusLogTable/OpenVpnServerStatusLogQueryService.cs
@@ -6,27 +6,22 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerStatusLogTable
 
 public class OpenVpnServerStatusLogQueryService(IQueryService<OpenVpnServerStatusLog, int> q) : IOpenVpnServerStatusLogQueryService
 {
-    public Task<List<OpenVpnServerStatusLog>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<OpenVpnServerStatusLog>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
     public Task<List<OpenVpnServerStatusLog>> GetAllByVpnServerId(int vpnServerId, CancellationToken ct)
-        => q.WhereAsync(x => x.VpnServerId == vpnServerId, ct: ct);
+        => q.Where(x => x.VpnServerId == vpnServerId, ct: ct);
 
-    public Task<OpenVpnServerStatusLog?> GetBySessionIdAndVpnServerIdAsync(Guid sessionId, int vpnServerId, CancellationToken ct)
-        => q.Query()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(x => 
-                x.SessionId == sessionId && x.VpnServerId == vpnServerId, ct);
+    public Task<OpenVpnServerStatusLog?> GetBySessionIdAndVpnServerId(Guid sessionId, int vpnServerId, CancellationToken ct)
+        => q.FirstOrDefault(x => x.SessionId == sessionId && x.VpnServerId == vpnServerId, 
+            asNoTracking: true, ct:ct);
 
-    public Task<OpenVpnServerStatusLog?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<OpenVpnServerStatusLog?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
     
-    public Task<OpenVpnServerStatusLog?> GetByIdAndVpnServerIdAsync(int id, int vpnServerId, CancellationToken ct)
-        => q.Query()
-            .AsNoTracking()
-            .FirstOrDefaultAsync(x => 
-                x.Id == id && x.VpnServerId == vpnServerId, ct);
+    public Task<OpenVpnServerStatusLog?> GetByIdAndVpnServerId(int id, int vpnServerId, CancellationToken ct)
+        => q.FirstOrDefault(x => x.Id == id && x.VpnServerId == vpnServerId, asNoTracking: true, ct:ct);
     
-    public Task<IPagedResult<OpenVpnServerStatusLog>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<OpenVpnServerStatusLog>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQueryService.cs
@@ -5,8 +5,8 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 
 public interface IOpenVpnServerQueryService
 {
-    Task<List<OpenVpnServer>> GetAllAsync(CancellationToken ct);
-    Task<OpenVpnServer?> GetByIdAsync(int id, CancellationToken ct);
-    Task<List<OpenVpnServer>> GetDefaultExceptAsync(int exceptId, CancellationToken ct);
-    Task<IPagedResult<OpenVpnServer>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<List<OpenVpnServer>> GetAll(CancellationToken ct);
+    Task<OpenVpnServer?> GetById(int id, CancellationToken ct);
+    Task<List<OpenVpnServer>> GetDefaultExcept(int exceptId, CancellationToken ct);
+    Task<IPagedResult<OpenVpnServer>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryService.cs
@@ -5,15 +5,15 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 
 public class OpenVpnServerQueryService(IQueryService<OpenVpnServer, int> q) : IOpenVpnServerQueryService
 {
-    public Task<List<OpenVpnServer>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<OpenVpnServer>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<OpenVpnServer?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<OpenVpnServer?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<List<OpenVpnServer>> GetDefaultExceptAsync(int exceptId, CancellationToken ct)
-        => q.WhereAsync(x => x.IsDefault && x.Id != exceptId, ct: ct);
+    public Task<List<OpenVpnServer>> GetDefaultExcept(int exceptId, CancellationToken ct)
+        => q.Where(x => x.IsDefault && x.Id != exceptId, ct: ct);
 
-    public Task<IPagedResult<OpenVpnServer>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<OpenVpnServer>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryService.cs
@@ -7,18 +7,18 @@ public class QuotaPlanAllowedServerQueryService(
     IQueryService<QuotaPlanAllowedServer, int> q) : IQuotaPlanAllowedServerQueryService
 {
     public Task<List<QuotaPlanAllowedServer>> GetAll(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+        => q.GetAll(ct: ct);
 
     public Task<QuotaPlanAllowedServer?> GetById(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+        => q.FindById(id, ct: ct);
 
     public Task<QuotaPlanAllowedServer?> GetByQuotaPlanIdAndServerId(int quotaPlanId, int vpnServerId,
         CancellationToken ct)
-        => q.FirstOrDefaultAsync(
+        => q.FirstOrDefault(
             predicate: x => x.QuotaPlanId == quotaPlanId && x.VpnServerId == vpnServerId,
             orderBy: s => s.OrderBy(x => x.Id),
             asNoTracking: true,
             ct: ct);
     public Task<IPagedResult<QuotaPlanAllowedServer>> GetPage(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanTable/IQuotaPlanQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanTable/IQuotaPlanQueryService.cs
@@ -5,8 +5,8 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanTable;
 
 public interface IQuotaPlanQueryService
 {
-    Task<List<QuotaPlan>> GetAllAsync(CancellationToken ct);
-    Task<QuotaPlan?> GetByIdAsync(int id, CancellationToken ct);
-    Task<QuotaPlan?> GetDefaultAsync(CancellationToken ct);
-    Task<IPagedResult<QuotaPlan>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<List<QuotaPlan>> GetAll(CancellationToken ct);
+    Task<QuotaPlan?> GetById(int id, CancellationToken ct);
+    Task<QuotaPlan?> GetDefault(CancellationToken ct);
+    Task<IPagedResult<QuotaPlan>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanTable/QuotaPlanQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanTable/QuotaPlanQueryService.cs
@@ -5,17 +5,17 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanTable;
 
 public class QuotaPlanQueryService(IQueryService<QuotaPlan, int> q) : IQuotaPlanQueryService
 {
-    public Task<List<QuotaPlan>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<QuotaPlan>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<QuotaPlan?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
-    public Task<QuotaPlan?> GetDefaultAsync(CancellationToken ct)
-        => q.FirstOrDefaultAsync(
+    public Task<QuotaPlan?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
+    public Task<QuotaPlan?> GetDefault(CancellationToken ct)
+        => q.FirstOrDefault(
             predicate: x => x.IsDefault && x.IsActive,
             orderBy: s => s.OrderBy(x => x.Id),
             asNoTracking: true,
             ct: ct);
-    public Task<IPagedResult<QuotaPlan>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<QuotaPlan>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/RoleTable/IRoleQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/RoleTable/IRoleQueryService.cs
@@ -6,10 +6,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.RoleTable;
 
 public interface IRoleQueryService
 {
-    Task<List<Role>> GetAllAsync(CancellationToken ct);
-    Task<Role?> GetByIdAsync(int id, CancellationToken ct);
-    Task<IPagedResult<Role>> GetPageAsync(int page, int pageSize, CancellationToken ct);
-    public Task<List<Role>> SearchAsync(
+    Task<List<Role>> GetAll(CancellationToken ct);
+    Task<Role?> GetById(int id, CancellationToken ct);
+    Task<IPagedResult<Role>> GetPage(int page, int pageSize, CancellationToken ct);
+    public Task<List<Role>> Search(
         Expression<Func<Role, bool>> predicate,
         CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/RoleTable/RoleQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/RoleTable/RoleQueryService.cs
@@ -7,17 +7,17 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.RoleTable;
 public class RoleQueryService(
     IQueryService<Role, int> q) : IRoleQueryService
 {
-    public Task<List<Role>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<Role>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<Role?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<Role?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<IPagedResult<Role>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<Role>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 
-    public Task<List<Role>> SearchAsync(
+    public Task<List<Role>> Search(
         Expression<Func<Role, bool>> predicate,
         CancellationToken ct)
-        => q.WhereAsync(predicate, ct: ct);
+        => q.Where(predicate, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/TelegramBotUserTable/ITelegramBotUserQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/TelegramBotUserTable/ITelegramBotUserQueryService.cs
@@ -5,10 +5,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.TelegramBotUserTable;
 
 public interface ITelegramBotUserQueryService
 {
-    Task<List<TelegramBotUser>> GetAllAsync(CancellationToken ct);
-    Task<List<TelegramBotUser>> GetAllAdminsAsync(CancellationToken ct);
-    Task<TelegramBotUser?> GetByIdAsync(int id, CancellationToken ct);
-    Task<bool> AnyByTelegramIdAsync(long telegramId, CancellationToken ct);
-    Task<TelegramBotUser?> GetByTelegramIdAsync(long telegramId, CancellationToken ct);
-    Task<IPagedResult<TelegramBotUser>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<List<TelegramBotUser>> GetAll(CancellationToken ct);
+    Task<List<TelegramBotUser>> GetAllAdmins(CancellationToken ct);
+    Task<TelegramBotUser?> GetById(int id, CancellationToken ct);
+    Task<bool> AnyByTelegramId(long telegramId, CancellationToken ct);
+    Task<TelegramBotUser?> GetByTelegramId(long telegramId, CancellationToken ct);
+    Task<IPagedResult<TelegramBotUser>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/TelegramBotUserTable/TelegramBotUserQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/TelegramBotUserTable/TelegramBotUserQueryService.cs
@@ -6,21 +6,21 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.TelegramBotUserTable;
 
 public class TelegramBotUserQueryService(IQueryService<TelegramBotUser, int> q) : ITelegramBotUserQueryService
 {
-    public Task<List<TelegramBotUser>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<TelegramBotUser>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
     
-    public Task<List<TelegramBotUser>> GetAllAdminsAsync(CancellationToken ct)
+    public Task<List<TelegramBotUser>> GetAllAdmins(CancellationToken ct)
         => q.Query().Where(x => x.IsAdmin == true).ToListAsync(ct);
 
-    public Task<TelegramBotUser?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<TelegramBotUser?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<bool> AnyByTelegramIdAsync(long telegramId, CancellationToken ct)
-        => q.AnyAsync(x=> x.TelegramId == telegramId, ct: ct);
+    public Task<bool> AnyByTelegramId(long telegramId, CancellationToken ct)
+        => q.Any(x=> x.TelegramId == telegramId, ct: ct);
 
-    public Task<TelegramBotUser?> GetByTelegramIdAsync(long telegramId, CancellationToken ct)
+    public Task<TelegramBotUser?> GetByTelegramId(long telegramId, CancellationToken ct)
         => q.Query().FirstOrDefaultAsync(x => x.TelegramId == telegramId, ct);
     
-    public Task<IPagedResult<TelegramBotUser>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<TelegramBotUser>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/TelegramUserLanguagePreferenceTable/ITelegramUserLanguagePreferenceQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/TelegramUserLanguagePreferenceTable/ITelegramUserLanguagePreferenceQueryService.cs
@@ -5,10 +5,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.TelegramUserLanguagePrefere
 
 public interface ITelegramUserLanguagePreferenceQueryService
 {
-    Task<List<TelegramUserLanguagePreference>> GetAllAsync(CancellationToken ct);
-    Task<TelegramUserLanguagePreference?> GetByIdAsync(int id, CancellationToken ct);
+    Task<List<TelegramUserLanguagePreference>> GetAll(CancellationToken ct);
+    Task<TelegramUserLanguagePreference?> GetById(int id, CancellationToken ct);
     Task<TelegramUserLanguagePreference?> GetByTelegramId(long telegramId, CancellationToken ct);
     Task<bool> AnyByTelegramId(long telegramId, CancellationToken ct);
 
-    Task<IPagedResult<TelegramUserLanguagePreference>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<TelegramUserLanguagePreference>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/TelegramUserLanguagePreferenceTable/TelegramUserLanguagePreferenceQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/TelegramUserLanguagePreferenceTable/TelegramUserLanguagePreferenceQueryService.cs
@@ -6,18 +6,18 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.TelegramUserLanguagePrefere
 
 public class TelegramUserLanguagePreferenceQueryService(IQueryService<TelegramUserLanguagePreference, int> q) : ITelegramUserLanguagePreferenceQueryService
 {
-    public Task<List<TelegramUserLanguagePreference>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<TelegramUserLanguagePreference>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<TelegramUserLanguagePreference?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<TelegramUserLanguagePreference?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
     public Task<TelegramUserLanguagePreference?> GetByTelegramId(long telegramId, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.TelegramId == telegramId, ct);
+        => q.FirstOrDefault(x => x.TelegramId == telegramId, asNoTracking: true, ct: ct);
 
     public Task<bool> AnyByTelegramId(long telegramId, CancellationToken ct)
-        => q.AnyAsync(x => x.TelegramId == telegramId, ct: ct);
+        => q.Any(x => x.TelegramId == telegramId, ct: ct);
 
-    public Task<IPagedResult<TelegramUserLanguagePreference>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<TelegramUserLanguagePreference>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/TelegramUserLanguagePreferenceTable/TelegramUserLanguagePreferenceQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/TelegramUserLanguagePreferenceTable/TelegramUserLanguagePreferenceQueryService.cs
@@ -13,7 +13,8 @@ public class TelegramUserLanguagePreferenceQueryService(IQueryService<TelegramUs
         => q.FindById(id, ct: ct);
 
     public Task<TelegramUserLanguagePreference?> GetByTelegramId(long telegramId, CancellationToken ct)
-        => q.FirstOrDefault(x => x.TelegramId == telegramId, asNoTracking: true, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.TelegramId == telegramId, ct);
 
     public Task<bool> AnyByTelegramId(long telegramId, CancellationToken ct)
         => q.Any(x => x.TelegramId == telegramId, ct: ct);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserCredentialTable/IUserCredentialQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserCredentialTable/IUserCredentialQueryService.cs
@@ -5,13 +5,13 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserCredentialTable;
 
 public interface IUserCredentialQueryService
 {
-    Task<List<UserCredential>> GetAllAsync(CancellationToken ct);
-    Task<UserCredential?> GetByIdAsync(int id, CancellationToken ct);
+    Task<List<UserCredential>> GetAll(CancellationToken ct);
+    Task<UserCredential?> GetById(int id, CancellationToken ct);
     Task<UserCredential?> GetByNormalizedLogin(string normalizedLogin, CancellationToken ct);
-    Task<UserCredential?> GetByLoginAsync(string login, CancellationToken ct);
+    Task<UserCredential?> GetByLogin(string login, CancellationToken ct);
     Task<UserCredential?> GetByUserId(int userId, CancellationToken ct);
     Task<bool> AnyByUserId(int userId, CancellationToken ct);
-    Task<bool> LoginExistsAsync(string login, CancellationToken ct);
+    Task<bool> LoginExists(string login, CancellationToken ct);
 
-    Task<IPagedResult<UserCredential>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<UserCredential>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserCredentialTable/UserCredentialQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserCredentialTable/UserCredentialQueryService.cs
@@ -14,16 +14,19 @@ public class UserCredentialQueryService(IQueryService<UserCredential, int> q)
         => q.FindById(id, ct: ct);
 
     public Task<UserCredential?> GetByNormalizedLogin(string normalizedLogin, CancellationToken ct)
-        => q.FirstOrDefault(x => x.NormalizedLogin == normalizedLogin, asNoTracking: true, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.NormalizedLogin == normalizedLogin, ct);
 
     public Task<UserCredential?> GetByLogin(string login, CancellationToken ct)
     {
         var normalized = login.ToUpperInvariant();
-        return q.FirstOrDefault(x => x.NormalizedLogin == normalized, asNoTracking: true, ct: ct);
+        return q.Query()
+            .FirstOrDefaultAsync(x => x.NormalizedLogin == normalized, ct);
     }
 
     public Task<UserCredential?> GetByUserId(int userId, CancellationToken ct)
-        => q.FirstOrDefault(x => x.UserId == userId, asNoTracking: true, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.UserId == userId, ct);
 
     public Task<bool> AnyByUserId(int userId, CancellationToken ct)
         => q.Any(x => x.UserId == userId, ct: ct);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserCredentialTable/UserCredentialQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserCredentialTable/UserCredentialQueryService.cs
@@ -7,35 +7,33 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserCredentialTable;
 public class UserCredentialQueryService(IQueryService<UserCredential, int> q)
     : IUserCredentialQueryService
 {
-    public Task<List<UserCredential>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<UserCredential>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<UserCredential?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<UserCredential?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
     public Task<UserCredential?> GetByNormalizedLogin(string normalizedLogin, CancellationToken ct)
-        => q.Query()
-            .FirstOrDefaultAsync(x => x.NormalizedLogin == normalizedLogin, ct);
+        => q.FirstOrDefault(x => x.NormalizedLogin == normalizedLogin, asNoTracking: true, ct: ct);
 
-    public Task<UserCredential?> GetByLoginAsync(string login, CancellationToken ct)
+    public Task<UserCredential?> GetByLogin(string login, CancellationToken ct)
     {
         var normalized = login.ToUpperInvariant();
-        return q.Query()
-            .FirstOrDefaultAsync(x => x.NormalizedLogin == normalized, ct);
+        return q.FirstOrDefault(x => x.NormalizedLogin == normalized, asNoTracking: true, ct: ct);
     }
 
     public Task<UserCredential?> GetByUserId(int userId, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.UserId == userId, ct);
+        => q.FirstOrDefault(x => x.UserId == userId, asNoTracking: true, ct: ct);
 
     public Task<bool> AnyByUserId(int userId, CancellationToken ct)
-        => q.AnyAsync(x => x.UserId == userId, ct: ct);
+        => q.Any(x => x.UserId == userId, ct: ct);
 
-    public Task<bool> LoginExistsAsync(string login, CancellationToken ct)
+    public Task<bool> LoginExists(string login, CancellationToken ct)
     {
         var normalized = login.ToUpperInvariant();
-        return q.AnyAsync(x => x.NormalizedLogin == normalized, ct: ct);
+        return q.Any(x => x.NormalizedLogin == normalized, ct: ct);
     }
 
-    public Task<IPagedResult<UserCredential>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<UserCredential>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/IUserIdentityLinkQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/IUserIdentityLinkQueryService.cs
@@ -5,12 +5,12 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
 
 public interface IUserIdentityLinkQueryService
 {
-    Task<List<UserIdentityLink>> GetAllAsync(CancellationToken ct);
-    Task<UserIdentityLink?> GetByIdAsync(int id, CancellationToken ct);
-    Task<UserIdentityLink?> GetByProviderAndExternalIdAsync(string provider, string externalId, CancellationToken ct);
-    public Task<UserIdentityLink?> GetByExternalIdAsync(string externalId, CancellationToken ct);
-    Task<UserIdentityLink?> GetByUserIdAsync(int userId, CancellationToken ct);
-    Task<bool> AnyByUserIdAsync(int userId, CancellationToken ct);
+    Task<List<UserIdentityLink>> GetAll(CancellationToken ct);
+    Task<UserIdentityLink?> GetById(int id, CancellationToken ct);
+    Task<UserIdentityLink?> GetByProviderAndExternalId(string provider, string externalId, CancellationToken ct);
+    public Task<UserIdentityLink?> GetByExternalId(string externalId, CancellationToken ct);
+    Task<UserIdentityLink?> GetByUserId(int userId, CancellationToken ct);
+    Task<bool> AnyByUserId(int userId, CancellationToken ct);
 
-    Task<IPagedResult<UserIdentityLink>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<UserIdentityLink>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
@@ -14,14 +14,16 @@ public class UserIdentityLinkQueryService(IQueryService<UserIdentityLink, int> q
 
     public Task<UserIdentityLink?> GetByProviderAndExternalId(string provider, string externalId, 
         CancellationToken ct)
-        => q.FirstOrDefault(x => x.Provider == provider && x.ExternalId == externalId, 
-            asNoTracking: true, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.Provider == provider && x.ExternalId == externalId, ct);
     
     public Task<UserIdentityLink?> GetByExternalId(string externalId, CancellationToken ct)
-        => q.FirstOrDefault(x => x.ExternalId == externalId, asNoTracking: true, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.ExternalId == externalId, ct);
 
     public Task<UserIdentityLink?> GetByUserId(int userId, CancellationToken ct)
-        => q.FirstOrDefault(x => x.UserId == userId, asNoTracking: true, ct: ct);
+        => q.Query()
+            .FirstOrDefaultAsync(x => x.UserId == userId, ct);
 
     public Task<bool> AnyByUserId(int userId, CancellationToken ct)
         => q.Any(x => x.UserId == userId, ct: ct);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
@@ -6,25 +6,26 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
 
 public class UserIdentityLinkQueryService(IQueryService<UserIdentityLink, int> q) : IUserIdentityLinkQueryService
 {
-    public Task<List<UserIdentityLink>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<UserIdentityLink>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<UserIdentityLink?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<UserIdentityLink?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<UserIdentityLink?> GetByProviderAndExternalIdAsync(string provider, string externalId, 
+    public Task<UserIdentityLink?> GetByProviderAndExternalId(string provider, string externalId, 
         CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.Provider == provider && x.ExternalId == externalId, ct);
+        => q.FirstOrDefault(x => x.Provider == provider && x.ExternalId == externalId, 
+            asNoTracking: true, ct: ct);
     
-    public Task<UserIdentityLink?> GetByExternalIdAsync(string externalId, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.ExternalId == externalId, ct);
+    public Task<UserIdentityLink?> GetByExternalId(string externalId, CancellationToken ct)
+        => q.FirstOrDefault(x => x.ExternalId == externalId, asNoTracking: true, ct: ct);
 
-    public Task<UserIdentityLink?> GetByUserIdAsync(int userId, CancellationToken ct)
-        => q.Query().FirstOrDefaultAsync(x => x.UserId == userId, ct);
+    public Task<UserIdentityLink?> GetByUserId(int userId, CancellationToken ct)
+        => q.FirstOrDefault(x => x.UserId == userId, asNoTracking: true, ct: ct);
 
-    public Task<bool> AnyByUserIdAsync(int userId, CancellationToken ct)
-        => q.AnyAsync(x => x.UserId == userId, ct: ct);
+    public Task<bool> AnyByUserId(int userId, CancellationToken ct)
+        => q.Any(x => x.UserId == userId, ct: ct);
 
-    public Task<IPagedResult<UserIdentityLink>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<UserIdentityLink>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserQuotaPlanTable/IUserQuotaPlanQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserQuotaPlanTable/IUserQuotaPlanQueryService.cs
@@ -5,9 +5,9 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
 
 public interface IUserQuotaPlanQueryService
 {
-    Task<List<UserQuotaPlan>> GetAllAsync(CancellationToken ct);
-    Task<UserQuotaPlan?> GetByIdAsync(int id, CancellationToken ct);
+    Task<List<UserQuotaPlan>> GetAll(CancellationToken ct);
+    Task<UserQuotaPlan?> GetById(int id, CancellationToken ct);
     Task<UserQuotaPlan?> GetByUserIdAndQuotaPlanId(int userId, int quotaPlanId, CancellationToken ct);
     Task<UserQuotaPlan?> GetByUserId(int userId, CancellationToken ct);
-    Task<IPagedResult<UserQuotaPlan>> GetPageAsync(int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<UserQuotaPlan>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserQuotaPlanTable/UserQuotaPlanQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserQuotaPlanTable/UserQuotaPlanQueryService.cs
@@ -5,25 +5,25 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
 
 public class UserQuotaPlanQueryService(IQueryService<UserQuotaPlan, int> q) : IUserQuotaPlanQueryService
 {
-    public Task<List<UserQuotaPlan>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<UserQuotaPlan>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<UserQuotaPlan?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<UserQuotaPlan?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
     public Task<UserQuotaPlan?> GetByUserIdAndQuotaPlanId(int userId, int quotaPlanId, CancellationToken ct)
-        => q.FirstOrDefaultAsync(
+        => q.FirstOrDefault(
             predicate: x => x.UserId == userId && x.QuotaPlanId == quotaPlanId,
             orderBy: s => s.OrderBy(x => x.Id),
             asNoTracking: true,
             ct: ct);
 
     public Task<UserQuotaPlan?> GetByUserId(int userId, CancellationToken ct)
-        => q.FirstOrDefaultAsync(
+        => q.FirstOrDefault(
             predicate: x => x.UserId == userId,
             orderBy: s => s.OrderBy(x => x.Id),
             asNoTracking: true,
             ct: ct);
 
-    public Task<IPagedResult<UserQuotaPlan>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<UserQuotaPlan>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/IUserRoleQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/IUserRoleQueryService.cs
@@ -6,12 +6,12 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserRoleTable;
 
 public interface IUserRoleQueryService
 {
-    Task<List<UserRole>> GetAllAsync(CancellationToken ct);
-    Task<UserRole?> GetByIdAsync(int id, CancellationToken ct);
-    Task<UserRole?> GetByUserIdAsync(int userId, CancellationToken ct);
-    Task<UserRole?> GetByIdAndUserIdAsync(int id, int userId, CancellationToken ct);
-    Task<IPagedResult<UserRole>> GetPageAsync(int page, int pageSize, CancellationToken ct);
-    public Task<List<UserRole>> SearchAsync(
+    Task<List<UserRole>> GetAll(CancellationToken ct);
+    Task<UserRole?> GetById(int id, CancellationToken ct);
+    Task<UserRole?> GetByUserId(int userId, CancellationToken ct);
+    Task<UserRole?> GetByIdAndUserId(int id, int userId, CancellationToken ct);
+    Task<IPagedResult<UserRole>> GetPage(int page, int pageSize, CancellationToken ct);
+    public Task<List<UserRole>> Search(
         Expression<Func<UserRole, bool>> predicate,
         CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/UserRoleQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/UserRoleQueryService.cs
@@ -7,23 +7,23 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserRoleTable;
 public class UserRoleQueryService(
     IQueryService<UserRole, int> q) : IUserRoleQueryService
 {
-    public Task<List<UserRole>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<UserRole>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<UserRole?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<UserRole?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public Task<UserRole?> GetByUserIdAsync(int userId, CancellationToken ct)
-        => q.FirstOrDefaultAsync(x=> x.UserId == userId, ct: ct);
+    public Task<UserRole?> GetByUserId(int userId, CancellationToken ct)
+        => q.FirstOrDefault(x=> x.UserId == userId, ct: ct);
 
-    public Task<UserRole?> GetByIdAndUserIdAsync(int id, int userId, CancellationToken ct)
-        => q.FirstOrDefaultAsync(x=> x.Id == id && x.UserId == userId, ct: ct);
+    public Task<UserRole?> GetByIdAndUserId(int id, int userId, CancellationToken ct)
+        => q.FirstOrDefault(x=> x.Id == id && x.UserId == userId, ct: ct);
 
-    public Task<IPagedResult<UserRole>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<UserRole>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 
-    public Task<List<UserRole>> SearchAsync(
+    public Task<List<UserRole>> Search(
         Expression<Func<UserRole, bool>> predicate,
         CancellationToken ct)
-        => q.WhereAsync(predicate, ct: ct);
+        => q.Where(predicate, ct: ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
@@ -6,13 +6,13 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.UserTable;
 
 public interface IUserQueryService
 {
-    Task<List<User>> GetAllAsync(CancellationToken ct);
-    Task<User?> GetByEmailAsync(string email, CancellationToken ct);
-    Task<bool> AnyByEmailAsync(string email, CancellationToken ct);
-    Task<User?> GetByIdAsync(int id, CancellationToken ct);
-    Task<User?> GetByExternalIdAsync(string externalId, CancellationToken ct);
-    Task<IPagedResult<User>> GetPageAsync(int page, int pageSize, CancellationToken ct);
-    public Task<List<User>> SearchAsync(
+    Task<List<User>> GetAll(CancellationToken ct);
+    Task<User?> GetByEmail(string email, CancellationToken ct);
+    Task<bool> AnyByEmail(string email, CancellationToken ct);
+    Task<User?> GetById(int id, CancellationToken ct);
+    Task<User?> GetByExternalId(string externalId, CancellationToken ct);
+    Task<IPagedResult<User>> GetPage(int page, int pageSize, CancellationToken ct);
+    public Task<List<User>> Search(
         Expression<Func<User, bool>> predicate,
         CancellationToken ct);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
@@ -9,25 +9,25 @@ public class UserQueryService(
     IQueryService<UserIdentityLink, int> qUserIdentityLink
 ) : IUserQueryService
 {
-    public Task<List<User>> GetAllAsync(CancellationToken ct)
-        => q.GetAllAsync(ct: ct);
+    public Task<List<User>> GetAll(CancellationToken ct)
+        => q.GetAll(ct: ct);
 
-    public Task<User?> GetByIdAsync(int id, CancellationToken ct)
-        => q.FindByIdAsync(id, ct: ct);
+    public Task<User?> GetById(int id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
 
-    public async Task<User?> GetByEmailAsync(string email, CancellationToken ct)
-        => await q.FirstOrDefaultAsync(
+    public async Task<User?> GetByEmail(string email, CancellationToken ct)
+        => await q.FirstOrDefault(
             predicate: u => u.Email != null && u.Email == email,
             asNoTracking: true,
             ct: ct
         );
 
-    public Task<bool> AnyByEmailAsync(string email, CancellationToken ct)
-        => q.AnyAsync(x => x.Email == email, ct: ct);
+    public Task<bool> AnyByEmail(string email, CancellationToken ct)
+        => q.Any(x => x.Email == email, ct: ct);
 
-    public async Task<User?> GetByExternalIdAsync(string externalId, CancellationToken ct)
+    public async Task<User?> GetByExternalId(string externalId, CancellationToken ct)
     {
-        var link = await qUserIdentityLink.FirstOrDefaultAsync(
+        var link = await qUserIdentityLink.FirstOrDefault(
             predicate: x => x.ExternalId == externalId,
             asNoTracking: true,
             ct: ct
@@ -36,18 +36,18 @@ public class UserQueryService(
         if (link is null)
             return null;
 
-        return await q.FirstOrDefaultAsync(
+        return await q.FirstOrDefault(
             predicate: x => x.Id == link.UserId,
             asNoTracking: true,
             ct: ct
         );
     }
 
-    public Task<IPagedResult<User>> GetPageAsync(int page, int pageSize, CancellationToken ct)
-        => q.PageAsync(page, pageSize, ct: ct);
+    public Task<IPagedResult<User>> GetPage(int page, int pageSize, CancellationToken ct)
+        => q.Page(page, pageSize, ct: ct);
 
-    public Task<List<User>> SearchAsync(
+    public Task<List<User>> Search(
         Expression<Func<User, bool>> predicate,
         CancellationToken ct)
-        => q.WhereAsync(predicate, ct: ct);
+        => q.Where(predicate, ct: ct);
 }

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="Mapster" Version="7.4.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.73" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.74" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="Mapster" Version="7.4.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.74" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.75" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.74" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.75" />
     </ItemGroup>
 
 </Project>

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.73" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.74" />
     </ItemGroup>
 
 </Project>

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnFiles/Requests/DownloadFileByCnRequest.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnFiles/Requests/DownloadFileByCnRequest.cs
@@ -4,9 +4,9 @@ namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnFiles.Re
 
 public class DownloadFileByCnRequest
 {
-    [Required(ErrorMessage = "issuedOvpnFileId is required.")]
-    [Range(1, int.MaxValue, ErrorMessage = "issuedOvpnFileId must be greater than 0.")]
-    public int IssuedOvpnFileId { get; set; }
+    [Required(ErrorMessage = "vpnServerId is required.")]
+    [Range(1, int.MaxValue, ErrorMessage = "vpnServerId must be greater than 0.")]
+    public int VpnServerId { get; set; }
 
     [Required(ErrorMessage = "commonName is required.")]
     public string CommonName { get; set; } = string.Empty;

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnFiles/Requests/DownloadFileByCnRequest.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnFiles/Requests/DownloadFileByCnRequest.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnFiles.Requests;
+
+public class DownloadFileByCnRequest
+{
+    [Required(ErrorMessage = "issuedOvpnFileId is required.")]
+    [Range(1, int.MaxValue, ErrorMessage = "issuedOvpnFileId must be greater than 0.")]
+    public int IssuedOvpnFileId { get; set; }
+
+    [Required(ErrorMessage = "commonName is required.")]
+    public string CommonName { get; set; } = string.Empty;
+}

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,9 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.74</Version>
-        <AssemblyVersion>1.0.74.0</AssemblyVersion>
-        <FileVersion>1.0.74.0</FileVersion>
+        <Version>1.0.75</Version>
+        <AssemblyVersion>1.0.75.0</AssemblyVersion>
+        <FileVersion>1.0.75.0</FileVersion>
 
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,9 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.73</Version>
-        <AssemblyVersion>1.0.73.0</AssemblyVersion>
-        <FileVersion>1.0.73.0</FileVersion>
+        <Version>1.0.74</Version>
+        <AssemblyVersion>1.0.74.0</AssemblyVersion>
+        <FileVersion>1.0.74.0</FileVersion>
 
         <Deterministic>true</Deterministic>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>

--- a/OpenVPNGateMonitor.Tests/Controllers/NotificationControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/NotificationControllerTests.cs
@@ -33,7 +33,7 @@ public class NotificationControllerTests
         var ct = CancellationToken.None;
 
         notificationServiceMock
-            .Setup(s => s.NotifyAdminsAsync(request, It.Is<IEnumerable<string>>(c => c.SequenceEqual(new[] { "web" })), ct))
+            .Setup(s => s.NotifyAdmins(request, It.Is<IEnumerable<string>>(c => c.SequenceEqual(new[] { "web" })), ct))
             .ReturnsAsync(expectedId);
 
         // Act
@@ -60,7 +60,7 @@ public class NotificationControllerTests
         var ct = CancellationToken.None;
 
         notificationServiceMock
-            .Setup(s => s.MarkDeliveredAsync(notificationId, adminUserId, channel, ct))
+            .Setup(s => s.MarkDelivered(notificationId, adminUserId, channel, ct))
             .Returns(Task.CompletedTask);
 
         // Act
@@ -86,7 +86,7 @@ public class NotificationControllerTests
         var ct = CancellationToken.None;
 
         notificationServiceMock
-            .Setup(s => s.MarkReadAsync(notificationId, adminUserId, ct))
+            .Setup(s => s.MarkRead(notificationId, adminUserId, ct))
             .Returns(Task.CompletedTask);
 
         // Act

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
@@ -33,7 +33,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllByVpnServerId_Returns_Ok()
     {
-        _service.Setup(s => s.GetAllByVpnServerIdAsync(5, It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.GetAllByVpnServerId(5, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<OpenVPNGateMonitor.Models.IssuedOvpnFile>());
 
         var result = await _controller.GetAllByVpnServerId(new ByVpnServerIdRequest { VpnServerId = 5 }, CancellationToken.None);
@@ -46,7 +46,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task AddFile_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.AddOvpnFileAsync(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.AddOvpnFile(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
 
         var result = await _controller.AddFile(new AddFileRequest { CommonName = "cn", VpnServerId = 1 }, CancellationToken.None);
@@ -59,7 +59,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetByToken_Returns_Ok()
     {
-        _service.Setup(s => s.GetByTokenAsync("tkn", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetByToken("tkn", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ReturnsAsync(new OpenVPNGateMonitor.Models.IssuedOvpnFile());
 
         var result = await _controller.GetByToken(new ByTokenRequest { Token = "tkn" }, CancellationToken.None);
@@ -72,7 +72,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetByToken_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.GetByTokenAsync("tkn", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetByToken("tkn", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.GetByToken(new ByTokenRequest { Token = "tkn" }, CancellationToken.None);
@@ -85,7 +85,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllByVpnServerId_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.GetAllByVpnServerIdAsync(10, It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.GetAllByVpnServerId(10, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.GetAllByVpnServerId(new ByVpnServerIdRequest { VpnServerId = 10 }, CancellationToken.None);
@@ -98,7 +98,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllByExternalIdAndVpnServerId_Returns_Ok()
     {
-        _service.Setup(s => s.GetAllByExternalIdAndVpnServerIdAsync(3, "ext", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetAllByExternalIdAndVpnServerId(3, "ext", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ReturnsAsync(new List<OpenVPNGateMonitor.Models.IssuedOvpnFile>());
 
         var result = await _controller.GetAllByExternalIdAndVpnServerId(
@@ -112,7 +112,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllByExternalIdAndVpnServerId_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.GetAllByExternalIdAndVpnServerIdAsync(3, "ext", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetAllByExternalIdAndVpnServerId(3, "ext", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.GetAllByExternalIdAndVpnServerId(
@@ -126,7 +126,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllWithToken_ByServerId_Returns_Ok()
     {
-        _service.Setup(s => s.GetAllByVpnServerIdWithTokenAsync(6, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetAllByVpnServerIdWithToken(6, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ReturnsAsync(new List<(OpenVPNGateMonitor.Models.IssuedOvpnFile, OpenVPNGateMonitor.Models.IssuedOvpnFileToken?)>());
 
         var result = await _controller.GetAllWithToken(new ByVpnServerIdRequest { VpnServerId = 6 }, CancellationToken.None);
@@ -139,7 +139,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllWithToken_ByServerId_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.GetAllByVpnServerIdWithTokenAsync(6, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetAllByVpnServerIdWithToken(6, It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.GetAllWithToken(new ByVpnServerIdRequest { VpnServerId = 6 }, CancellationToken.None);
@@ -152,7 +152,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllWithToken_ByExternalId_Returns_Ok()
     {
-        _service.Setup(s => s.GetAllByExternalIdAndVpnServerIdWithTokenAsync(2, "e1", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetAllByExternalIdAndVpnServerIdWithToken(2, "e1", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ReturnsAsync(new List<(OpenVPNGateMonitor.Models.IssuedOvpnFile, OpenVPNGateMonitor.Models.IssuedOvpnFileToken?)>());
 
         var result = await _controller.GetAllWithToken(new ByExternalIdAndVpnServerIdRequest { VpnServerId = 2, ExternalId = "e1" }, CancellationToken.None);
@@ -165,7 +165,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetAllWithToken_ByExternalId_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.GetAllByExternalIdAndVpnServerIdWithTokenAsync(2, "e1", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.GetAllByExternalIdAndVpnServerIdWithToken(2, "e1", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.GetAllWithToken(new ByExternalIdAndVpnServerIdRequest { VpnServerId = 2, ExternalId = "e1" }, CancellationToken.None);
@@ -178,7 +178,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetFiles_ByExternalId_Returns_Ok()
     {
-        _service.Setup(s => s.GetAllByExternalIdAsync("ext2", It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.GetAllByExternalId("ext2", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<OpenVPNGateMonitor.Models.IssuedOvpnFile>());
 
         var result = await _controller.GetFiles(new ByExternalIdRequest { ExternalId = "ext2" }, CancellationToken.None);
@@ -191,7 +191,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task GetFiles_ByExternalId_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.GetAllByExternalIdAsync("ext2", It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.GetAllByExternalId("ext2", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.GetFiles(new ByExternalIdRequest { ExternalId = "ext2" }, CancellationToken.None);
@@ -204,7 +204,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task AddFile_Returns_Ok()
     {
-        _service.Setup(s => s.AddOvpnFileAsync(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.AddOvpnFile(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new OpenVPNGateMonitor.Models.IssuedOvpnFile());
 
         var result = await _controller.AddFile(new AddFileRequest { CommonName = "cn", VpnServerId = 1 }, CancellationToken.None);
@@ -217,7 +217,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task AddFileWithToken_Returns_Ok()
     {
-        _service.Setup(s => s.AddOvpnFileWithTokenAsync(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.AddOvpnFileWithToken(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((new OpenVPNGateMonitor.Models.IssuedOvpnFile(), new OpenVPNGateMonitor.Models.IssuedOvpnFileToken()));
 
         var result = await _controller.AddFileWithToken(new AddFileRequest { CommonName = "cn", VpnServerId = 1 }, CancellationToken.None);
@@ -230,7 +230,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task AddFileWithToken_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.AddOvpnFileWithTokenAsync(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.AddOvpnFileWithToken(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.AddFileWithToken(new AddFileRequest { CommonName = "cn", VpnServerId = 1 }, CancellationToken.None);
@@ -243,7 +243,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task RevokeFile_Returns_Ok()
     {
-        _service.Setup(s => s.RevokeOvpnFileAsync(It.IsAny<RevokeFileRequest>(), It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.RevokeOvpnFile(It.IsAny<RevokeFileRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new OpenVPNGateMonitor.Models.IssuedOvpnFile());
 
         var result = await _controller.RevokeFile(new RevokeFileRequest { CommonName = "cn", VpnServerId = 5 }, CancellationToken.None);
@@ -256,7 +256,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task RevokeFile_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.RevokeOvpnFileAsync(It.IsAny<RevokeFileRequest>(), It.IsAny<CancellationToken>()))
+        _service.Setup(s => s.RevokeOvpnFile(It.IsAny<RevokeFileRequest>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.RevokeFile(new RevokeFileRequest { CommonName = "cn", VpnServerId = 5 }, CancellationToken.None);
@@ -269,7 +269,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task DownloadFile_Returns_Ok()
     {
-        _service.Setup(s => s.DownloadOvpnFileAsync(It.IsAny<DownloadFileRequest>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.DownloadOvpnFile(It.IsAny<DownloadFileRequest>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ReturnsAsync(new DownloadFileResponse { Content = new byte[] { 1, 2, 3 }, FileSizeBytes = 3 });
 
         var result = await _controller.DownloadFile(new DownloadFileRequest { IssuedOvpnFileId = 1, VpnServerId = 1 }, CancellationToken.None);
@@ -282,7 +282,7 @@ public class OpenVpnFilesControllerTests
     [Fact]
     public async Task DownloadFile_Returns_BadRequest_On_Exception()
     {
-        _service.Setup(s => s.DownloadOvpnFileAsync(It.IsAny<DownloadFileRequest>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+        _service.Setup(s => s.DownloadOvpnFile(It.IsAny<DownloadFileRequest>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()))
             .ThrowsAsync(new Exception("err"));
 
         var result = await _controller.DownloadFile(new DownloadFileRequest { IssuedOvpnFileId = 1, VpnServerId = 1 }, CancellationToken.None);

--- a/OpenVPNGateMonitor.Tests/Controllers/TelegramBotIncomingMessageLogControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/TelegramBotIncomingMessageLogControllerTests.cs
@@ -82,7 +82,7 @@ public class TelegramBotIncomingMessageLogControllerTests
         };
 
         _query
-            .Setup(q => q.GetPageAsync(2, 5, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetPage(2, 5, It.IsAny<CancellationToken>()))
             .ReturnsAsync(paged);
 
         var request = new GetAllMessagesRequest { Page = 2, PageSize = 5 };
@@ -98,7 +98,7 @@ public class TelegramBotIncomingMessageLogControllerTests
         Assert.Equal(12, response.Data!.Messages.TotalCount);
         Assert.Single(response.Data!.Messages.Items);
 
-        _query.Verify(q => q.GetPageAsync(2, 5, It.IsAny<CancellationToken>()), Times.Once);
+        _query.Verify(q => q.GetPage(2, 5, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class TelegramBotIncomingMessageLogControllerTests
         };
 
         _query
-            .Setup(q => q.GetPageByTelegramIdAsync(777, 1, 10, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetPageByTelegramId(777, 1, 10, It.IsAny<CancellationToken>()))
             .ReturnsAsync(paged);
 
         var req = new GetAllByTelegramIdMessagesRequest
@@ -144,7 +144,7 @@ public class TelegramBotIncomingMessageLogControllerTests
         Assert.Single(response.Data!.Messages.Items);
         Assert.Equal(777, response.Data!.Messages.Items[0].TelegramId);
 
-        _query.Verify(q => q.GetPageByTelegramIdAsync(777, 1, 10, It.IsAny<CancellationToken>()), Times.Once);
+        _query.Verify(q => q.GetPageByTelegramId(777, 1, 10, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Command/EfCommandServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Command/EfCommandServiceTests.cs
@@ -38,7 +38,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
         var entity = new TestEntity { Id = 1, Name = "a" };
-        var result = await sut.AddAsync(entity, saveChanges: true, CancellationToken.None);
+        var result = await sut.Add(entity, saveChanges: true, CancellationToken.None);
 
         m.Repo.Verify(r => r.AddAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
         m.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -52,7 +52,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
         var entity = new TestEntity { Id = 2, Name = "b" };
-        var result = await sut.AddAsync(entity, saveChanges: false, CancellationToken.None);
+        var result = await sut.Add(entity, saveChanges: false, CancellationToken.None);
 
         m.Repo.Verify(r => r.AddAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
         m.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -73,7 +73,7 @@ public class EfCommandServiceTests
             new TestEntity { Id = 3 }
         };
 
-        var affected = await sut.AddRangeAsync(list, saveChanges: true, CancellationToken.None);
+        var affected = await sut.AddRange(list, saveChanges: true, CancellationToken.None);
 
         m.Repo.Verify(
             r => r.AddRangeAsync(
@@ -91,7 +91,7 @@ public class EfCommandServiceTests
         var m = new Mocks();
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
-        var affected = await sut.AddRangeAsync(Array.Empty<TestEntity>(), saveChanges: true, CancellationToken.None);
+        var affected = await sut.AddRange(Array.Empty<TestEntity>(), saveChanges: true, CancellationToken.None);
 
         m.Repo.Verify(
             r => r.AddRangeAsync(It.IsAny<IEnumerable<TestEntity>>(), It.IsAny<CancellationToken>()),
@@ -107,7 +107,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
         var list = new[] { new TestEntity { Id = 1 } };
-        var affected = await sut.AddRangeAsync(list, saveChanges: false, CancellationToken.None);
+        var affected = await sut.AddRange(list, saveChanges: false, CancellationToken.None);
 
         m.Repo.Verify(
             r => r.AddRangeAsync(
@@ -127,7 +127,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
         var entity = new TestEntity { Id = 5 };
-        var affected = await sut.UpdateAsync(entity, saveChanges: true, CancellationToken.None);
+        var affected = await sut.Update(entity, saveChanges: true, CancellationToken.None);
 
         m.Repo.Verify(r => r.Update(entity), Times.Once);
         m.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -141,7 +141,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
         var entity = new TestEntity { Id = 6 };
-        var affected = await sut.UpdateAsync(entity, saveChanges: false, CancellationToken.None);
+        var affected = await sut.Update(entity, saveChanges: false, CancellationToken.None);
 
         m.Repo.Verify(r => r.Update(entity), Times.Once);
         m.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -156,7 +156,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
         var entity = new TestEntity { Id = 10 };
-        var affected = await sut.DeleteAsync(entity, saveChanges: true, CancellationToken.None);
+        var affected = await sut.Delete(entity, saveChanges: true, CancellationToken.None);
 
         m.Repo.Verify(r => r.Delete(entity), Times.Once);
         m.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -170,7 +170,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
         var entity = new TestEntity { Id = 11 };
-        var affected = await sut.DeleteAsync(entity, saveChanges: false, CancellationToken.None);
+        var affected = await sut.Delete(entity, saveChanges: false, CancellationToken.None);
 
         m.Repo.Verify(r => r.Delete(entity), Times.Once);
         m.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
@@ -184,7 +184,7 @@ public class EfCommandServiceTests
         m.Uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(42);
         var sut = new EfCommandService<TestEntity, int>(m.Uow.Object);
 
-        var affected = await sut.SaveChangesAsync(CancellationToken.None);
+        var affected = await sut.SaveChanges(CancellationToken.None);
 
         m.Uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
         Assert.Equal(42, affected);
@@ -234,7 +234,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(uowMock.Object);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.DeleteByIdAsync(1, CancellationToken.None));
+            () => sut.DeleteById(1, CancellationToken.None));
     }
 
     [Fact]
@@ -256,7 +256,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(uowMock.Object);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.DeleteWhereAsync(e => !e.IsActive, CancellationToken.None));
+            () => sut.DeleteWhere(e => !e.IsActive, CancellationToken.None));
     }
 
     [Fact]
@@ -278,7 +278,7 @@ public class EfCommandServiceTests
         var sut = new EfCommandService<TestEntity, int>(uowMock.Object);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.UpdateWhereAsync(
+            () => sut.UpdateWhere(
                 e => !e.IsActive,
                 set => set.SetProperty(e => e.IsActive, _ => true),
                 CancellationToken.None));

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/ClientApplicationTable/ClientApplicationQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/ClientApplicationTable/ClientApplicationQueryServiceTests.cs
@@ -54,17 +54,17 @@ public class ClientApplicationQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new ClientApplicationQueryService(q.Object);
 
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -75,7 +75,7 @@ public class ClientApplicationQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new ClientApplicationQueryService(q.Object);
 
-        var result = await sut.GetAllIsNotRevokedAsync(CancellationToken.None);
+        var result = await sut.GetAllIsNotRevoked(CancellationToken.None);
 
         Assert.All(result, x => Assert.False(x.IsRevoked));
         Assert.Equal(new[] { 1, 2 }, result.Select(x => x.Id).OrderBy(i => i));
@@ -87,15 +87,15 @@ public class ClientApplicationQueryServiceTests
     {
         var target = new ClientApplication { Id = 42, Name = "X" };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new ClientApplicationQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -106,7 +106,7 @@ public class ClientApplicationQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new ClientApplicationQueryService(q.Object);
 
-        var result = await sut.GetByNameAsync("AppB", CancellationToken.None);
+        var result = await sut.GetByName("AppB", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(2, result!.Id);
@@ -120,7 +120,7 @@ public class ClientApplicationQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new ClientApplicationQueryService(q.Object);
 
-        var result = await sut.GetByClientIdAsync("cid-c", CancellationToken.None);
+        var result = await sut.GetByClientId("cid-c", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(3, result!.Id);
@@ -140,7 +140,7 @@ public class ClientApplicationQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new ClientApplicationQueryService(q.Object);
 
-        var result = await sut.GetBySystemByClientIdAsync("same", CancellationToken.None);
+        var result = await sut.GetBySystemByClientId("same", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(12, result!.Id);
@@ -160,7 +160,7 @@ public class ClientApplicationQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new ClientApplicationQueryService(q.Object);
 
-        var result = await sut.IsSystemConfiguredAsync(CancellationToken.None);
+        var result = await sut.IsSystemConfigured(CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(2, result!.Id);
@@ -181,15 +181,15 @@ public class ClientApplicationQueryServiceTests
             Items = data.Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()))
+        q.Setup(x => x.Page(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<ClientApplication>)
          .Verifiable();
 
         var sut = new ClientApplicationQueryService(q.Object);
-        var result = await sut.GetPageAsync(2, 10, CancellationToken.None);
+        var result = await sut.GetPage(2, 10, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<ClientApplication, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/IncomingMessageLogTable/IncomingMessageLogQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/IncomingMessageLogTable/IncomingMessageLogQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using OpenVPNGateMonitor.DataBase.Services.Query.IncomingMessageLogTable;
@@ -46,17 +47,17 @@ public class IncomingMessageLogQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new IncomingMessageLogQueryService(q.Object);
 
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -65,15 +66,15 @@ public class IncomingMessageLogQueryServiceTests
     {
         var target = new IncomingMessageLog { Id = 42, TelegramId = 999, MessageText = "hello" };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IncomingMessageLog, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IncomingMessageLog, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new IncomingMessageLogQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IncomingMessageLog, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IncomingMessageLog, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -95,7 +96,7 @@ public class IncomingMessageLogQueryServiceTests
             Items = data.Where(x => x.TelegramId == 1001).OrderByDescending(x => x.Id).Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(
+        q.Setup(x => x.Page(
                 1,
                 2,
                 It.IsAny<Expression<Func<IncomingMessageLog, bool>>>(),
@@ -115,7 +116,7 @@ public class IncomingMessageLogQueryServiceTests
          .Verifiable();
 
         var sut = new IncomingMessageLogQueryService(q.Object);
-        var result = await sut.GetPageByTelegramIdAsync(1001, 1, 2, CancellationToken.None);
+        var result = await sut.GetPageByTelegramId(1001, 1, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
         Assert.NotNull(capturedPredicate);
@@ -152,7 +153,7 @@ public class IncomingMessageLogQueryServiceTests
             Items = data.OrderByDescending(x => x.Id).Skip(10).Take(5).ToList()
         };
 
-        q.Setup(x => x.PageAsync(
+        q.Setup(x => x.Page(
                 3,
                 5,
                 null,
@@ -172,7 +173,7 @@ public class IncomingMessageLogQueryServiceTests
          .Verifiable();
 
         var sut = new IncomingMessageLogQueryService(q.Object);
-        var result = await sut.GetPageAsync(3, 5, CancellationToken.None);
+        var result = await sut.GetPage(3, 5, CancellationToken.None);
 
         Assert.Same(paged, result);
         Assert.Null(capturedPredicate);

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryServiceTests.cs
@@ -46,16 +46,16 @@ public class IssuedOvpnFileQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new IssuedOvpnFileQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -67,7 +67,7 @@ public class IssuedOvpnFileQueryServiceTests
 
         Expression<Func<IssuedOvpnFile, bool>>? captured = null;
 
-        q.Setup(x => x.WhereAsync(
+        q.Setup(x => x.Where(
                 It.IsAny<Expression<Func<IssuedOvpnFile, bool>>>(),
                 null,
                 true,
@@ -101,7 +101,7 @@ public class IssuedOvpnFileQueryServiceTests
 
         Expression<Func<IssuedOvpnFile, bool>>? captured = null;
 
-        q.Setup(x => x.WhereAsync(
+        q.Setup(x => x.Where(
                 It.IsAny<Expression<Func<IssuedOvpnFile, bool>>>(),
                 null,
                 true,
@@ -133,7 +133,7 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         Expression<Func<IssuedOvpnFile, bool>>? captured = null;
 
-        q.Setup(x => x.WhereAsync(
+        q.Setup(x => x.Where(
                 It.IsAny<Expression<Func<IssuedOvpnFile, bool>>>(),
                 null,
                 true,
@@ -162,7 +162,7 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         Expression<Func<IssuedOvpnFile, bool>>? captured = null;
 
-        q.Setup(x => x.WhereAsync(
+        q.Setup(x => x.Where(
                 It.IsAny<Expression<Func<IssuedOvpnFile, bool>>>(),
                 null,
                 true,
@@ -189,15 +189,15 @@ public class IssuedOvpnFileQueryServiceTests
     {
         var target = new IssuedOvpnFile { Id = 99, VpnServerId = 7, ExternalId = "e", CommonName = "u", IssuedTo = "userX", FileName = "f", FilePath = "/f", PemFilePath = "/p", CertFilePath = "/c", KeyFilePath = "/k", ReqFilePath = "/r" };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(99, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()))
+        q.Setup(x => x.FindById(99, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new IssuedOvpnFileQueryService(q.Object);
-        var result = await sut.GetByIdAsync(99, CancellationToken.None);
+        var result = await sut.GetById(99, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(99, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(99, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -208,7 +208,7 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileQueryService(q.Object);
 
-        var result = await sut.GetByIdAndIsRevokedAsync(2, true, CancellationToken.None);
+        var result = await sut.GetByIdAndIsRevoked(2, true, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(2, result!.Id);
@@ -223,7 +223,7 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileQueryService(q.Object);
 
-        var result = await sut.GetByIdAndVpnServerIdAndIsRevokedAsync(1, 1, false, CancellationToken.None);
+        var result = await sut.GetByIdAndVpnServerIdAndIsRevoked(1, 1, false, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(1, result!.Id);
@@ -252,7 +252,7 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileQueryService(q.Object);
 
-        var result = await sut.GetByIdAndVpnServerIdAndCommonNameAndIsRevokedAsync(2, 3, "cn-a", false, CancellationToken.None);
+        var result = await sut.GetByIdAndVpnServerIdAndCommonNameAndIsRevoked(2, 3, "cn-a", false, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(3, result!.Id);
@@ -269,7 +269,7 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileQueryService(q.Object);
 
-        var result = await sut.GetByVpnServerIdAndCommonNameAsync(1, 1, "cn-a", CancellationToken.None);
+        var result = await sut.GetByVpnServerIdAndCommonName(1, 1, "cn-a", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(1, result!.Id);
@@ -285,7 +285,7 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileQueryService(q.Object);
 
-        var result = await sut.GetActiveByIdVpnServerAndCommonNameAndIsRevokedAAsync(2, 3, "cn-a", false, CancellationToken.None);
+        var result = await sut.GetActiveByIdVpnServerAndCommonNameAndIsRevokedA(2, 3, "cn-a", false, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(3, result!.Id);
@@ -302,10 +302,10 @@ public class IssuedOvpnFileQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileQueryService(q.Object);
 
-        var exists = await sut.ExistsActiveByVpnServerIdAndCommonNameAsync(1, "cn-a", CancellationToken.None);
+        var exists = await sut.ExistsActiveByVpnServerIdAndCommonName(1, "cn-a", CancellationToken.None);
         Assert.True(exists);
 
-        var notExists = await sut.ExistsActiveByVpnServerIdAndCommonNameAsync(2, "cn-x", CancellationToken.None);
+        var notExists = await sut.ExistsActiveByVpnServerIdAndCommonName(2, "cn-x", CancellationToken.None);
         // cn-x on server 2 is revoked in sample (Id=4), so should be false
         Assert.False(notExists);
         await ctx.DisposeAsync();
@@ -325,15 +325,15 @@ public class IssuedOvpnFileQueryServiceTests
             Items = data.Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()))
+        q.Setup(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<IssuedOvpnFile>)
          .Verifiable();
 
         var sut = new IssuedOvpnFileQueryService(q.Object);
-        var result = await sut.GetPageAsync(1, 2, CancellationToken.None);
+        var result = await sut.GetPage(1, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFile, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/IssuedOvpnFileTokenTable/IssuedOvpnFileTokenQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/IssuedOvpnFileTokenTable/IssuedOvpnFileTokenQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using OpenVPNGateMonitor.DataBase.Services.Query.IssuedOvpnFileTokenTable;
@@ -45,16 +46,16 @@ public class IssuedOvpnFileTokenQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -63,15 +64,15 @@ public class IssuedOvpnFileTokenQueryServiceTests
     {
         var target = new IssuedOvpnFileToken { Id = 42, IssuedOvpnFileId = 77, Token = "tok-x", CreatedAt = DateTimeOffset.UtcNow };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -89,15 +90,15 @@ public class IssuedOvpnFileTokenQueryServiceTests
             Items = data.Skip(1).Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()))
+        q.Setup(x => x.Page(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<IssuedOvpnFileToken>)
          .Verifiable();
 
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
-        var result = await sut.GetPageAsync(2, 10, CancellationToken.None);
+        var result = await sut.GetPage(2, 10, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -109,7 +110,7 @@ public class IssuedOvpnFileTokenQueryServiceTests
         q.Setup(x => x.Query(It.IsAny<bool>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>())).Verifiable();
 
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
-        var result = await sut.GetByIssuedFileIdsAsync(null!, CancellationToken.None);
+        var result = await sut.GetByIssuedFileIds(null!, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Empty(result);
@@ -123,7 +124,7 @@ public class IssuedOvpnFileTokenQueryServiceTests
         q.Setup(x => x.Query(It.IsAny<bool>(), It.IsAny<Expression<Func<IssuedOvpnFileToken, object>>[]>())).Verifiable();
 
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
-        var result = await sut.GetByIssuedFileIdsAsync(Array.Empty<int>(), CancellationToken.None);
+        var result = await sut.GetByIssuedFileIds(Array.Empty<int>(), CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Empty(result);
@@ -137,7 +138,7 @@ public class IssuedOvpnFileTokenQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
 
-        var result = await sut.GetByIssuedFileIdsAsync(new[] { 10, 10, 30, 999 }, CancellationToken.None);
+        var result = await sut.GetByIssuedFileIds(new[] { 10, 10, 30, 999 }, CancellationToken.None);
 
         // Expect tokens with IssuedOvpnFileId == 10 or 30
         Assert.True(result.All(x => x.IssuedOvpnFileId == 10 || x.IssuedOvpnFileId == 30));
@@ -159,7 +160,7 @@ public class IssuedOvpnFileTokenQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
 
-        var result = await sut.GetByTokenAsync("tok-3", CancellationToken.None);
+        var result = await sut.GetByToken("tok-3", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal("tok-3", result!.Token);
@@ -174,7 +175,7 @@ public class IssuedOvpnFileTokenQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
 
-        var result = await sut.GetRequiredByTokenAsync("tok-4", CancellationToken.None);
+        var result = await sut.GetRequiredByToken("tok-4", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(30, result.IssuedOvpnFileId);
@@ -189,7 +190,7 @@ public class IssuedOvpnFileTokenQueryServiceTests
         var sut = new IssuedOvpnFileTokenQueryService(q.Object);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await sut.GetRequiredByTokenAsync("missing-token", CancellationToken.None));
+            await sut.GetRequiredByToken("missing-token", CancellationToken.None));
 
         Assert.Contains("missing-token", ex.Message);
         await ctx.DisposeAsync();

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/LocalizationTextTable/LocalizationTextQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/LocalizationTextTable/LocalizationTextQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using OpenVPNGateMonitor.DataBase.Services.Query.LocalizationTextTable;
@@ -46,17 +47,17 @@ public class LocalizationTextQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new LocalizationTextQueryService(q.Object);
 
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -65,15 +66,15 @@ public class LocalizationTextQueryServiceTests
     {
         var target = new LocalizationText { Id = 42, Key = "k", Language = Language.English, Text = "v" };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new LocalizationTextQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -84,7 +85,7 @@ public class LocalizationTextQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new LocalizationTextQueryService(q.Object);
 
-        var text = await sut.GetTextValueByKeyAndLanguageAsync("hello", Language.Russian, CancellationToken.None);
+        var text = await sut.GetTextValueByKeyAndLanguage("hello", Language.Russian, CancellationToken.None);
 
         Assert.Equal("Привет", text);
         await ctx.DisposeAsync();
@@ -97,7 +98,7 @@ public class LocalizationTextQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new LocalizationTextQueryService(q.Object);
 
-        var text = await sut.GetTextValueByKeyAndLanguageAsync("missing", Language.English, CancellationToken.None);
+        var text = await sut.GetTextValueByKeyAndLanguage("missing", Language.English, CancellationToken.None);
 
         Assert.Null(text);
         await ctx.DisposeAsync();
@@ -117,15 +118,15 @@ public class LocalizationTextQueryServiceTests
             Items = data.Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()))
+        q.Setup(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<LocalizationText>)
          .Verifiable();
 
         var sut = new LocalizationTextQueryService(q.Object);
-        var result = await sut.GetPageAsync(1, 2, CancellationToken.None);
+        var result = await sut.GetPage(1, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<LocalizationText, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientOverviewQueryTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientOverviewQueryTests.cs
@@ -45,9 +45,9 @@ public class OpenVpnServerClientOverviewQueryTests
         var (uow, ctx) = CreateUowWithData(data);
 
         var users = new Mock<IUserQueryService>();
-        users.Setup(x => x.GetByExternalIdAsync("ext-1", It.IsAny<CancellationToken>()))
+        users.Setup(x => x.GetByExternalId("ext-1", It.IsAny<CancellationToken>()))
              .ReturnsAsync(new User { Id = 10, DisplayName = "DN-ext-1" });
-        users.Setup(x => x.GetByExternalIdAsync("ext-3", It.IsAny<CancellationToken>()))
+        users.Setup(x => x.GetByExternalId("ext-3", It.IsAny<CancellationToken>()))
              .ReturnsAsync(new User { Id = 11, DisplayName = "DN-ext-3" });
 
         var sut = new OpenVpnServerClientOverviewQuery(uow.Object, users.Object);
@@ -76,7 +76,7 @@ public class OpenVpnServerClientOverviewQueryTests
 
         var (uow, ctx) = CreateUowWithData(data);
         var users = new Mock<IUserQueryService>();
-        users.Setup(x => x.GetByExternalIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        users.Setup(x => x.GetByExternalId(It.IsAny<string>(), It.IsAny<CancellationToken>()))
              .ReturnsAsync((string extId, CancellationToken _) => new User { Id = 100, DisplayName = $"DN-{extId}" });
 
         var sut = new OpenVpnServerClientOverviewQuery(uow.Object, users.Object);

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnServerClientQueryServiceTests.cs
@@ -45,12 +45,12 @@ public class OpenVpnServerClientQueryServiceTests
         var data = Sample();
         var (q, ctx) = CreateEfBackedQuery(data);
 
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new OpenVpnServerClientQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(3, result.Count);
         q.Verify();
@@ -65,7 +65,7 @@ public class OpenVpnServerClientQueryServiceTests
 
         Expression<Func<OpenVpnServerClient, bool>>? captured = null;
 
-        q.Setup(x => x.WhereAsync(
+        q.Setup(x => x.Where(
                 It.IsAny<Expression<Func<OpenVpnServerClient, bool>>>(),
                 null,
                 true,
@@ -82,7 +82,7 @@ public class OpenVpnServerClientQueryServiceTests
          .Verifiable();
 
         var sut = new OpenVpnServerClientQueryService(q.Object);
-        var result = await sut.GetAllConnectedByVpnServerIdAsync(10, CancellationToken.None);
+        var result = await sut.GetAllConnectedByVpnServerId(10, CancellationToken.None);
 
         Assert.All(result, x => { Assert.Equal(10, x.VpnServerId); Assert.True(x.IsConnected); });
         Assert.NotNull(captured);
@@ -98,12 +98,12 @@ public class OpenVpnServerClientQueryServiceTests
         var entity = new OpenVpnServerClient { Id = 42, VpnServerId = 10, IsConnected = true, SessionId = Guid.NewGuid(), ConnectedSince = DateTimeOffset.UtcNow };
         var (q, ctx) = CreateEfBackedQuery(new[] { entity });
 
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerClient, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerClient, object>>[]>()))
          .ReturnsAsync(entity)
          .Verifiable();
 
         var sut = new OpenVpnServerClientQueryService(q.Object);
-        var res = await sut.GetByIdAsync(42, CancellationToken.None);
+        var res = await sut.GetById(42, CancellationToken.None);
         Assert.Same(entity, res);
         q.Verify();
         await ctx.DisposeAsync();
@@ -123,7 +123,7 @@ public class OpenVpnServerClientQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new OpenVpnServerClientQueryService(q.Object);
 
-        var found = await sut.GetBySessionAndServerIdAsync(s2, 10, CancellationToken.None);
+        var found = await sut.GetBySessionAndServerId(s2, 10, CancellationToken.None);
         Assert.NotNull(found);
         Assert.Equal(2, found!.Id);
 
@@ -144,12 +144,12 @@ public class OpenVpnServerClientQueryServiceTests
             Items = data.Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerClient, object>>[]>()))
+        q.Setup(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerClient, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<OpenVpnServerClient>)
          .Verifiable();
 
         var sut = new OpenVpnServerClientQueryService(q.Object);
-        var res = await sut.GetPageAsync(1, 2, CancellationToken.None);
+        var res = await sut.GetPage(1, 2, CancellationToken.None);
         Assert.Same(paged, res);
         q.Verify();
         await ctx.DisposeAsync();

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerEventLogTable/OpenVpnServerEventLogQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerEventLogTable/OpenVpnServerEventLogQueryServiceTests.cs
@@ -48,16 +48,16 @@ public class OpenVpnServerEventLogQueryServiceTests
     public async Task GetAllAsync_Delegates_To_IQueryService()
     {
         var (q, ctx, data) = CreateEfBackedQuery();
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new OpenVpnServerEventLogQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -66,15 +66,15 @@ public class OpenVpnServerEventLogQueryServiceTests
     {
         var (q, ctx, _) = CreateEfBackedQuery();
         var expected = new OpenVpnServerEventLog { Id = 42, VpnServerId = 99 };
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()))
          .ReturnsAsync(expected)
          .Verifiable();
 
         var sut = new OpenVpnServerEventLogQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(expected, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -85,13 +85,13 @@ public class OpenVpnServerEventLogQueryServiceTests
         var sut = new OpenVpnServerEventLogQueryService(q.Object);
 
         // Pass invalid page/pageSize to test normalization to 1 and 10
-        var pageResult = await sut.GetByVpnServerIdAsync(10, 0, 0, CancellationToken.None);
+        var pageResult = await sut.GetByVpnServerId(10, 0, 0, CancellationToken.None);
 
         Assert.Equal(1, pageResult.Page);
         Assert.Equal(10, pageResult.PageSize);
 
         // Now request page 1 size 2 to test ordering and paging
-        var result = await sut.GetByVpnServerIdAsync(10, 1, 2, CancellationToken.None);
+        var result = await sut.GetByVpnServerId(10, 1, 2, CancellationToken.None);
 
         var expectedAll = data.Where(x => x.VpnServerId == 10).OrderByDescending(x => x.Id).ToList();
         Assert.Equal(expectedAll.Count, result.TotalCount);
@@ -104,7 +104,7 @@ public class OpenVpnServerEventLogQueryServiceTests
             i => Assert.Equal(4, i.Id));
 
         // Next page should contain next two items: Id=2 and Id=1 (only those with serverId 10)
-        var result2 = await sut.GetByVpnServerIdAsync(10, 2, 2, CancellationToken.None);
+        var result2 = await sut.GetByVpnServerId(10, 2, 2, CancellationToken.None);
         Assert.Collection(result2.Items,
             i => Assert.Equal(2, i.Id),
             i => Assert.Equal(1, i.Id));
@@ -125,15 +125,15 @@ public class OpenVpnServerEventLogQueryServiceTests
             Items = data.Skip(2).Take(2).ToList()
         } as IPagedResult<OpenVpnServerEventLog>;
 
-        q.Setup(x => x.PageAsync(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()))
+        q.Setup(x => x.Page(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()))
          .ReturnsAsync(paged)
          .Verifiable();
 
         var sut = new OpenVpnServerEventLogQueryService(q.Object);
-        var result = await sut.GetPageAsync(2, 2, CancellationToken.None);
+        var result = await sut.GetPage(2, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerEventLog, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/OpenVpnServerOvpnFileConfigQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerOvpnFileConfigTable/OpenVpnServerOvpnFileConfigQueryServiceTests.cs
@@ -44,16 +44,16 @@ public class OpenVpnServerOvpnFileConfigQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new OpenVpnServerOvpnFileConfigQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -62,15 +62,15 @@ public class OpenVpnServerOvpnFileConfigQueryServiceTests
     {
         var target = new OpenVpnServerOvpnFileConfig { Id = 42, VpnServerId = 777, VpnServerIp = "10.8.0.1" };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new OpenVpnServerOvpnFileConfigQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -81,7 +81,7 @@ public class OpenVpnServerOvpnFileConfigQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new OpenVpnServerOvpnFileConfigQueryService(q.Object);
 
-        var result = await sut.GetByVpnServerIdIdAsync(22, CancellationToken.None);
+        var result = await sut.GetByVpnServerIdId(22, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(22, result!.VpnServerId);
@@ -92,7 +92,7 @@ public class OpenVpnServerOvpnFileConfigQueryServiceTests
     public async Task AnyByVpnServerId_Delegates_To_AnyAsync()
     {
         var (q, ctx) = CreateEfBackedQuery(Array.Empty<OpenVpnServerOvpnFileConfig>());
-        q.Setup(x => x.AnyAsync(It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, bool>>>(), It.IsAny<CancellationToken>()))
+        q.Setup(x => x.Any(It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, bool>>>(), It.IsAny<CancellationToken>()))
          .ReturnsAsync(true)
          .Verifiable();
 
@@ -100,7 +100,7 @@ public class OpenVpnServerOvpnFileConfigQueryServiceTests
         var found = await sut.AnyByVpnServerId(999, CancellationToken.None);
 
         Assert.True(found);
-        q.Verify(x => x.AnyAsync(It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.Any(It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -118,15 +118,15 @@ public class OpenVpnServerOvpnFileConfigQueryServiceTests
             Items = data.Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()))
+        q.Setup(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<OpenVpnServerOvpnFileConfig>)
          .Verifiable();
 
         var sut = new OpenVpnServerOvpnFileConfigQueryService(q.Object);
-        var result = await sut.GetPageAsync(1, 2, CancellationToken.None);
+        var result = await sut.GetPage(1, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerOvpnFileConfig, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerStatusLogTable/OpenVpnServerStatusLogQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerStatusLogTable/OpenVpnServerStatusLogQueryServiceTests.cs
@@ -50,16 +50,16 @@ public class OpenVpnServerStatusLogQueryServiceTests
     public async Task GetAllAsync_Delegates_To_IQueryService()
     {
         var (q, ctx, data) = CreateEfBackedQuery();
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new OpenVpnServerStatusLogQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -68,7 +68,7 @@ public class OpenVpnServerStatusLogQueryServiceTests
     {
         var (q, ctx, _) = CreateEfBackedQuery();
         // delegate WhereAsync to real filtered result using setup
-        q.Setup(x => x.WhereAsync(It.IsAny<Expression<Func<OpenVpnServerStatusLog, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()))
+        q.Setup(x => x.Where(It.IsAny<Expression<Func<OpenVpnServerStatusLog, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()))
          .Returns<Expression<Func<OpenVpnServerStatusLog, bool>>, Func<IQueryable<OpenVpnServerStatusLog>, IOrderedQueryable<OpenVpnServerStatusLog>>?, bool, CancellationToken, Expression<Func<OpenVpnServerStatusLog, object>>[]>((pred, _, _, _, _) =>
              Task.FromResult(ctx.OpenVpnServerStatusLogs.Where(pred).ToList()))
          .Verifiable();
@@ -89,7 +89,7 @@ public class OpenVpnServerStatusLogQueryServiceTests
         var target = data.First();
         var sut = new OpenVpnServerStatusLogQueryService(q.Object);
 
-        var result = await sut.GetBySessionIdAndVpnServerIdAsync(target.SessionId, target.VpnServerId, CancellationToken.None);
+        var result = await sut.GetBySessionIdAndVpnServerId(target.SessionId, target.VpnServerId, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(target.Id, result!.Id);
@@ -101,15 +101,15 @@ public class OpenVpnServerStatusLogQueryServiceTests
     {
         var (q, ctx, _) = CreateEfBackedQuery();
         var expected = new OpenVpnServerStatusLog { Id = 123, VpnServerId = 999, SessionId = Guid.NewGuid() };
-        q.Setup(x => x.FindByIdAsync(123, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()))
+        q.Setup(x => x.FindById(123, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()))
          .ReturnsAsync(expected)
          .Verifiable();
 
         var sut = new OpenVpnServerStatusLogQueryService(q.Object);
-        var result = await sut.GetByIdAsync(123, CancellationToken.None);
+        var result = await sut.GetById(123, CancellationToken.None);
 
         Assert.Same(expected, result);
-        q.Verify(x => x.FindByIdAsync(123, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(123, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -120,7 +120,7 @@ public class OpenVpnServerStatusLogQueryServiceTests
         var target = data.First(x => x.VpnServerId == 10);
         var sut = new OpenVpnServerStatusLogQueryService(q.Object);
 
-        var result = await sut.GetByIdAndVpnServerIdAsync(target.Id, target.VpnServerId, CancellationToken.None);
+        var result = await sut.GetByIdAndVpnServerId(target.Id, target.VpnServerId, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(target.Id, result!.Id);
@@ -141,15 +141,15 @@ public class OpenVpnServerStatusLogQueryServiceTests
             Items = data.Skip(1).Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()))
+        q.Setup(x => x.Page(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<OpenVpnServerStatusLog>)
          .Verifiable();
 
         var sut = new OpenVpnServerStatusLogQueryService(q.Object);
-        var result = await sut.GetPageAsync(2, 2, CancellationToken.None);
+        var result = await sut.GetPage(2, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<OpenVpnServerStatusLog, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/QuotaPlanTable/UserQuotaPlanQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/QuotaPlanTable/UserQuotaPlanQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Linq;
 using Moq;
 using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanTable;
 using OpenVPNGateMonitor.Models;
@@ -19,15 +20,15 @@ public class UserQuotaPlanQueryServiceTests
         };
 
         var q = new Mock<IQueryService<QuotaPlan, int>>();
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new QuotaPlanQueryService(q.Object);
-        var res = await sut.GetAllAsync(CancellationToken.None);
+        var res = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(2, res.Count);
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -35,12 +36,12 @@ public class UserQuotaPlanQueryServiceTests
     {
         var plan = new QuotaPlan { Id = 42, Name = "Test" };
         var q = new Mock<IQueryService<QuotaPlan, int>>();
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<QuotaPlan, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<QuotaPlan, object>>[]>()))
          .ReturnsAsync(plan)
          .Verifiable();
 
         var sut = new QuotaPlanQueryService(q.Object);
-        var res = await sut.GetByIdAsync(42, CancellationToken.None);
+        var res = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(plan, res);
         q.Verify();
@@ -54,7 +55,7 @@ public class UserQuotaPlanQueryServiceTests
 
         var expected = new QuotaPlan { Id = 10, Name = "Default", IsDefault = true, IsActive = true };
         var q = new Mock<IQueryService<QuotaPlan, int>>();
-        q.Setup(x => x.FirstOrDefaultAsync(
+        q.Setup(x => x.FirstOrDefault(
                 It.IsAny<Expression<Func<QuotaPlan, bool>>>(),
                 It.IsAny<Func<IQueryable<QuotaPlan>, IOrderedQueryable<QuotaPlan>>>(),
                 true,
@@ -71,7 +72,7 @@ public class UserQuotaPlanQueryServiceTests
          .Verifiable();
 
         var sut = new QuotaPlanQueryService(q.Object);
-        var res = await sut.GetDefaultAsync(CancellationToken.None);
+        var res = await sut.GetDefault(CancellationToken.None);
 
         Assert.Same(expected, res);
         Assert.NotNull(capturedPredicate);
@@ -109,12 +110,12 @@ public class UserQuotaPlanQueryServiceTests
         } as IPagedResult<QuotaPlan>;
 
         var q = new Mock<IQueryService<QuotaPlan, int>>();
-        q.Setup(x => x.PageAsync(1, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<QuotaPlan, object>>[]>()))
+        q.Setup(x => x.Page(1, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<QuotaPlan, object>>[]>()))
          .ReturnsAsync(paged)
          .Verifiable();
 
         var sut = new QuotaPlanQueryService(q.Object);
-        var res = await sut.GetPageAsync(1, 10, CancellationToken.None);
+        var res = await sut.GetPage(1, 10, CancellationToken.None);
 
         Assert.Same(paged, res);
         q.Verify();

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/TelegramBotUserTable/TelegramBotUserQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/TelegramBotUserTable/TelegramBotUserQueryServiceTests.cs
@@ -42,16 +42,16 @@ public class TelegramBotUserQueryServiceTests
     public async Task GetAllAsync_Delegates_To_IQueryService()
     {
         var (q, ctx, data) = CreateEfBackedQuery();
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new TelegramBotUserQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -61,7 +61,7 @@ public class TelegramBotUserQueryServiceTests
         var (q, ctx, _) = CreateEfBackedQuery();
         var sut = new TelegramBotUserQueryService(q.Object);
 
-        var result = await sut.GetAllAdminsAsync(CancellationToken.None);
+        var result = await sut.GetAllAdmins(CancellationToken.None);
 
         Assert.NotEmpty(result);
         Assert.All(result, x => Assert.True(x.IsAdmin));
@@ -73,15 +73,15 @@ public class TelegramBotUserQueryServiceTests
     {
         var (q, ctx, _) = CreateEfBackedQuery();
         var expected = new TelegramBotUser { Id = 42, TelegramId = 123456, IsAdmin = false };
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()))
          .ReturnsAsync(expected)
          .Verifiable();
 
         var sut = new TelegramBotUserQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(expected, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -89,15 +89,15 @@ public class TelegramBotUserQueryServiceTests
     public async Task AnyByTelegramIdAsync_Delegates_To_AnyAsync()
     {
         var (q, ctx, _) = CreateEfBackedQuery();
-        q.Setup(x => x.AnyAsync(It.IsAny<Expression<Func<TelegramBotUser, bool>>>(), It.IsAny<CancellationToken>()))
+        q.Setup(x => x.Any(It.IsAny<Expression<Func<TelegramBotUser, bool>>>(), It.IsAny<CancellationToken>()))
          .ReturnsAsync(true)
          .Verifiable();
 
         var sut = new TelegramBotUserQueryService(q.Object);
-        var exists = await sut.AnyByTelegramIdAsync(1001, CancellationToken.None);
+        var exists = await sut.AnyByTelegramId(1001, CancellationToken.None);
 
         Assert.True(exists);
-        q.Verify(x => x.AnyAsync(It.IsAny<Expression<Func<TelegramBotUser, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.Any(It.IsAny<Expression<Func<TelegramBotUser, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -108,7 +108,7 @@ public class TelegramBotUserQueryServiceTests
         var target = data.First();
         var sut = new TelegramBotUserQueryService(q.Object);
 
-        var found = await sut.GetByTelegramIdAsync(target.TelegramId, CancellationToken.None);
+        var found = await sut.GetByTelegramId(target.TelegramId, CancellationToken.None);
 
         Assert.NotNull(found);
         Assert.Equal(target.Id, found!.Id);
@@ -128,15 +128,15 @@ public class TelegramBotUserQueryServiceTests
             Items = data.Take(2).ToList()
         } as IPagedResult<TelegramBotUser>;
 
-        q.Setup(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()))
+        q.Setup(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()))
          .ReturnsAsync(paged)
          .Verifiable();
 
         var sut = new TelegramBotUserQueryService(q.Object);
-        var result = await sut.GetPageAsync(1, 2, CancellationToken.None);
+        var result = await sut.GetPage(1, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramBotUser, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/TelegramUserLanguagePreferenceTable/TelegramUserLanguagePreferenceQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/TelegramUserLanguagePreferenceTable/TelegramUserLanguagePreferenceQueryServiceTests.cs
@@ -45,16 +45,16 @@ public class TelegramUserLanguagePreferenceQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new TelegramUserLanguagePreferenceQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -63,15 +63,15 @@ public class TelegramUserLanguagePreferenceQueryServiceTests
     {
         var target = new TelegramUserLanguagePreference { Id = 42, TelegramId = 999, PreferredLanguage = Language.Greek };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new TelegramUserLanguagePreferenceQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -93,7 +93,7 @@ public class TelegramUserLanguagePreferenceQueryServiceTests
     public async Task AnyByTelegramId_Delegates_To_AnyAsync()
     {
         var (q, ctx) = CreateEfBackedQuery(Array.Empty<TelegramUserLanguagePreference>());
-        q.Setup(x => x.AnyAsync(It.IsAny<Expression<Func<TelegramUserLanguagePreference, bool>>>(), It.IsAny<CancellationToken>()))
+        q.Setup(x => x.Any(It.IsAny<Expression<Func<TelegramUserLanguagePreference, bool>>>(), It.IsAny<CancellationToken>()))
          .ReturnsAsync(true)
          .Verifiable();
 
@@ -101,7 +101,7 @@ public class TelegramUserLanguagePreferenceQueryServiceTests
         var found = await sut.AnyByTelegramId(555, CancellationToken.None);
 
         Assert.True(found);
-        q.Verify(x => x.AnyAsync(It.IsAny<Expression<Func<TelegramUserLanguagePreference, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.Any(It.IsAny<Expression<Func<TelegramUserLanguagePreference, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -119,15 +119,15 @@ public class TelegramUserLanguagePreferenceQueryServiceTests
             Items = data.Skip(2).Take(1).ToList()
         };
 
-        q.Setup(x => x.PageAsync(3, 1, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()))
+        q.Setup(x => x.Page(3, 1, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<TelegramUserLanguagePreference>)
          .Verifiable();
 
         var sut = new TelegramUserLanguagePreferenceQueryService(q.Object);
-        var result = await sut.GetPageAsync(3, 1, CancellationToken.None);
+        var result = await sut.GetPage(3, 1, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(3, 1, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(3, 1, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<TelegramUserLanguagePreference, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserCredentialTable/UserCredentialQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserCredentialTable/UserCredentialQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using OpenVPNGateMonitor.DataBase.Services.Query.UserCredentialTable;
@@ -40,15 +41,15 @@ public class UserCredentialQueryServiceTests
         };
 
         var q = new Mock<IQueryService<UserCredential, int>>();
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(items)
          .Verifiable();
 
         var sut = new UserCredentialQueryService(q.Object);
-        var res = await sut.GetAllAsync(CancellationToken.None);
+        var res = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(2, res.Count);
-        q.Verify();
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -56,12 +57,12 @@ public class UserCredentialQueryServiceTests
     {
         var item = new UserCredential { Id = 77, NormalizedLogin = "U77", UserId = 777 };
         var q = new Mock<IQueryService<UserCredential, int>>();
-        q.Setup(x => x.FindByIdAsync(77, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserCredential, object>>[]>()))
+        q.Setup(x => x.FindById(77, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserCredential, object>>[]>()))
          .ReturnsAsync(item)
          .Verifiable();
 
         var sut = new UserCredentialQueryService(q.Object);
-        var res = await sut.GetByIdAsync(77, CancellationToken.None);
+        var res = await sut.GetById(77, CancellationToken.None);
         Assert.Same(item, res);
         q.Verify();
     }
@@ -107,7 +108,7 @@ public class UserCredentialQueryServiceTests
     {
         Expression<Func<UserCredential, bool>>? captured = null;
         var q = new Mock<IQueryService<UserCredential, int>>();
-        q.Setup(x => x.AnyAsync(It.IsAny<Expression<Func<UserCredential, bool>>>(), It.IsAny<CancellationToken>()))
+        q.Setup(x => x.Any(It.IsAny<Expression<Func<UserCredential, bool>>>(), It.IsAny<CancellationToken>()))
          .Callback((Expression<Func<UserCredential, bool>> predicate, CancellationToken _) => captured = predicate)
          .ReturnsAsync(true)
          .Verifiable();
@@ -142,12 +143,12 @@ public class UserCredentialQueryServiceTests
         } as IPagedResult<UserCredential>;
 
         var q = new Mock<IQueryService<UserCredential, int>>();
-        q.Setup(x => x.PageAsync(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserCredential, object>>[]>()))
+        q.Setup(x => x.Page(2, 10, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserCredential, object>>[]>()))
          .ReturnsAsync(paged)
          .Verifiable();
 
         var sut = new UserCredentialQueryService(q.Object);
-        var res = await sut.GetPageAsync(2, 10, CancellationToken.None);
+        var res = await sut.GetPage(2, 10, CancellationToken.None);
         Assert.Same(paged, res);
         q.Verify();
     }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryServiceTests.cs
@@ -45,16 +45,16 @@ public class UserIdentityLinkQueryServiceTests
     {
         var data = CreateSample();
         var (q, ctx) = CreateEfBackedQuery(data);
-        q.Setup(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
          .ReturnsAsync(data)
          .Verifiable();
 
         var sut = new UserIdentityLinkQueryService(q.Object);
-        var result = await sut.GetAllAsync(CancellationToken.None);
+        var result = await sut.GetAll(CancellationToken.None);
 
         Assert.Equal(data.Count, result.Count);
         Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAllAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -63,15 +63,15 @@ public class UserIdentityLinkQueryServiceTests
     {
         var target = new UserIdentityLink { Id = 42, UserId = 500, Provider = "tg", ExternalId = "E-42" };
         var (q, ctx) = CreateEfBackedQuery(new[] { target });
-        q.Setup(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()))
+        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()))
          .ReturnsAsync(target)
          .Verifiable();
 
         var sut = new UserIdentityLinkQueryService(q.Object);
-        var result = await sut.GetByIdAsync(42, CancellationToken.None);
+        var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.Same(target, result);
-        q.Verify(x => x.FindByIdAsync(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()), Times.Once);
+        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -82,7 +82,7 @@ public class UserIdentityLinkQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new UserIdentityLinkQueryService(q.Object);
 
-        var result = await sut.GetByProviderAndExternalIdAsync("google", "ext-2", CancellationToken.None);
+        var result = await sut.GetByProviderAndExternalId("google", "ext-2", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal("google", result!.Provider);
@@ -97,7 +97,7 @@ public class UserIdentityLinkQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new UserIdentityLinkQueryService(q.Object);
 
-        var result = await sut.GetByExternalIdAsync("ext-3", CancellationToken.None);
+        var result = await sut.GetByExternalId("ext-3", CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal("ext-3", result!.ExternalId);
@@ -111,7 +111,7 @@ public class UserIdentityLinkQueryServiceTests
         var (q, ctx) = CreateEfBackedQuery(data);
         var sut = new UserIdentityLinkQueryService(q.Object);
 
-        var result = await sut.GetByUserIdAsync(100, CancellationToken.None);
+        var result = await sut.GetByUserId(100, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(100, result!.UserId);
@@ -122,15 +122,15 @@ public class UserIdentityLinkQueryServiceTests
     public async Task AnyByUserIdAsync_Delegates_To_AnyAsync()
     {
         var (q, ctx) = CreateEfBackedQuery(Array.Empty<UserIdentityLink>());
-        q.Setup(x => x.AnyAsync(It.IsAny<Expression<Func<UserIdentityLink, bool>>>(), It.IsAny<CancellationToken>()))
+        q.Setup(x => x.Any(It.IsAny<Expression<Func<UserIdentityLink, bool>>>(), It.IsAny<CancellationToken>()))
          .ReturnsAsync(true)
          .Verifiable();
 
         var sut = new UserIdentityLinkQueryService(q.Object);
-        var found = await sut.AnyByUserIdAsync(777, CancellationToken.None);
+        var found = await sut.AnyByUserId(777, CancellationToken.None);
 
         Assert.True(found);
-        q.Verify(x => x.AnyAsync(It.IsAny<Expression<Func<UserIdentityLink, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
+        q.Verify(x => x.Any(It.IsAny<Expression<Func<UserIdentityLink, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
         await ctx.DisposeAsync();
     }
 
@@ -148,15 +148,15 @@ public class UserIdentityLinkQueryServiceTests
             Items = data.Take(2).ToList()
         };
 
-        q.Setup(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()))
+        q.Setup(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()))
          .ReturnsAsync(paged as IPagedResult<UserIdentityLink>)
          .Verifiable();
 
         var sut = new UserIdentityLinkQueryService(q.Object);
-        var result = await sut.GetPageAsync(1, 2, CancellationToken.None);
+        var result = await sut.GetPage(1, 2, CancellationToken.None);
 
         Assert.Same(paged, result);
-        q.Verify(x => x.PageAsync(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()), Times.Once);
+        q.Verify(x => x.Page(1, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<UserIdentityLink, object>>[]>()), Times.Once);
         await ctx.DisposeAsync();
     }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserTable/UserQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserTable/UserQueryServiceTests.cs
@@ -42,7 +42,7 @@ public class UserQueryServiceTests
         );
         await ctx.SaveChangesAsync();
 
-        var user = await sut.GetByExternalIdAsync("ext-1", CancellationToken.None);
+        var user = await sut.GetByExternalId("ext-1", CancellationToken.None);
         Assert.NotNull(user);
         Assert.Equal(2, user!.Id);
         Assert.Equal("u2", user.DisplayName);
@@ -55,7 +55,7 @@ public class UserQueryServiceTests
         await ctx.Users.AddAsync(new User { Id = 1, DisplayName = "u1" });
         await ctx.SaveChangesAsync();
 
-        var user = await sut.GetByExternalIdAsync("missing", CancellationToken.None);
+        var user = await sut.GetByExternalId("missing", CancellationToken.None);
         Assert.Null(user);
     }
 
@@ -66,7 +66,7 @@ public class UserQueryServiceTests
         await ctx.Users.AddRangeAsync(Enumerable.Range(1, 15).Select(i => new User { Id = i, DisplayName = $"u{i}" }));
         await ctx.SaveChangesAsync();
 
-        var page = await sut.GetPageAsync(2, 10, CancellationToken.None);
+        var page = await sut.GetPage(2, 10, CancellationToken.None);
         Assert.Equal(2, page.Page);
         Assert.Equal(10, page.PageSize);
         Assert.Equal(15, page.TotalCount);

--- a/OpenVPNGateMonitor.Tests/Services/Api/OpenVpnServerOvpnFileConfigServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/Api/OpenVpnServerOvpnFileConfigServiceTests.cs
@@ -30,7 +30,7 @@ public class OpenVpnServerOvpnFileConfigServiceTests
     {
         var (svc, _, q, _) = CreateService();
         var entity = new OpenVpnServerOvpnFileConfig { Id = 1, VpnServerId = 77, VpnServerIp = "1.2.3.4", VpnServerPort = 1194 };
-        q.Setup(x => x.GetByVpnServerIdIdAsync(77, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetByVpnServerIdId(77, It.IsAny<CancellationToken>()))
             .ReturnsAsync(entity);
 
         var result = await svc.GetOpenVpnServerOvpnFileConfigByServerId(77, CancellationToken.None);
@@ -43,7 +43,7 @@ public class OpenVpnServerOvpnFileConfigServiceTests
     public async Task GetByServerId_Throws_When_NotFound()
     {
         var (svc, _, q, _) = CreateService();
-        q.Setup(x => x.GetByVpnServerIdIdAsync(42, It.IsAny<CancellationToken>()))
+        q.Setup(x => x.GetByVpnServerIdId(42, It.IsAny<CancellationToken>()))
             .ReturnsAsync((OpenVpnServerOvpnFileConfig?)null);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -70,11 +70,11 @@ public class OpenVpnServerOvpnFileConfigServiceTests
         };
 
         // First call returns existing entity, second call (after update) returns same updated reference
-        q.SetupSequence(x => x.GetByVpnServerIdIdAsync(100, It.IsAny<CancellationToken>()))
+        q.SetupSequence(x => x.GetByVpnServerIdId(100, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing)
             .ReturnsAsync(existing);
 
-        cmd.Setup(c => c.UpdateAsync(existing, true, It.IsAny<CancellationToken>()))
+        cmd.Setup(c => c.Update(existing, true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1)
             .Verifiable();
 
@@ -107,10 +107,10 @@ public class OpenVpnServerOvpnFileConfigServiceTests
         OpenVpnServerOvpnFileConfig? added = null;
 
         // First lookup returns null, second re-fetch returns the same object that was added
-        q.SetupSequence(x => x.GetByVpnServerIdIdAsync(serverId, It.IsAny<CancellationToken>()))
+        q.SetupSequence(x => x.GetByVpnServerIdId(serverId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((OpenVpnServerOvpnFileConfig?)null)
             .ReturnsAsync(() => added!);
-        cmd.Setup(c => c.AddAsync(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()))
+        cmd.Setup(c => c.Add(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()))
             .Callback<OpenVpnServerOvpnFileConfig, bool, CancellationToken>((e, _, _) => added = e)
             .ReturnsAsync((OpenVpnServerOvpnFileConfig e, bool _, CancellationToken __) => e);
 
@@ -136,7 +136,7 @@ public class OpenVpnServerOvpnFileConfigServiceTests
 
         Assert.Same(added, result);
 
-        cmd.Verify(c => c.AddAsync(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        cmd.Verify(c => c.Add(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Once);
         q.VerifyAll();
     }
 
@@ -146,11 +146,11 @@ public class OpenVpnServerOvpnFileConfigServiceTests
         var (svc, _, q, cmd) = CreateService();
         var serverId = 300;
 
-        q.SetupSequence(x => x.GetByVpnServerIdIdAsync(serverId, It.IsAny<CancellationToken>()))
+        q.SetupSequence(x => x.GetByVpnServerIdId(serverId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((OpenVpnServerOvpnFileConfig?)null)
             .ReturnsAsync((OpenVpnServerOvpnFileConfig?)null);
 
-        cmd.Setup(c => c.AddAsync(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()))
+        cmd.Setup(c => c.Add(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((OpenVpnServerOvpnFileConfig e, bool _, CancellationToken __) => e);
 
         var incoming = new OpenVpnServerOvpnFileConfig
@@ -166,6 +166,6 @@ public class OpenVpnServerOvpnFileConfigServiceTests
 
         Assert.Contains(serverId.ToString(), ex.Message);
         q.VerifyAll();
-        cmd.Verify(c => c.AddAsync(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        cmd.Verify(c => c.Add(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/OpenVPNGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
@@ -96,7 +96,7 @@ public class OpenVpnMicroserviceClientFactoryTests
         };
 
         serverQueryMock
-            .Setup(q => q.GetByIdAsync(42, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetById(42, It.IsAny<CancellationToken>()))
             .ReturnsAsync(server);
 
         var client = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
@@ -107,7 +107,7 @@ public class OpenVpnMicroserviceClientFactoryTests
         var client2 = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
         Assert.Same(client, client2);
 
-        serverQueryMock.Verify(q => q.GetByIdAsync(42, It.IsAny<CancellationToken>()), Times.Exactly(2));
+        serverQueryMock.Verify(q => q.GetById(42, It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class OpenVpnMicroserviceClientFactoryTests
         var (factory, _, serverQueryMock) = CreateFactory();
 
         serverQueryMock
-            .Setup(q => q.GetByIdAsync(99, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetById(99, It.IsAny<CancellationToken>()))
             .ReturnsAsync((OpenVpnServer?)null);
 
         var ex = await Assert.ThrowsAsync<Exception>(

--- a/OpenVPNGateMonitor.Tests/Services/Others/SettingsServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/Others/SettingsServiceTests.cs
@@ -27,7 +27,7 @@ public class SettingsServiceTests
     public async Task GetValueAsync_ReturnsDefault_When_NotFound()
     {
         var (svc, q, _) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync((Setting?)null);
 
         var result = await svc.GetValueAsync<string>("NoKey", CancellationToken.None);
@@ -39,7 +39,7 @@ public class SettingsServiceTests
     public async Task GetValueAsync_ReturnsDefault_When_ValueType_Null()
     {
         var (svc, q, _) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(new Setting { Id = 1, Key = "A", ValueType = "null" });
 
         var result = await svc.GetValueAsync<int>("A", CancellationToken.None);
@@ -51,7 +51,7 @@ public class SettingsServiceTests
     public async Task GetValueAsync_Returns_Int()
     {
         var (svc, q, _) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(new Setting { Id = 1, Key = "IntKey", ValueType = "int", IntValue = 42 });
 
         var result = await svc.GetValueAsync<int>("IntKey", CancellationToken.None);
@@ -63,7 +63,7 @@ public class SettingsServiceTests
     public async Task GetValueAsync_Returns_Bool()
     {
         var (svc, q, _) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(new Setting { Id = 2, Key = "Flag", ValueType = "bool", BoolValue = true });
 
         var result = await svc.GetValueAsync<bool>("Flag", CancellationToken.None);
@@ -75,7 +75,7 @@ public class SettingsServiceTests
     public async Task GetValueAsync_Returns_Double()
     {
         var (svc, q, _) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(new Setting { Id = 3, Key = "Pi", ValueType = "double", DoubleValue = 3.14 });
 
         var result = await svc.GetValueAsync<double>("Pi", CancellationToken.None);
@@ -88,7 +88,7 @@ public class SettingsServiceTests
     {
         var moment = DateTimeOffset.UtcNow.AddMinutes(-1);
         var (svc, q, _) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(new Setting { Id = 4, Key = "When", ValueType = "datetime", DateTimeValue = moment });
 
         var result = await svc.GetValueAsync<DateTimeOffset>("When", CancellationToken.None);
@@ -100,7 +100,7 @@ public class SettingsServiceTests
     public async Task GetValueAsync_Returns_String()
     {
         var (svc, q, _) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(new Setting { Id = 5, Key = "Name", ValueType = "string", StringValue = "Alice" });
 
         var result = await svc.GetValueAsync<string>("Name", CancellationToken.None);
@@ -114,11 +114,11 @@ public class SettingsServiceTests
     public async Task SetValueAsync_Creates_New_With_Null()
     {
         var (svc, q, cmd) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync((Setting?)null);
 
         Setting? saved = null;
-        cmd.Setup(c => c.AddAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
+        cmd.Setup(c => c.Add(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
             .Callback<Setting, bool, CancellationToken>((s, _, _) => saved = s)
             .ReturnsAsync((Setting s, bool _, CancellationToken __) => s);
 
@@ -135,7 +135,7 @@ public class SettingsServiceTests
         saved.CreateDate.Should().NotBe(default);
         saved.LastUpdate.Should().NotBe(default);
 
-        cmd.Verify(c => c.AddAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        cmd.Verify(c => c.Add(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
         q.VerifyAll();
         cmd.VerifyAll();
     }
@@ -144,11 +144,11 @@ public class SettingsServiceTests
     public async Task SetValueAsync_Creates_New_With_Int()
     {
         var (svc, q, cmd) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync((Setting?)null);
 
         Setting? saved = null;
-        cmd.Setup(c => c.AddAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
+        cmd.Setup(c => c.Add(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
             .Callback<Setting, bool, CancellationToken>((s, _, _) => saved = s)
             .ReturnsAsync((Setting s, bool _, CancellationToken __) => s);
 
@@ -163,7 +163,7 @@ public class SettingsServiceTests
         saved.DateTimeValue.Should().BeNull();
         saved.StringValue.Should().BeNull();
 
-        cmd.Verify(c => c.AddAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        cmd.Verify(c => c.Add(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -184,10 +184,10 @@ public class SettingsServiceTests
         };
 
         var (svc, q, cmd) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(existing);
 
-        cmd.Setup(c => c.UpdateAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
+        cmd.Setup(c => c.Update(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         await svc.SetValueAsync("UserName", "Bob", CancellationToken.None);
@@ -200,7 +200,7 @@ public class SettingsServiceTests
         existing.DateTimeValue.Should().BeNull();
         existing.CreateDate.Should().BeOnOrBefore(existing.LastUpdate);
 
-        cmd.Verify(c => c.UpdateAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        cmd.Verify(c => c.Update(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -217,10 +217,10 @@ public class SettingsServiceTests
         };
 
         var (svc, q, cmd) = CreateService();
-        q.Setup(x => x.FirstOrDefaultAsync(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
+        q.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<Setting, bool>>>(), null, false, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<Setting, object>>[]>()))
             .ReturnsAsync(existing);
 
-        cmd.Setup(c => c.UpdateAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
+        cmd.Setup(c => c.Update(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         var now = DateTimeOffset.UtcNow;
@@ -231,6 +231,6 @@ public class SettingsServiceTests
         existing.StringValue.Should().BeNull();
         existing.LastUpdate.Should().BeOnOrAfter(existing.CreateDate);
 
-        cmd.Verify(c => c.UpdateAsync(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        cmd.Verify(c => c.Update(It.IsAny<Setting>(), true, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/OpenVPNGateMonitor.Tests/Services/QuotaPlans/QuotaPlanServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/QuotaPlans/QuotaPlanServiceTests.cs
@@ -22,39 +22,39 @@ public class QuotaPlanServiceTests
     public async Task GetAll_DelegatesToQuery()
     {
         var plans = new List<QuotaPlan> { new() { Id = 1, Name = "A" } };
-        _query.Setup(q => q.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(plans);
+        _query.Setup(q => q.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync(plans);
 
         var svc = CreateService();
         var result = await svc.GetAllAsync();
 
         Assert.Same(plans, result);
-        _query.Verify(q => q.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _query.Verify(q => q.GetAll(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetById_DelegatesToQuery()
     {
         var plan = new QuotaPlan { Id = 7, Name = "P" };
-        _query.Setup(q => q.GetByIdAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(plan);
+        _query.Setup(q => q.GetById(7, It.IsAny<CancellationToken>())).ReturnsAsync(plan);
 
         var svc = CreateService();
         var result = await svc.GetByIdAsync(7);
 
         Assert.Same(plan, result);
-        _query.Verify(q => q.GetByIdAsync(7, It.IsAny<CancellationToken>()), Times.Once);
+        _query.Verify(q => q.GetById(7, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetPage_DelegatesToQuery()
     {
         var paged = Mock.Of<SharedModels.Responses.IPagedResult<QuotaPlan>>();
-        _query.Setup(q => q.GetPageAsync(2, 5, It.IsAny<CancellationToken>())).ReturnsAsync(paged);
+        _query.Setup(q => q.GetPage(2, 5, It.IsAny<CancellationToken>())).ReturnsAsync(paged);
 
         var svc = CreateService();
         var result = await svc.GetPageAsync(2, 5);
 
         Assert.Same(paged, result);
-        _query.Verify(q => q.GetPageAsync(2, 5, It.IsAny<CancellationToken>()), Times.Once);
+        _query.Verify(q => q.GetPage(2, 5, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -66,7 +66,7 @@ public class QuotaPlanServiceTests
             new() { Id = 2, Name = "B", IsDefault = true },
             new() { Id = 3, Name = "C", IsDefault = true },
         };
-        _query.Setup(q => q.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(list);
+        _query.Setup(q => q.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync(list);
 
         var svc = CreateService();
         var result = await svc.GetDefaultAsync();
@@ -78,7 +78,7 @@ public class QuotaPlanServiceTests
     [Fact]
     public async Task GetDefault_ReturnsNullWhenNone()
     {
-        _query.Setup(q => q.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<QuotaPlan>());
+        _query.Setup(q => q.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync(new List<QuotaPlan>());
         var svc = CreateService();
         var result = await svc.GetDefaultAsync();
         Assert.Null(result);
@@ -89,14 +89,14 @@ public class QuotaPlanServiceTests
     {
         var input = new QuotaPlan { Id = 123, Name = "Plan" };
         var created = new QuotaPlan { Id = 10, Name = "Plan" };
-        _command.Setup(c => c.AddAsync(It.IsAny<QuotaPlan>(), true, It.IsAny<CancellationToken>())).ReturnsAsync(created);
+        _command.Setup(c => c.Add(It.IsAny<QuotaPlan>(), true, It.IsAny<CancellationToken>())).ReturnsAsync(created);
 
         var svc = CreateService();
         var result = await svc.CreateAsync(input);
 
         Assert.Same(created, result);
         _command.Verify(
-            c => c.AddAsync(
+            c => c.Add(
                 It.Is<QuotaPlan>(p => p.Id == 0 && p.Name == "Plan"),
                 true,
                 It.IsAny<CancellationToken>()),
@@ -109,14 +109,14 @@ public class QuotaPlanServiceTests
         var unsetCalls = 0;
 
         _command
-            .Setup(c => c.UpdateWhereAsync(
+            .Setup(c => c.UpdateWhere(
                 It.IsAny<Expression<Func<QuotaPlan, bool>>>(),
                 It.IsAny<Action<UpdateSettersBuilder<QuotaPlan>>>(),
                 It.IsAny<CancellationToken>()))
             .Callback(() => unsetCalls++)
             .ReturnsAsync(1);
 
-        _command.Setup(c => c.AddAsync(It.IsAny<QuotaPlan>(), true, It.IsAny<CancellationToken>()))
+        _command.Setup(c => c.Add(It.IsAny<QuotaPlan>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((QuotaPlan p, bool _, CancellationToken _) => new QuotaPlan
             {
                 Id = 42,
@@ -155,14 +155,14 @@ public class QuotaPlanServiceTests
         var unsetCalls = 0;
 
         _command
-            .Setup(c => c.UpdateWhereAsync(
+            .Setup(c => c.UpdateWhere(
                 It.IsAny<Expression<Func<QuotaPlan, bool>>>(),
                 It.IsAny<Action<UpdateSettersBuilder<QuotaPlan>>>(),
                 It.IsAny<CancellationToken>()))
             .Callback(() => unsetCalls++)
             .ReturnsAsync(3);
 
-        _command.Setup(c => c.UpdateAsync(It.IsAny<QuotaPlan>(), true, It.IsAny<CancellationToken>()))
+        _command.Setup(c => c.Update(It.IsAny<QuotaPlan>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         var svc = CreateService();
@@ -171,7 +171,7 @@ public class QuotaPlanServiceTests
         Assert.Equal(1, affected);
         Assert.Equal(1, unsetCalls);
         _command.Verify(
-            c => c.UpdateAsync(
+            c => c.Update(
                 It.Is<QuotaPlan>(p => p.Id == 5 && p.IsDefault),
                 true,
                 It.IsAny<CancellationToken>()),
@@ -184,7 +184,7 @@ public class QuotaPlanServiceTests
         Expression<Func<QuotaPlan, bool>>? capturedPredicate = null;
 
         _command
-            .Setup(c => c.UpdateWhereAsync(
+            .Setup(c => c.UpdateWhere(
                 It.IsAny<Expression<Func<QuotaPlan, bool>>>(),
                 It.IsAny<Action<UpdateSettersBuilder<QuotaPlan>>>(),
                 It.IsAny<CancellationToken>()))
@@ -212,7 +212,7 @@ public class QuotaPlanServiceTests
         Expression<Func<QuotaPlan, bool>>? capturedPredicate = null;
 
         _command
-            .Setup(c => c.UpdateWhereAsync(
+            .Setup(c => c.UpdateWhere(
                 It.IsAny<Expression<Func<QuotaPlan, bool>>>(),
                 It.IsAny<Action<UpdateSettersBuilder<QuotaPlan>>>(),
                 It.IsAny<CancellationToken>()))
@@ -237,11 +237,11 @@ public class QuotaPlanServiceTests
     [Fact]
     public async Task Delete_DelegatesToCommand()
     {
-        _command.Setup(c => c.DeleteByIdAsync(11, It.IsAny<CancellationToken>())).ReturnsAsync(1);
+        _command.Setup(c => c.DeleteById(11, It.IsAny<CancellationToken>())).ReturnsAsync(1);
         var svc = CreateService();
         var rows = await svc.DeleteAsync(11);
         Assert.Equal(1, rows);
-        _command.Verify(c => c.DeleteByIdAsync(11, It.IsAny<CancellationToken>()), Times.Once);
+        _command.Verify(c => c.DeleteById(11, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -250,7 +250,7 @@ public class QuotaPlanServiceTests
         var calls = 0;
 
         _command
-            .Setup(c => c.UpdateWhereAsync(
+            .Setup(c => c.UpdateWhere(
                 It.IsAny<Expression<Func<QuotaPlan, bool>>>(),
                 It.IsAny<Action<UpdateSettersBuilder<QuotaPlan>>>(),
                 It.IsAny<CancellationToken>()))
@@ -269,7 +269,7 @@ public class QuotaPlanServiceTests
         var calls = 0;
 
         _command
-            .Setup(c => c.UpdateWhereAsync(
+            .Setup(c => c.UpdateWhere(
                 It.IsAny<Expression<Func<QuotaPlan, bool>>>(),
                 It.IsAny<Action<UpdateSettersBuilder<QuotaPlan>>>(),
                 It.IsAny<CancellationToken>()))

--- a/OpenVPNGateMonitor.Tests/Services/TelegramBot/IncomingMessageLogServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/TelegramBot/IncomingMessageLogServiceTests.cs
@@ -59,7 +59,7 @@ public class IncomingMessageLogServiceTests
         IncomingMessageLog? savedEntity = null;
 
         _command
-            .Setup(c => c.AddAsync(
+            .Setup(c => c.Add(
                 It.IsAny<IncomingMessageLog>(),
                 true,
                 It.IsAny<CancellationToken>()))
@@ -76,7 +76,7 @@ public class IncomingMessageLogServiceTests
         Assert.NotNull(response.Message);
 
         _command.Verify(
-            c => c.AddAsync(It.IsAny<IncomingMessageLog>(), true, It.IsAny<CancellationToken>()),
+            c => c.Add(It.IsAny<IncomingMessageLog>(), true, It.IsAny<CancellationToken>()),
             Times.Once);
 
         // ----- Entity mapping check -----
@@ -135,7 +135,7 @@ public class IncomingMessageLogServiceTests
         };
 
         _query
-            .Setup(q => q.GetByIdAsync(55, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetById(55, It.IsAny<CancellationToken>()))
             .ReturnsAsync(entity);
 
         // Act
@@ -157,7 +157,7 @@ public class IncomingMessageLogServiceTests
         Assert.Equal(entity.FilePath, result.FilePath);
 
         _query.Verify(
-            q => q.GetByIdAsync(55, It.IsAny<CancellationToken>()),
+            q => q.GetById(55, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -170,7 +170,7 @@ public class IncomingMessageLogServiceTests
     {
         // Arrange
         _query
-            .Setup(q => q.GetByIdAsync(99, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetById(99, It.IsAny<CancellationToken>()))
             .ReturnsAsync((IncomingMessageLog?)null);
 
         // Act
@@ -180,7 +180,7 @@ public class IncomingMessageLogServiceTests
         Assert.Null(result);
 
         _query.Verify(
-            q => q.GetByIdAsync(99, It.IsAny<CancellationToken>()),
+            q => q.GetById(99, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/OpenVPNGateMonitor.Tests/Services/TelegramBot/LocalizationServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/TelegramBot/LocalizationServiceTests.cs
@@ -57,7 +57,7 @@ public class LocalizationServiceTests
             .ReturnsAsync(stored);                               // second call
 
         _userPrefCommand
-            .Setup(s => s.AddAsync(
+            .Setup(s => s.Add(
                 It.IsAny<TelegramUserLanguagePreference>(),
                 true,
                 It.IsAny<CancellationToken>()))
@@ -84,11 +84,11 @@ public class LocalizationServiceTests
             Times.Exactly(2));
 
         _userPrefCommand.Verify(
-            s => s.AddAsync(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
+            s => s.Add(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
             Times.Once);
 
         _userPrefCommand.Verify(
-            s => s.UpdateAsync(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
+            s => s.Update(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -117,7 +117,7 @@ public class LocalizationServiceTests
             .ReturnsAsync(existing); // second call
 
         _userPrefCommand
-            .Setup(s => s.UpdateAsync(
+            .Setup(s => s.Update(
                 It.IsAny<TelegramUserLanguagePreference>(),
                 true,
                 It.IsAny<CancellationToken>()))
@@ -144,11 +144,11 @@ public class LocalizationServiceTests
             Times.Exactly(2));
 
         _userPrefCommand.Verify(
-            s => s.UpdateAsync(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
+            s => s.Update(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
             Times.Once);
 
         _userPrefCommand.Verify(
-            s => s.AddAsync(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
+            s => s.Add(It.IsAny<TelegramUserLanguagePreference>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -168,7 +168,7 @@ public class LocalizationServiceTests
             .ReturnsAsync((TelegramUserLanguagePreference?)null); // second
 
         _userPrefCommand
-            .Setup(s => s.AddAsync(
+            .Setup(s => s.Add(
                 It.IsAny<TelegramUserLanguagePreference>(),
                 true,
                 It.IsAny<CancellationToken>()))
@@ -258,7 +258,7 @@ public class LocalizationServiceTests
         long telegramId = 80;
 
         _textQuery
-            .Setup(s => s.GetTextValueByKeyAndLanguageAsync(
+            .Setup(s => s.GetTextValueByKeyAndLanguage(
                 key,
                 Language.Greek,
                 It.IsAny<CancellationToken>()))
@@ -294,7 +294,7 @@ public class LocalizationServiceTests
             .ReturnsAsync(pref);
 
         _textQuery
-            .Setup(s => s.GetTextValueByKeyAndLanguageAsync(
+            .Setup(s => s.GetTextValueByKeyAndLanguage(
                 key,
                 Language.Russian,
                 It.IsAny<CancellationToken>()))
@@ -319,7 +319,7 @@ public class LocalizationServiceTests
             .ReturnsAsync((TelegramUserLanguagePreference?)null);
 
         _textQuery
-            .Setup(s => s.GetTextValueByKeyAndLanguageAsync(
+            .Setup(s => s.GetTextValueByKeyAndLanguage(
                 key,
                 Language.English,
                 It.IsAny<CancellationToken>()))
@@ -344,7 +344,7 @@ public class LocalizationServiceTests
             .ReturnsAsync((TelegramUserLanguagePreference?)null);
 
         _textQuery
-            .Setup(s => s.GetTextValueByKeyAndLanguageAsync(
+            .Setup(s => s.GetTextValueByKeyAndLanguage(
                 key,
                 Language.English,
                 It.IsAny<CancellationToken>()))

--- a/OpenVPNGateMonitor.Tests/Services/TelegramBot/TelegramUserService.cs
+++ b/OpenVPNGateMonitor.Tests/Services/TelegramBot/TelegramUserService.cs
@@ -42,11 +42,11 @@ public class TelegramUserServiceTests
         TelegramBotUser? addedEntity = null;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(request.TelegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(request.TelegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((TelegramBotUser?)null);
 
         _userCommand
-            .Setup(c => c.AddAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
+            .Setup(c => c.Add(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
             .Callback<TelegramBotUser, bool, CancellationToken>((entity, _, _) =>
             {
                 addedEntity = entity;
@@ -65,15 +65,15 @@ public class TelegramUserServiceTests
         Assert.Equal(request.TelegramId, addedEntity!.TelegramId);
 
         _userQuery.Verify(
-            q => q.GetByTelegramIdAsync(request.TelegramId, It.IsAny<CancellationToken>()),
+            q => q.GetByTelegramId(request.TelegramId, It.IsAny<CancellationToken>()),
             Times.Once);
 
         _userCommand.Verify(
-            c => c.AddAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Add(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Once);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -102,11 +102,11 @@ public class TelegramUserServiceTests
         TelegramBotUser? updatedEntity = null;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(request.TelegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(request.TelegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
 
         _userCommand
-            .Setup(c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
+            .Setup(c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
             .Callback<TelegramBotUser, bool, CancellationToken>((entity, _, _) =>
             {
                 updatedEntity = entity;
@@ -127,11 +127,11 @@ public class TelegramUserServiceTests
         Assert.Equal(request.Username, updatedEntity!.Username);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Once);
 
         _userCommand.Verify(
-            c => c.AddAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Add(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -145,7 +145,7 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = 3003, Username = "exists" };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(user.TelegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(user.TelegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         var result = await _service.GetUserAsync(user.TelegramId, CancellationToken.None);
@@ -159,7 +159,7 @@ public class TelegramUserServiceTests
         long telegramId = 4004;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((TelegramBotUser?)null);
 
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -180,7 +180,7 @@ public class TelegramUserServiceTests
         };
 
         _userQuery
-            .Setup(q => q.GetAllAdminsAsync(It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetAllAdmins(It.IsAny<CancellationToken>()))
             .ReturnsAsync(admins);
 
         var result = await _service.GetAdminsAsync(CancellationToken.None);
@@ -193,7 +193,7 @@ public class TelegramUserServiceTests
     public async Task GetAdminsAsync_WhenListEmpty_ReturnsEmptyList()
     {
         _userQuery
-            .Setup(q => q.GetAllAdminsAsync(It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetAllAdmins(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<TelegramBotUser>());
 
         var result = await _service.GetAdminsAsync(CancellationToken.None);
@@ -216,7 +216,7 @@ public class TelegramUserServiceTests
         };
 
         _userQuery
-            .Setup(q => q.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetAll(It.IsAny<CancellationToken>()))
             .ReturnsAsync(users);
 
         var result = await _service.GetAllUsersAsync(CancellationToken.None);
@@ -235,7 +235,7 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { Id = 10, TelegramId = 5555 };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(user.TelegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(user.TelegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         var result = await _service.GetUserByTelegramIdAsync(user.TelegramId, CancellationToken.None);
@@ -249,7 +249,7 @@ public class TelegramUserServiceTests
         long telegramId = 9999;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((TelegramBotUser?)null);
 
         var result = await _service.GetUserByTelegramIdAsync(telegramId, CancellationToken.None);
@@ -267,7 +267,7 @@ public class TelegramUserServiceTests
         long telegramId = 6006;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((TelegramBotUser?)null);
 
         var result = await _service.BlockUserAsync(telegramId, CancellationToken.None);
@@ -275,7 +275,7 @@ public class TelegramUserServiceTests
         Assert.False(result);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -286,7 +286,7 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsBlocked = true };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         var result = await _service.BlockUserAsync(telegramId, CancellationToken.None);
@@ -295,7 +295,7 @@ public class TelegramUserServiceTests
         Assert.True(user.IsBlocked);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -306,11 +306,11 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsBlocked = false };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         _userCommand
-            .Setup(c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
+            .Setup(c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         var result = await _service.BlockUserAsync(telegramId, CancellationToken.None);
@@ -319,7 +319,7 @@ public class TelegramUserServiceTests
         Assert.True(user.IsBlocked);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.Is<TelegramBotUser>(u => u.IsBlocked), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.Is<TelegramBotUser>(u => u.IsBlocked), true, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -333,7 +333,7 @@ public class TelegramUserServiceTests
         long telegramId = 9009;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((TelegramBotUser?)null);
 
         var result = await _service.UnblockUserAsync(telegramId, CancellationToken.None);
@@ -341,7 +341,7 @@ public class TelegramUserServiceTests
         Assert.False(result);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -352,7 +352,7 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsBlocked = false };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         var result = await _service.UnblockUserAsync(telegramId, CancellationToken.None);
@@ -361,7 +361,7 @@ public class TelegramUserServiceTests
         Assert.False(user.IsBlocked);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -372,11 +372,11 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsBlocked = true };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         _userCommand
-            .Setup(c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
+            .Setup(c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         var result = await _service.UnblockUserAsync(telegramId, CancellationToken.None);
@@ -385,7 +385,7 @@ public class TelegramUserServiceTests
         Assert.False(user.IsBlocked);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.Is<TelegramBotUser>(u => !u.IsBlocked), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.Is<TelegramBotUser>(u => !u.IsBlocked), true, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -399,7 +399,7 @@ public class TelegramUserServiceTests
         long telegramId = 12012;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((TelegramBotUser?)null);
 
         var result = await _service.SetAdminAsync(telegramId, CancellationToken.None);
@@ -407,7 +407,7 @@ public class TelegramUserServiceTests
         Assert.False(result);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -418,7 +418,7 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsAdmin = true };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         var result = await _service.SetAdminAsync(telegramId, CancellationToken.None);
@@ -427,7 +427,7 @@ public class TelegramUserServiceTests
         Assert.True(user.IsAdmin);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -438,11 +438,11 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsAdmin = false };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         _userCommand
-            .Setup(c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
+            .Setup(c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         var result = await _service.SetAdminAsync(telegramId, CancellationToken.None);
@@ -451,7 +451,7 @@ public class TelegramUserServiceTests
         Assert.True(user.IsAdmin);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.Is<TelegramBotUser>(u => u.IsAdmin), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.Is<TelegramBotUser>(u => u.IsAdmin), true, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -465,7 +465,7 @@ public class TelegramUserServiceTests
         long telegramId = 15015;
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((TelegramBotUser?)null);
 
         var result = await _service.UnsetAdminAsync(telegramId, CancellationToken.None);
@@ -473,7 +473,7 @@ public class TelegramUserServiceTests
         Assert.False(result);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -484,7 +484,7 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsAdmin = false };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         var result = await _service.UnsetAdminAsync(telegramId, CancellationToken.None);
@@ -493,7 +493,7 @@ public class TelegramUserServiceTests
         Assert.False(user.IsAdmin);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -504,11 +504,11 @@ public class TelegramUserServiceTests
         var user = new TelegramBotUser { TelegramId = telegramId, IsAdmin = true };
 
         _userQuery
-            .Setup(q => q.GetByTelegramIdAsync(telegramId, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByTelegramId(telegramId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(user);
 
         _userCommand
-            .Setup(c => c.UpdateAsync(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
+            .Setup(c => c.Update(It.IsAny<TelegramBotUser>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
 
         var result = await _service.UnsetAdminAsync(telegramId, CancellationToken.None);
@@ -517,7 +517,7 @@ public class TelegramUserServiceTests
         Assert.False(user.IsAdmin);
 
         _userCommand.Verify(
-            c => c.UpdateAsync(It.Is<TelegramBotUser>(u => !u.IsAdmin), true, It.IsAny<CancellationToken>()),
+            c => c.Update(It.Is<TelegramBotUser>(u => !u.IsAdmin), true, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 }

--- a/OpenVPNGateMonitor/Controllers/NotificationController.cs
+++ b/OpenVPNGateMonitor/Controllers/NotificationController.cs
@@ -20,7 +20,7 @@ public class NotificationController(INotificationService notificationService) : 
         [FromBody] NotificationRequest request,
         CancellationToken cancellationToken)
     {
-        var result = await notificationService.NotifyAdminsAsync(request, new[] { "web" }, cancellationToken);
+        var result = await notificationService.NotifyAdmins(request, new[] { "web" }, cancellationToken);
         return Ok(ApiResponse<int>.SuccessResponse(result));
     }
 
@@ -34,7 +34,7 @@ public class NotificationController(INotificationService notificationService) : 
         [FromQuery] string channel,
         CancellationToken cancellationToken)
     {
-        await notificationService.MarkDeliveredAsync(notificationId, adminUserId, channel, cancellationToken);
+        await notificationService.MarkDelivered(notificationId, adminUserId, channel, cancellationToken);
         return Ok(ApiResponse<bool>.SuccessResponse(true));
     }
 
@@ -47,7 +47,7 @@ public class NotificationController(INotificationService notificationService) : 
         [FromQuery] int adminUserId,
         CancellationToken cancellationToken)
     {
-        await notificationService.MarkReadAsync(notificationId, adminUserId, cancellationToken);
+        await notificationService.MarkRead(notificationId, adminUserId, cancellationToken);
         return Ok(ApiResponse<bool>.SuccessResponse(true));
     }
 }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -217,7 +217,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     
     [HttpPost("download-file-by-cn")]
     public async Task<ActionResult<ApiResponse<DownloadFileResponse>>> DownloadFileByCn(
-        [FromBody] DownloadFileRequest request, CancellationToken cancellationToken)
+        [FromBody] DownloadFileByCnRequest request, CancellationToken cancellationToken)
     {
         try
         {

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -227,8 +227,8 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to download OVPN file {IssuedOvpnFileId} for {VpnServerId}", 
-                request.IssuedOvpnFileId, request.VpnServerId);
+            logger.LogError(ex, "Failed to download OVPN file {CommonName} for {VpnServerId}", 
+                request.CommonName, request.VpnServerId);
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -221,7 +221,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var content = await ovpnFileApiService.DownloadOvpnFile(request, 
+            var content = await ovpnFileApiService.DownloadOvpnFileByCn(request, 
                 cancellationToken);
             return Ok(ApiResponse<DownloadFileResponse>.SuccessResponse(content));
         }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -29,7 +29,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
 
         try
         {
-            var result = await ovpnFileApiService.GetByTokenAsync(request.Token, cancellationToken);
+            var result = await ovpnFileApiService.GetByToken(request.Token, cancellationToken);
             var response = result.Adapt<OvpnFileResponse>();
             return Ok(ApiResponse<OvpnFileResponse>.SuccessResponse(response));
         }
@@ -46,7 +46,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var result = await ovpnFileApiService.GetAllByVpnServerIdAsync(request.VpnServerId, 
+            var result = await ovpnFileApiService.GetAllByVpnServerId(request.VpnServerId, 
                 cancellationToken);
             var response = result.Adapt<OvpnFilesResponse>();
             return Ok(ApiResponse<OvpnFilesResponse>.SuccessResponse(response));
@@ -64,7 +64,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var result = await ovpnFileApiService.GetAllByExternalIdAndVpnServerIdAsync(
+            var result = await ovpnFileApiService.GetAllByExternalIdAndVpnServerId(
                 request.VpnServerId, request.ExternalId, cancellationToken);
 
             var response = result.Adapt<OvpnFilesResponse>();
@@ -85,7 +85,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var result = await ovpnFileApiService.GetAllByVpnServerIdWithTokenAsync(
+            var result = await ovpnFileApiService.GetAllByVpnServerIdWithToken(
                 request.VpnServerId, cancellationToken);
 
             return Ok(ApiResponse<OvpnFilesWithTokensResponse>.SuccessResponse(
@@ -105,7 +105,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var result = await ovpnFileApiService.GetAllByExternalIdAndVpnServerIdWithTokenAsync(
+            var result = await ovpnFileApiService.GetAllByExternalIdAndVpnServerIdWithToken(
                 request.VpnServerId, request.ExternalId, cancellationToken);
 
             var response = result.Adapt<OvpnFilesWithTokensResponse>();
@@ -127,7 +127,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var result = await ovpnFileApiService.GetAllByExternalIdAsync(
+            var result = await ovpnFileApiService.GetAllByExternalId(
                 request.ExternalId, cancellationToken);
 
             var response = result.Adapt<OvpnFilesResponse>();
@@ -147,7 +147,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var result = await ovpnFileApiService.AddOvpnFileAsync(request, cancellationToken);
+            var result = await ovpnFileApiService.AddOvpnFile(request, cancellationToken);
 
             return Ok(ApiResponse<OvpnFileResponse>.SuccessResponse( result.Adapt<OvpnFileResponse>()));
         }
@@ -165,7 +165,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var (file, token) = await ovpnFileApiService.AddOvpnFileWithTokenAsync(request, cancellationToken);
+            var (file, token) = await ovpnFileApiService.AddOvpnFileWithToken(request, cancellationToken);
 
             var response = (file, token).Adapt<OvpnFileWithTokenResponse>();
             
@@ -185,7 +185,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var result = await ovpnFileApiService.RevokeOvpnFileAsync(request, cancellationToken);
+            var result = await ovpnFileApiService.RevokeOvpnFile(request, cancellationToken);
             var response = result.Adapt<OvpnFileResponse>();
             return Ok(ApiResponse<OvpnFileResponse>.SuccessResponse(response));
         }
@@ -203,7 +203,25 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     {
         try
         {
-            var content = await ovpnFileApiService.DownloadOvpnFileAsync(request, 
+            var content = await ovpnFileApiService.DownloadOvpnFile(request, 
+                cancellationToken);
+            return Ok(ApiResponse<DownloadFileResponse>.SuccessResponse(content));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to download OVPN file {IssuedOvpnFileId} for {VpnServerId}", 
+                request.IssuedOvpnFileId, request.VpnServerId);
+            return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
+        }
+    }
+    
+    [HttpPost("download-file-by-cn")]
+    public async Task<ActionResult<ApiResponse<DownloadFileResponse>>> DownloadFileByCn(
+        [FromBody] DownloadFileRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var content = await ovpnFileApiService.DownloadOvpnFile(request, 
                 cancellationToken);
             return Ok(ApiResponse<DownloadFileResponse>.SuccessResponse(content));
         }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServerEventController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServerEventController.cs
@@ -31,7 +31,7 @@ public class OpenVpnServerEventController(IOpenVpnServerEventLogQueryService ope
         if (!authResult.Succeeded)
             return Forbid();
 
-        var page = await openVpnServerEventLogQueryService.GetByVpnServerIdAsync(
+        var page = await openVpnServerEventLogQueryService.GetByVpnServerId(
             request.VpnServerId,
             request.Page,
             request.PageSize,

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
@@ -46,7 +46,7 @@ public class OpenVpnServersController(ILogger<OpenVpnServersController> logger, 
     public async Task<ActionResult<ApiResponse<OpenVpnServersResponse>>> GetAllServers(
         CancellationToken ct)
     {
-        var serversList = await openVpnServerQueryService.GetAllAsync(ct);
+        var serversList = await openVpnServerQueryService.GetAll(ct);
 
         return Ok(ApiResponse<OpenVpnServersResponse>.SuccessResponse(
             serversList.Adapt<OpenVpnServersResponse>()));
@@ -56,7 +56,7 @@ public class OpenVpnServersController(ILogger<OpenVpnServersController> logger, 
     public async Task<ActionResult<ApiResponse<OpenVpnServerResponse>>> GetServer(
         [FromRoute] GetServerRequest request, CancellationToken ct)
     {
-        var server = await openVpnServerQueryService.GetByIdAsync(request.VpnServerId, ct);
+        var server = await openVpnServerQueryService.GetById(request.VpnServerId, ct);
 
         return Ok(ApiResponse<OpenVpnServerResponse>.SuccessResponse(server.Adapt<OpenVpnServerResponse>()));
     }

--- a/OpenVPNGateMonitor/Controllers/TelegramBotIncomingMessageLogController.cs
+++ b/OpenVPNGateMonitor/Controllers/TelegramBotIncomingMessageLogController.cs
@@ -32,7 +32,7 @@ public class TelegramBotIncomingMessageLogController(
     public async Task<ActionResult<ApiResponse<GetAllMessagesResponse>>> GetAllMessages(
         [FromQuery] GetAllMessagesRequest request, CancellationToken cancellationToken)
     {
-        var messages = await incomingMessageLogQueryService.GetPageAsync(
+        var messages = await incomingMessageLogQueryService.GetPage(
             request.Page, request.PageSize, cancellationToken);
 
         var response = new GetAllMessagesResponse
@@ -47,7 +47,7 @@ public class TelegramBotIncomingMessageLogController(
     public async Task<ActionResult<ApiResponse<GetByTelegramIdMessagesResponse>>> GetAllMessages(
         [FromRoute] GetAllByTelegramIdMessagesRequest request, CancellationToken ct)
     {
-        var messages= await incomingMessageLogQueryService.GetPageByTelegramIdAsync(
+        var messages= await incomingMessageLogQueryService.GetPageByTelegramId(
             request.TelegramId, request.Page, request.PageSize, ct);
         
         var response = new GetByTelegramIdMessagesResponse

--- a/OpenVPNGateMonitor/Middlewares/GlobalExceptionMiddleware.cs
+++ b/OpenVPNGateMonitor/Middlewares/GlobalExceptionMiddleware.cs
@@ -32,7 +32,7 @@ public class GlobalExceptionMiddleware(
         {
             using var scope = serviceProvider.CreateScope();
             var appNotifications = scope.ServiceProvider.GetRequiredService<IAppNotificationFacade>();
-            await appNotifications.SystemExceptionAsync(exception, CancellationToken.None);
+            await appNotifications.SystemException(exception, CancellationToken.None);
         }
         catch (Exception sendEx)
         {

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.2.81</AssemblyVersion>
-        <FileVersion>1.0.2.81</FileVersion>
+        <AssemblyVersion>1.0.2.82</AssemblyVersion>
+        <FileVersion>1.0.2.82</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.74" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.75" />
         <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.15.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.73" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.74" />
         <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/OpenVPNGateMonitor/Properties/launchSettings.json
+++ b/OpenVPNGateMonitor/Properties/launchSettings.json
@@ -9,7 +9,7 @@
       "applicationUrl": "http://0.0.0.0:5581",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "OPEN_VPN_BACKGROUND_SERVICE_DISABLED": "true"
+        "OPEN_VPN_BACKGROUND_SERVICE_DISABLED": "false"
       }
     },
     "OpenVPNGateMonitor Release": {

--- a/OpenVPNGateMonitor/Services/Api/Auth/Login/UserLoginService.cs
+++ b/OpenVPNGateMonitor/Services/Api/Auth/Login/UserLoginService.cs
@@ -44,7 +44,7 @@ public sealed class UserLoginService(
         if (credential is null)
             throw new UnauthorizedAccessException("Invalid login or password.");
 
-        var user = await userQueryService.GetByIdAsync(credential.UserId, ct)
+        var user = await userQueryService.GetById(credential.UserId, ct)
                    ?? throw new InvalidOperationException("User record is missing.");
 
         if (user.IsBlocked)
@@ -80,20 +80,20 @@ public sealed class UserLoginService(
         var externalId = googleUser.Subject;
 
         var existingLink = await userIdentityLinkQueryService
-            .GetByProviderAndExternalIdAsync(provider, externalId, ct);
+            .GetByProviderAndExternalId(provider, externalId, ct);
 
         User? user = null;
         var isNew = false;
 
         if (existingLink is { UserId: > 0 })
         {
-            user = await userQueryService.GetByIdAsync(existingLink.UserId, ct)
+            user = await userQueryService.GetById(existingLink.UserId, ct)
                    ?? throw new InvalidOperationException("User linked to Google account not found.");
         }
         else
         {
             if (!string.IsNullOrEmpty(googleUser.Email))
-                user = await userQueryService.GetByEmailAsync(googleUser.Email, ct);
+                user = await userQueryService.GetByEmail(googleUser.Email, ct);
 
             if (user is null)
             {
@@ -113,7 +113,7 @@ public sealed class UserLoginService(
                 ExternalId = externalId
             };
 
-            await userIdentityLinkCommandService.AddAsync(link, saveChanges: true, ct);
+            await userIdentityLinkCommandService.Add(link, saveChanges: true, ct);
         }
 
         var (token, expires) = await CreateJwtAsync(user, ct);

--- a/OpenVPNGateMonitor/Services/Api/Auth/Registers/ApplicationService.cs
+++ b/OpenVPNGateMonitor/Services/Api/Auth/Registers/ApplicationService.cs
@@ -12,7 +12,7 @@ public class ApplicationService(IClientApplicationQueryService clientApplication
 {
     public async Task<ClientApplication> RegisterApplicationAsync(string name, CancellationToken ct)
     {
-        var existClientApplication = await clientApplicationQueryService.GetByNameAsync(name, ct);
+        var existClientApplication = await clientApplicationQueryService.GetByName(name, ct);
         
         if (existClientApplication != null)
         {
@@ -24,46 +24,46 @@ public class ApplicationService(IClientApplicationQueryService clientApplication
             Name = name
         };
 
-        await clientApplicationCommandService.AddAsync(clientApplication, true, ct);
+        await clientApplicationCommandService.Add(clientApplication, true, ct);
         return clientApplication;
     }
 
     public async Task<ClientApplication?> GetApplicationByClientIdAsync(string clientId, 
         CancellationToken ct)
     {
-        return await clientApplicationQueryService.GetByClientIdAsync(clientId, ct);
+        return await clientApplicationQueryService.GetByClientId(clientId, ct);
     }
     
     public async Task<ClientApplication?> GetApplicationSystemByClientIdAsync(string clientId, 
         CancellationToken ct)
     {
-        return await clientApplicationQueryService.GetBySystemByClientIdAsync(clientId, ct);
+        return await clientApplicationQueryService.GetBySystemByClientId(clientId, ct);
 
     }
     
     public async Task<bool> IsSystemApplicationSetAsync(CancellationToken ct)
     {
-        var systemApp = await clientApplicationQueryService.IsSystemConfiguredAsync(ct);
+        var systemApp = await clientApplicationQueryService.IsSystemConfigured(ct);
 
         return systemApp != null && !string.IsNullOrEmpty(systemApp.ClientSecret);
     }
 
     public async Task<List<ClientApplication>> GetAllApplicationsAsync(CancellationToken ct)
     {
-        return await clientApplicationQueryService.GetAllAsync(ct);
+        return await clientApplicationQueryService.GetAll(ct);
     }
     
     public async Task<ClientApplication> UpdateApplicationAsync(ClientApplication clientApplication, 
         CancellationToken ct)
     {
-        await clientApplicationCommandService.UpdateAsync(clientApplication, true, ct);
+        await clientApplicationCommandService.Update(clientApplication, true, ct);
     
         return clientApplication;
     }
 
     public async Task<bool> RevokeApplicationAsync(string clientId, CancellationToken ct)
     {
-        var clientApplication = await clientApplicationQueryService.GetByClientIdAsync(clientId, ct);
+        var clientApplication = await clientApplicationQueryService.GetByClientId(clientId, ct);
 
         if (clientApplication == null)
         {
@@ -72,7 +72,7 @@ public class ApplicationService(IClientApplicationQueryService clientApplication
 
         clientApplication.IsRevoked = true;
         
-        await clientApplicationCommandService.UpdateAsync(clientApplication, true, ct);
+        await clientApplicationCommandService.Update(clientApplication, true, ct);
         return true;
     }
 }

--- a/OpenVPNGateMonitor/Services/Api/Auth/Registers/UserQuotaPlanService.cs
+++ b/OpenVPNGateMonitor/Services/Api/Auth/Registers/UserQuotaPlanService.cs
@@ -22,7 +22,7 @@ public class UserQuotaPlanService(
             QuotaPlanId = quotaPlanId,
         };
 
-        userQuotaPlan = await userQuotaPlanCommandService.AddAsync(userQuotaPlan, true, ct);
+        userQuotaPlan = await userQuotaPlanCommandService.Add(userQuotaPlan, true, ct);
 
         return userQuotaPlan;
     }

--- a/OpenVPNGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
+++ b/OpenVPNGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
@@ -49,7 +49,7 @@ public sealed class UserRegistrationService(
 
         if (!string.IsNullOrEmpty(email))
         {
-            var emailTaken = await userQueryService.AnyByEmailAsync(email, ct);
+            var emailTaken = await userQueryService.AnyByEmail(email, ct);
 
             if (emailTaken)
                 throw new InvalidOperationException("Email is already in use.");
@@ -73,7 +73,7 @@ public sealed class UserRegistrationService(
             LockoutUntilUtc = null
         };
 
-        await userCredentialCommandService.AddAsync(credential, saveChanges: true, ct);
+        await userCredentialCommandService.Add(credential, saveChanges: true, ct);
 
         return new RegisterUserResponse
         {

--- a/OpenVPNGateMonitor/Services/Api/Auth/Registers/UserRoleService.cs
+++ b/OpenVPNGateMonitor/Services/Api/Auth/Registers/UserRoleService.cs
@@ -11,7 +11,7 @@ public class UserRoleService(IUserRoleQueryService userRoleQueryService, IRoleQu
 {
     public async Task<UserRole> AssignRoleAsync(int userId, int roleId, CancellationToken ct)
     {
-        var exists = await userRoleQueryService.GetByIdAndUserIdAsync(roleId, userId, ct);
+        var exists = await userRoleQueryService.GetByIdAndUserId(roleId, userId, ct);
 
         if (exists is not null)
             return exists;
@@ -22,19 +22,19 @@ public class UserRoleService(IUserRoleQueryService userRoleQueryService, IRoleQu
             RoleId = roleId
         };
 
-        userRole = await userRoleCommandService.AddAsync(userRole, true, ct);
+        userRole = await userRoleCommandService.Add(userRole, true, ct);
 
         return userRole;
     }
 
     public async Task<string> GetUserRoleNameAsync(int userId, CancellationToken ct)
     {
-        var role = await userRoleQueryService.GetByUserIdAsync(userId, ct);
+        var role = await userRoleQueryService.GetByUserId(userId, ct);
 
         if (role == null || role.RoleId <= 0)
             throw new Exception($"Role not found for user {userId}");
 
-        var roleName = await roleQueryService.GetByIdAsync(role.RoleId, ct);
+        var roleName = await roleQueryService.GetById(role.RoleId, ct);
         
         if (roleName is null)
             throw new Exception($"Role not found for role {role.RoleId}");

--- a/OpenVPNGateMonitor/Services/Api/Auth/Users/UserAccountService.cs
+++ b/OpenVPNGateMonitor/Services/Api/Auth/Users/UserAccountService.cs
@@ -15,14 +15,14 @@ public sealed class UserAccountService(
 {
     public async Task<User> CreateUserWithDefaultRoleAsync(User user, CancellationToken ct)
     {
-        user = await userCommandService.AddAsync(user, saveChanges: true, ct);
+        user = await userCommandService.Add(user, saveChanges: true, ct);
 
         if (user.Id <= 0)
             throw new InvalidOperationException($"Failed to create user {user.DisplayName}");
 
         await userRoleService.AssignRoleAsync(user.Id, SystemRoles.VpnUserId, ct);
 
-        var quotaPlanDefault = await quotaPlanQueryService.GetDefaultAsync(ct);
+        var quotaPlanDefault = await quotaPlanQueryService.GetDefault(ct);
         if (quotaPlanDefault != null) await userQuotaPlanService.AssignQuotaPlanAsync(user.Id, quotaPlanDefault.Id, ct);
 
         return user;

--- a/OpenVPNGateMonitor/Services/Api/OpenVpnServerOvpnFileConfigService.cs
+++ b/OpenVPNGateMonitor/Services/Api/OpenVpnServerOvpnFileConfigService.cs
@@ -17,7 +17,7 @@ public class OpenVpnServerOvpnFileConfigService(
     public async Task<OpenVpnServerOvpnFileConfig> GetOpenVpnServerOvpnFileConfigByServerId(int vpnServerId, 
         CancellationToken ct)
     {
-        return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdIdAsync(vpnServerId, ct)
+        return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(vpnServerId, ct)
                ?? throw new InvalidOperationException("OvpnFileConfig not found");
     }
     
@@ -25,7 +25,7 @@ public class OpenVpnServerOvpnFileConfigService(
         OpenVpnServerOvpnFileConfig openVpnServerOvpnFileConfig, CancellationToken ct)
     {
 
-        var existingConfig = await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdIdAsync(
+        var existingConfig = await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(
             openVpnServerOvpnFileConfig.VpnServerId, ct);
 
         if (existingConfig != null)
@@ -35,17 +35,17 @@ public class OpenVpnServerOvpnFileConfigService(
             existingConfig.ConfigTemplate = openVpnServerOvpnFileConfig.ConfigTemplate;
             existingConfig.LastUpdate = DateTimeOffset.UtcNow;
 
-            await openVpnServerOvpnFileConfigCommandService.UpdateAsync(existingConfig, true, ct);
+            await openVpnServerOvpnFileConfigCommandService.Update(existingConfig, true, ct);
         }
         else
         {
             openVpnServerOvpnFileConfig.CreateDate = DateTimeOffset.UtcNow;
             openVpnServerOvpnFileConfig.LastUpdate = DateTimeOffset.UtcNow;
             
-            await openVpnServerOvpnFileConfigCommandService.AddAsync(openVpnServerOvpnFileConfig, true, ct);
+            await openVpnServerOvpnFileConfigCommandService.Add(openVpnServerOvpnFileConfig, true, ct);
         }
         
-        return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdIdAsync(
+        return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(
                    openVpnServerOvpnFileConfig.VpnServerId, ct)
                ?? throw new InvalidOperationException($"OpenVPN server OVPN file configuration not found for " +
                                                       $"server ID {openVpnServerOvpnFileConfig.VpnServerId}.");

--- a/OpenVPNGateMonitor/Services/Api/VpnDataService.cs
+++ b/OpenVPNGateMonitor/Services/Api/VpnDataService.cs
@@ -25,7 +25,7 @@ public class VpnDataService(
             if (server.IsDefault)
             {
                 // Unset previous default in one SQL statement (no entity loading)
-                await openVpnServerCommandService.UpdateWhereAsync(
+                await openVpnServerCommandService.UpdateWhere(
                     s => s.IsDefault,
                     u => u.SetProperty(x => x.IsDefault, false)
                         .SetProperty(x => x.LastUpdate, now),
@@ -35,7 +35,7 @@ public class VpnDataService(
             // Insert server (need Id immediately for further operations)
             server.CreateDate = now;
             server.LastUpdate = now;
-            await openVpnServerCommandService.AddAsync(server, saveChanges: true, ct);
+            await openVpnServerCommandService.Add(server, saveChanges: true, ct);
             
             await SyncQuotaPlanLinksAsync(server.Id, quotaPlanIds, ct);
 
@@ -44,7 +44,7 @@ public class VpnDataService(
                 logger.LogWarning("Failed to add default settings for OpenVPN server.");
 
             // Return a fresh snapshot
-            return await openVpnServerQueryService.GetByIdAsync(server.Id, ct)
+            return await openVpnServerQueryService.GetById(server.Id, ct)
                    ?? throw new InvalidOperationException("OpenVPN server not found");
         }, ct);
 
@@ -57,7 +57,7 @@ public class VpnDataService(
             if (server.IsDefault)
             {
                 // Unset all other defaults in a single SQL statement
-                await openVpnServerCommandService.UpdateWhereAsync(
+                await openVpnServerCommandService.UpdateWhere(
                     s => s.IsDefault && s.Id != server.Id,
                     u => u.SetProperty(x => x.IsDefault, false)
                         .SetProperty(x => x.LastUpdate, now),
@@ -66,7 +66,7 @@ public class VpnDataService(
 
             // Update this server
             server.LastUpdate = now;
-            await openVpnServerCommandService.UpdateAsync(server, saveChanges: true, ct);
+            await openVpnServerCommandService.Update(server, saveChanges: true, ct);
             
             await SyncQuotaPlanLinksAsync(server.Id, quotaPlanIds, ct);
 
@@ -75,16 +75,16 @@ public class VpnDataService(
                 logger.LogWarning("Failed to add/update default settings for OpenVPN server.");
 
             // Return fresh snapshot
-            return await openVpnServerQueryService.GetByIdAsync(server.Id, ct)
+            return await openVpnServerQueryService.GetById(server.Id, ct)
                    ?? throw new InvalidOperationException("OpenVPN server not found");
         }, ct);
 
 
     public async Task<bool> DeleteOpenVpnServer(int vpnServerId, CancellationToken ct)
     {
-        var openVpnServer = await openVpnServerQueryService.GetByIdAsync(vpnServerId, ct)
+        var openVpnServer = await openVpnServerQueryService.GetById(vpnServerId, ct)
                             ?? throw new InvalidOperationException("OpenVpnServer not found");
-        await openVpnServerCommandService.DeleteAsync(openVpnServer, true, ct);
+        await openVpnServerCommandService.Delete(openVpnServer, true, ct);
         return true;
     }
 
@@ -94,7 +94,7 @@ public class VpnDataService(
 
         if (!await openVpnServerOvpnFileConfigQueryService.AnyByVpnServerId(openVpnServer.Id, ct))
         {
-            await openVpnServerOvpnFileConfigCommandService.AddAsync(new OpenVpnServerOvpnFileConfig
+            await openVpnServerOvpnFileConfigCommandService.Add(new OpenVpnServerOvpnFileConfig
             {
                 VpnServerId = openVpnServer.Id,
                 VpnServerIp = await externalIpAddressService.GetRemoteIpAddress(ct),
@@ -111,7 +111,7 @@ public class VpnDataService(
         CancellationToken ct)
     {
         // Remove old links
-        await quotaPlanAllowedServerCommandService.DeleteWhereAsync(
+        await quotaPlanAllowedServerCommandService.DeleteWhere(
             x => x.VpnServerId == vpnServerId,
             ct);
 
@@ -128,6 +128,6 @@ public class VpnDataService(
             })
             .ToList();
 
-        await quotaPlanAllowedServerCommandService.AddRangeAsync(links, saveChanges: true, ct);
+        await quotaPlanAllowedServerCommandService.AddRange(links, saveChanges: true, ct);
     }
 }

--- a/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
+++ b/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
@@ -63,7 +63,7 @@ public class OpenVpnBackgroundService : BackgroundService, IOpenVpnBackgroundSer
             _logger.LogInformation("Starting OpenVPN task execution...");
             using var scope = _serviceProvider.CreateScope();
             var openVpnServerQueryService = scope.ServiceProvider.GetRequiredService<IOpenVpnServerQueryService>();
-            var openVpnServers = await openVpnServerQueryService.GetAllAsync(cancellationToken);
+            var openVpnServers = await openVpnServerQueryService.GetAll(cancellationToken);
             _statusManager.ClearAllStatuses();
 
             openVpnServers = openVpnServers.Where(x=> x.IsDisable != true).ToList();

--- a/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnEventBackgroundService.cs
+++ b/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnEventBackgroundService.cs
@@ -26,7 +26,7 @@ public sealed class OpenVpnEventBackgroundService(
         {
             using var scope = scopeFactory.CreateScope();
             var openVpnOverviewQuery = scope.ServiceProvider.GetRequiredService<IOpenVpnServerQueryService>();
-            var servers = await openVpnOverviewQuery.GetAllAsync(cancellationToken);
+            var servers = await openVpnOverviewQuery.GetAll(cancellationToken);
             servers = servers.Where(x=> !x.IsDisable).ToList();
 
             foreach (var server in servers)

--- a/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerProcessor.cs
+++ b/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerProcessor.cs
@@ -28,7 +28,7 @@ public class OpenVpnServerProcessor(
 
             // Set IsOnline = true (server-side update, no entity tracking)
             var now = DateTimeOffset.UtcNow;
-            await serverCmd.UpdateWhereAsync(
+            await serverCmd.UpdateWhere(
                 s => s.Id == openVpnServer.Id,
                 u => u.SetProperty(x => x.IsOnline, true)
                     .SetProperty(x => x.LastUpdate, now),
@@ -42,7 +42,7 @@ public class OpenVpnServerProcessor(
         {
             // Mark server offline on failure
             var now = DateTimeOffset.UtcNow;
-            await serverCmd.UpdateWhereAsync(
+            await serverCmd.UpdateWhere(
                 s => s.Id == openVpnServer.Id,
                 u => u.SetProperty(x => x.IsOnline, false)
                     .SetProperty(x => x.LastUpdate, now),

--- a/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerService.cs
+++ b/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerService.cs
@@ -45,7 +45,7 @@ public class OpenVpnServerService(
                     GenerateSessionId(c.CommonName, c.RemoteIp, c.ConnectedSince)));
 
             // Mark not-present sessions as disconnected
-            await openVpnServerClientCommandService.UpdateWhereAsync(
+            await openVpnServerClientCommandService.UpdateWhere(
                 x => x.VpnServerId == openVpnServer.Id
                      && x.IsConnected
                      && !currentSessionIds.Contains(x.SessionId),
@@ -63,7 +63,7 @@ public class OpenVpnServerService(
                     m.CommonName, openVpnServer.Id, ct) ?? string.Empty;
 
                 // ---- Upsert main client row ----
-                var rows = await openVpnServerClientCommandService.UpdateWhereAsync(
+                var rows = await openVpnServerClientCommandService.UpdateWhere(
                     x => x.VpnServerId == openVpnServer.Id && x.SessionId == sessionId,
                     s => s
                         .SetProperty(c => c.CommonName, m.CommonName)
@@ -95,7 +95,7 @@ public class OpenVpnServerService(
                     newClient.LastUpdate = nowUtc;
                     newClient.CreateDate = nowUtc;
 
-                    await openVpnServerClientCommandService.AddAsync(newClient, saveChanges: false, ct);
+                    await openVpnServerClientCommandService.Add(newClient, saveChanges: false, ct);
                     logger.LogInformation("VpnServerId: {Id}. Added new client session {SessionId}.",
                         openVpnServer.Id, sessionId);
                 }
@@ -108,7 +108,7 @@ public class OpenVpnServerService(
                 var measuredAt = DateTimeOffset.UtcNow; // exact timestamp of this poll
 
                 // Conditional UPDATE to avoid counter regression; then INSERT if not found
-                var tRows = await openVpnClientTrafficCommandService.UpdateWhereAsync(
+                var tRows = await openVpnClientTrafficCommandService.UpdateWhere(
                     x => x.VpnServerId == openVpnServer.Id
                          && x.SessionId == sessionId
                          && x.MeasuredAt == measuredAt
@@ -132,13 +132,13 @@ public class OpenVpnServerService(
                         MeasuredAt = measuredAt // saved as UTC in setter
                     };
 
-                    await openVpnClientTrafficCommandService.AddAsync(sample, saveChanges: false, ct);
+                    await openVpnClientTrafficCommandService.Add(sample, saveChanges: false, ct);
                 }
             }
 
             // Persist both sets (clients + traffic)
-            await openVpnServerClientCommandService.SaveChangesAsync(ct);
-            await openVpnClientTrafficCommandService.SaveChangesAsync(ct);
+            await openVpnServerClientCommandService.SaveChanges(ct);
+            await openVpnClientTrafficCommandService.SaveChanges(ct);
 
             logger.LogInformation("VpnServerId: {Id}. SaveConnectedClientsAsync completed successfully.",
                 openVpnServer.Id);
@@ -194,7 +194,7 @@ public class OpenVpnServerService(
         );
 
         var existingStatusLog =
-            await openVpnServerStatusLogQueryService.GetBySessionIdAndVpnServerIdAsync(sessionId, openVpnServer.Id, ct);
+            await openVpnServerStatusLogQueryService.GetBySessionIdAndVpnServerId(sessionId, openVpnServer.Id, ct);
 
         if (existingStatusLog != null)
         {
@@ -207,7 +207,7 @@ public class OpenVpnServerService(
             existingStatusLog.Version = serverInfo.Version;
             existingStatusLog.LastUpdate = DateTimeOffset.UtcNow;
 
-            await openVpnServerStatusLogCommandService.UpdateAsync(existingStatusLog, true, ct);
+            await openVpnServerStatusLogCommandService.Update(existingStatusLog, true, ct);
             logger.LogInformation($"VpnServerId: {openVpnServer.Id}. Updated existing status log {sessionId}.");
         }
         else
@@ -226,7 +226,7 @@ public class OpenVpnServerService(
                 CreateDate = DateTimeOffset.UtcNow
             };
 
-            await openVpnServerStatusLogCommandService.AddAsync(newStatusLog, true, ct);
+            await openVpnServerStatusLogCommandService.Add(newStatusLog, true, ct);
             logger.LogInformation($"VpnServerId: {openVpnServer.Id}. Created new status log {{SessionId}}.", sessionId);
         }
 

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/CertApiClient.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/CertApiClient.cs
@@ -45,7 +45,7 @@ public class CertApiClient(
 
     private async Task<HttpClient> GetClientForServerAsync(int vpnServerId, CancellationToken cancellationToken)
     {
-        var server = await openVpnServerQueryService.GetByIdAsync(vpnServerId, cancellationToken) 
+        var server = await openVpnServerQueryService.GetById(vpnServerId, cancellationToken) 
             ?? throw new InvalidOperationException("OpenVPN server not found");
         var client = httpClientFactory.CreateClient();
         client.BaseAddress = new Uri(server.ApiUrl);

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
@@ -271,7 +271,7 @@ public class OpenVpnEventClient(
                 openVpnServerClient.SessionId = GenerateSessionId(
                     openVpnServerClient.CommonName, openVpnServerClient.RemoteIp, openVpnServerClient.ConnectedSince);
 
-                await clientCmd.AddAsync(openVpnServerClient, saveChanges: false, CancellationToken.None);
+                await clientCmd.Add(openVpnServerClient, saveChanges: false, CancellationToken.None);
                 logger.LogInformation("VpnServerId: {Id}. Added new client session {SessionId}.",
                     _serverId, openVpnServerClient.SessionId);
             }
@@ -280,7 +280,7 @@ public class OpenVpnEventClient(
             {
                 var nowUtc = DateTimeOffset.UtcNow;
 
-                await clientCmd.UpdateWhereAsync(
+                await clientCmd.UpdateWhere(
                     x => x.VpnServerId == _serverId
                          && x.IsConnected
                          && x.CommonName == req.CommonName
@@ -294,7 +294,7 @@ public class OpenVpnEventClient(
             }
 
             // save while scope (DbContext) is still alive
-            await clientCmd.SaveChangesAsync(CancellationToken.None);
+            await clientCmd.SaveChanges(CancellationToken.None);
 
             swSave.Stop();
             logger.LogInformation("Saved event {EventType} for ServerId={ServerId}; SaveMs={ElapsedMs}",

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactory.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactory.cs
@@ -32,7 +32,7 @@ public class OpenVpnEventClientFactory(IServiceProvider rootProvider) : IOpenVpn
 
         using var scope = rootProvider.CreateScope();
         var serverQuery = scope.ServiceProvider.GetRequiredService<IOpenVpnServerQueryService>();
-        var server = await serverQuery.GetByIdAsync(serverId, cancellationToken);
+        var server = await serverQuery.GetById(serverId, cancellationToken);
         if (server is null) return null;
 
         return Create(server);

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Events/VpnEventLogService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Events/VpnEventLogService.cs
@@ -48,6 +48,6 @@ public class VpnEventLogService(
             Message         = e.Message
         };
 
-        await cmd.AddAsync(row, saveChanges: true, ct);
+        await cmd.Add(row, saveChanges: true, ct);
     }
 }

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IOvpnFileApiClient.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IOvpnFileApiClient.cs
@@ -5,8 +5,8 @@ namespace OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 
 public interface IOvpnFileApiClient
 {
-    Task<OvpnFileMetadata> AddOvpnFileAsync(int vpnServerId, GenerateOvpnFileRequest request, 
+    Task<OvpnFileMetadata> AddOvpnFile(int vpnServerId, GenerateOvpnFileRequest request, 
         CancellationToken cancellationToken);
-    Task<bool> RevokeOvpnFileAsync(int vpnServerId, RevokeOvpnFileRequest request, CancellationToken cancellationToken);
-    Task<OvpnFileDownload> DownloadOvpnFileAsync(int vpnServerId, DownloadOvpnFileRequest request, CancellationToken cancellationToken);
+    Task<bool> RevokeOvpnFile(int vpnServerId, RevokeOvpnFileRequest request, CancellationToken cancellationToken);
+    Task<OvpnFileDownload> DownloadOvpnFile(int vpnServerId, DownloadOvpnFileRequest request, CancellationToken cancellationToken);
 }

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IOvpnFileApiService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IOvpnFileApiService.cs
@@ -6,29 +6,32 @@ namespace OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 
 public interface IOvpnFileApiService
 {
-    Task<IssuedOvpnFile> GetByTokenAsync(string token, CancellationToken cancellationToken
+    Task<IssuedOvpnFile> GetByToken(string token, CancellationToken cancellationToken
         , bool isRevoked = false);
-    Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAsync(int vpnServerId, CancellationToken cancellationToken);
-    Task<List<IssuedOvpnFile>> GetAllByExternalIdAsync(string externalId, 
+    Task<List<IssuedOvpnFile>> GetAllByVpnServerId(int vpnServerId, CancellationToken cancellationToken);
+    Task<List<IssuedOvpnFile>> GetAllByExternalId(string externalId, 
         CancellationToken cancellationToken);
 
-    Task<List<(IssuedOvpnFile File, IssuedOvpnFileToken? Token)>> GetAllByVpnServerIdWithTokenAsync(int vpnServerId,
+    Task<List<(IssuedOvpnFile File, IssuedOvpnFileToken? Token)>> GetAllByVpnServerIdWithToken(int vpnServerId,
         CancellationToken cancellationToken, bool isRevoked = false);
 
-    Task<List<IssuedOvpnFile>> GetAllByExternalIdAndVpnServerIdAsync(int vpnServerId, string externalId,
+    Task<List<IssuedOvpnFile>> GetAllByExternalIdAndVpnServerId(int vpnServerId, string externalId,
         CancellationToken cancellationToken, bool isRevoked = false);
     Task<List<(IssuedOvpnFile File, IssuedOvpnFileToken? Token)>> 
-        GetAllByExternalIdAndVpnServerIdWithTokenAsync(int vpnServerId, string externalId, 
+        GetAllByExternalIdAndVpnServerIdWithToken(int vpnServerId, string externalId, 
             CancellationToken cancellationToken, bool isRevoked = false);
     
-    Task<IssuedOvpnFile> AddOvpnFileAsync(AddFileRequest request, 
+    Task<IssuedOvpnFile> AddOvpnFile(AddFileRequest request, 
         CancellationToken cancellationToken);
-    Task<(IssuedOvpnFile File, IssuedOvpnFileToken Token)> AddOvpnFileWithTokenAsync(AddFileRequest request, 
+    Task<(IssuedOvpnFile File, IssuedOvpnFileToken Token)> AddOvpnFileWithToken(AddFileRequest request, 
         CancellationToken cancellationToken);
     
-    Task<IssuedOvpnFile> RevokeOvpnFileAsync(RevokeFileRequest request,
+    Task<IssuedOvpnFile> RevokeOvpnFile(RevokeFileRequest request,
         CancellationToken cancellationToken);
 
-    Task<DownloadFileResponse> DownloadOvpnFileAsync(DownloadFileRequest request,
+    Task<DownloadFileResponse> DownloadOvpnFile(DownloadFileRequest request,
+        CancellationToken cancellationToken, bool isRevoked = false);
+    
+    Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileRequest request,
         CancellationToken cancellationToken, bool isRevoked = false);
 }

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IOvpnFileApiService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IOvpnFileApiService.cs
@@ -32,6 +32,6 @@ public interface IOvpnFileApiService
     Task<DownloadFileResponse> DownloadOvpnFile(DownloadFileRequest request,
         CancellationToken cancellationToken, bool isRevoked = false);
     
-    Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileRequest request,
+    Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileByCnRequest request,
         CancellationToken cancellationToken, bool isRevoked = false);
 }

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
@@ -36,7 +36,7 @@ public class OpenVpnMicroserviceClientFactory(IServiceProvider serviceProvider) 
     {
         using var scope = serviceProvider.CreateScope();
         var openVpnOverviewQuery = scope.ServiceProvider.GetRequiredService<IOpenVpnServerQueryService>();
-        var server = await openVpnOverviewQuery.GetByIdAsync(serverId, cancellationToken)
+        var server = await openVpnOverviewQuery.GetById(serverId, cancellationToken)
                      ?? throw new Exception($"OpenVPN server not found with id {serverId}");
 
         return Create(server);

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiClient.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiClient.cs
@@ -21,9 +21,9 @@ public class OvpnFileApiClient(
     private const string EndpointOvpnFilesDownload = "api/ovpn-files/download";
 
     
-    private async Task<HttpClient> GetClientForServerAsync(int serverId, CancellationToken cancellationToken)
+    private async Task<HttpClient> GetClientForServer(int serverId, CancellationToken cancellationToken)
     {
-        var server = await openVpnServerQueryService.GetByIdAsync(serverId, cancellationToken);
+        var server = await openVpnServerQueryService.GetById(serverId, cancellationToken);
         var client = httpClientFactory.CreateClient();
         if (server != null)
         {
@@ -40,12 +40,12 @@ public class OvpnFileApiClient(
         return client;
     }
 
-    public async Task<OvpnFileMetadata> AddOvpnFileAsync(int vpnServerId, GenerateOvpnFileRequest request,
+    public async Task<OvpnFileMetadata> AddOvpnFile(int vpnServerId, GenerateOvpnFileRequest request,
         CancellationToken cancellationToken)
     {
         try
         {
-            using var client = await GetClientForServerAsync(vpnServerId, cancellationToken);
+            using var client = await GetClientForServer(vpnServerId, cancellationToken);
             var jwt = tokenService.GenerateToken("vpn-cert-issuer", "cert-create",
                 "backend", "DataGateOpenVpnManager");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
@@ -103,12 +103,12 @@ public class OvpnFileApiClient(
         }
     }
 
-    public async Task<bool> RevokeOvpnFileAsync(int vpnServerId, RevokeOvpnFileRequest request,
+    public async Task<bool> RevokeOvpnFile(int vpnServerId, RevokeOvpnFileRequest request,
         CancellationToken cancellationToken)
     {
         try
         {
-            using var client = await GetClientForServerAsync(vpnServerId, cancellationToken);
+            using var client = await GetClientForServer(vpnServerId, cancellationToken);
             var jwt = tokenService.GenerateToken("vpn-cert-issuer", "cert-create",
                 "backend", "DataGateOpenVpnManager");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
@@ -166,12 +166,12 @@ public class OvpnFileApiClient(
         }
     }
 
-    public async Task<OvpnFileDownload> DownloadOvpnFileAsync(int vpnServerId, DownloadOvpnFileRequest request,
+    public async Task<OvpnFileDownload> DownloadOvpnFile(int vpnServerId, DownloadOvpnFileRequest request,
         CancellationToken cancellationToken)
     {
         try
         {
-            using var client = await GetClientForServerAsync(vpnServerId, cancellationToken);
+            using var client = await GetClientForServer(vpnServerId, cancellationToken);
             var jwt = tokenService.GenerateToken("vpn-cert-issuer", "cert-create",
                 "backend", "DataGateOpenVpnManager");
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
@@ -32,22 +32,22 @@ public class OvpnFileApiService(
     private int TokenExpireDays =>
         configuration.GetValue<int?>("OvpnFileToken:ExpireDays") ?? DefaultTokenExpireDays;
 
-    public async Task<IssuedOvpnFile> GetByTokenAsync(string token, CancellationToken ct, bool isRevoked = false)
+    public async Task<IssuedOvpnFile> GetByToken(string token, CancellationToken ct, bool isRevoked = false)
     {
         var issuedOvpnFileToken = await issuedOvpnFileTokenQueryService
-            .GetByTokenAsync(token, ct)
+            .GetByToken(token, ct)
             ?? throw new InvalidOperationException(
                 $"IssuedOvpnFileToken not found for token='{token}'. " +
                 "Possible reasons: the token is invalid, expired, or already used/revoked.");
 
         var issuedOvpnFile = await issuedOvpnFileQueryService
-                .GetByIdAndIsRevokedAsync(issuedOvpnFileToken.IssuedOvpnFileId, isRevoked, ct)
+                .GetByIdAndIsRevoked(issuedOvpnFileToken.IssuedOvpnFileId, isRevoked, ct)
             ?? throw new InvalidOperationException(
                 $"IssuedOvpnFile not found for token='{token}'. " +
                 $"IssuedOvpnFileId={issuedOvpnFileToken.IssuedOvpnFileId}, IsRevokedFilter={isRevoked}. " +
                 "Possible reasons: the file was deleted, or its revoked state does not match the requested filter.");
 
-        await ovpnFileNotificationService.NotifyReadByTokenAsync(
+        await ovpnFileNotificationService.NotifyReadByToken(
             token,
             issuedOvpnFile.Id,
             issuedOvpnFile.VpnServerId,
@@ -57,31 +57,31 @@ public class OvpnFileApiService(
         return issuedOvpnFile;
     }
     
-    public async Task<List<IssuedOvpnFile>> GetAllByExternalIdAsync(string externalId, CancellationToken ct)
+    public async Task<List<IssuedOvpnFile>> GetAllByExternalId(string externalId, CancellationToken ct)
     {
         var issuedFiles = await issuedOvpnFileQueryService.GetAllByExternalId(externalId, ct);
         
-        await ovpnFileNotificationService.NotifyReadByExternalIdAsync(externalId, issuedFiles.Count, ct);
+        await ovpnFileNotificationService.NotifyReadByExternalId(externalId, issuedFiles.Count, ct);
 
         return issuedFiles;
     }
     
-    public async Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAsync(int vpnServerId, CancellationToken ct)
+    public async Task<List<IssuedOvpnFile>> GetAllByVpnServerId(int vpnServerId, CancellationToken ct)
     {
         var issuedFiles = await issuedOvpnFileQueryService.GetAllByVpnServerId(vpnServerId, ct);
         
-        await ovpnFileNotificationService.NotifyReadAllAsync(vpnServerId, issuedFiles.Count, ct);
+        await ovpnFileNotificationService.NotifyReadAll(vpnServerId, issuedFiles.Count, ct);
 
         return issuedFiles;
     }
 
-    public async Task<List<(IssuedOvpnFile File, IssuedOvpnFileToken? Token)>> GetAllByVpnServerIdWithTokenAsync(
+    public async Task<List<(IssuedOvpnFile File, IssuedOvpnFileToken? Token)>> GetAllByVpnServerIdWithToken(
         int vpnServerId, CancellationToken ct, bool isRevoked = false)
     {
         var issuedFiles = await issuedOvpnFileQueryService.GetAllByVpnServerIdAndIsRevoked(
             vpnServerId, isRevoked, ct);
         
-        var tokens = await issuedOvpnFileTokenQueryService.GetByIssuedFileIdsAsync(
+        var tokens = await issuedOvpnFileTokenQueryService.GetByIssuedFileIds(
             issuedFiles.Select(x => x.Id).ToList(), ct);
 
         var result = issuedFiles.Select(file =>
@@ -91,31 +91,31 @@ public class OvpnFileApiService(
         }).ToList();
 
         
-        await ovpnFileNotificationService.NotifyReadAllWithTokenAsync(vpnServerId, result.Count, isRevoked, ct);
+        await ovpnFileNotificationService.NotifyReadAllWithToken(vpnServerId, result.Count, isRevoked, ct);
         
         return result;
     }
 
-    public async Task<List<IssuedOvpnFile>> GetAllByExternalIdAndVpnServerIdAsync(int vpnServerId, string externalId,
+    public async Task<List<IssuedOvpnFile>> GetAllByExternalIdAndVpnServerId(int vpnServerId, string externalId,
         CancellationToken ct, bool isRevoked = false)
     {
         var result = await issuedOvpnFileQueryService.GetAllByVpnServerIdAndExternalIdAndIsRevoked(
             vpnServerId, externalId, isRevoked, ct);
-        await ovpnFileNotificationService.NotifyReadByExternalIdAndVpnServerIdAsync(vpnServerId, externalId, result.Count,
+        await ovpnFileNotificationService.NotifyReadByExternalIdAndVpnServerId(vpnServerId, externalId, result.Count,
             isRevoked, ct);
 
         return result;
     }
 
     public async Task<List<(IssuedOvpnFile File, IssuedOvpnFileToken? Token)>> 
-        GetAllByExternalIdAndVpnServerIdWithTokenAsync(int vpnServerId, string externalId, 
+        GetAllByExternalIdAndVpnServerIdWithToken(int vpnServerId, string externalId, 
             CancellationToken ct, bool isRevoked = false)
     {
         var issuedFiles =
             await issuedOvpnFileQueryService.GetAllByVpnServerIdAndExternalIdAndIsRevoked(vpnServerId, externalId,
                 isRevoked, ct);
 
-        var tokens = await issuedOvpnFileTokenQueryService.GetByIssuedFileIdsAsync(
+        var tokens = await issuedOvpnFileTokenQueryService.GetByIssuedFileIds(
             issuedFiles.Select(x => x.Id).ToList(), ct);
 
         var result = issuedFiles
@@ -126,27 +126,27 @@ public class OvpnFileApiService(
             })
             .ToList();
         
-        await ovpnFileNotificationService.NotifyReadByExternalIdWithTokenAsync(vpnServerId, externalId, result.Count, 
+        await ovpnFileNotificationService.NotifyReadByExternalIdWithToken(vpnServerId, externalId, result.Count, 
             isRevoked, ct);
 
         return result;
     }
 
-    public async Task<(IssuedOvpnFile File, IssuedOvpnFileToken Token)> AddOvpnFileWithTokenAsync(
+    public async Task<(IssuedOvpnFile File, IssuedOvpnFileToken Token)> AddOvpnFileWithToken(
         AddFileRequest request,
         CancellationToken ct)
     {
-        var issuedOvpnFile = await AddOvpnFileAsync(request, ct);
-        var token = await MakeTokenForFileAsync(issuedOvpnFile, ct);
+        var issuedOvpnFile = await AddOvpnFile(request, ct);
+        var token = await MakeTokenForFile(issuedOvpnFile, ct);
 
-        await ovpnFileNotificationService.NotifyIssuedWithTokenAsync(
+        await ovpnFileNotificationService.NotifyIssuedWithToken(
             issuedOvpnFile.VpnServerId, issuedOvpnFile.Id, issuedOvpnFile.FileName,
             issuedOvpnFile.ExternalId, token.Id, /* todo: user ID*/ ct);
         
         return (issuedOvpnFile, token);
     }
     
-    public async Task<IssuedOvpnFile> AddOvpnFileAsync(
+    public async Task<IssuedOvpnFile> AddOvpnFile(
         AddFileRequest request, 
         CancellationToken ct)
     {
@@ -156,7 +156,7 @@ public class OvpnFileApiService(
             request.VpnServerId);
         
         if (await issuedOvpnFileQueryService
-                .ExistsActiveByVpnServerIdAndCommonNameAsync(request.VpnServerId, request.CommonName, ct))
+                .ExistsActiveByVpnServerIdAndCommonName(request.VpnServerId, request.CommonName, ct))
         {
             logger.LogWarning(
                 "OVPN file already exists: CommonName={CommonName}, VpnServerId={VpnServerId}",
@@ -179,7 +179,7 @@ public class OvpnFileApiService(
         generateOvpnFileRequest.ServerIp = ovpnFileConfig.VpnServerIp;
         generateOvpnFileRequest.ServerPort = ovpnFileConfig.VpnServerPort;
         
-        var result = await ovpnFileApiClient.AddOvpnFileAsync(
+        var result = await ovpnFileApiClient.AddOvpnFile(
             request.VpnServerId,
             generateOvpnFileRequest,
             ct);
@@ -190,7 +190,7 @@ public class OvpnFileApiService(
         issuedOvpnFile.ReqFilePath = "unavailable";
         issuedOvpnFile.IsRevoked = false;
 
-        var newIssuedOvpnFile = await issuedOvpnFileCommandService.AddAsync(
+        var newIssuedOvpnFile = await issuedOvpnFileCommandService.Add(
             issuedOvpnFile,
             true,
             ct);
@@ -207,7 +207,7 @@ public class OvpnFileApiService(
             request.CommonName,
             request.VpnServerId);
         
-        await ovpnFileNotificationService.NotifyIssuedAsync(
+        await ovpnFileNotificationService.NotifyIssued(
             issuedOvpnFile.VpnServerId,
             issuedOvpnFile.Id,
             issuedOvpnFile.FileName,
@@ -215,7 +215,7 @@ public class OvpnFileApiService(
             /* todo: user ID*/ ct);
 
         return await issuedOvpnFileQueryService
-                   .GetByVpnServerIdAndCommonNameAsync(
+                   .GetByVpnServerIdAndCommonName(
                        newIssuedOvpnFile.Id,
                        request.VpnServerId,
                        request.CommonName,
@@ -229,7 +229,7 @@ public class OvpnFileApiService(
                    "(server id / common name) do not match the stored record.");
     }
 
-    public async Task<IssuedOvpnFile> RevokeOvpnFileAsync(
+    public async Task<IssuedOvpnFile> RevokeOvpnFile(
         RevokeFileRequest request,
         CancellationToken ct)
     {
@@ -242,7 +242,7 @@ public class OvpnFileApiService(
             request.IsRevoked);
 
         var issuedOvpnFile = await issuedOvpnFileQueryService
-            .GetByIdAndVpnServerIdAndCommonNameAndIsRevokedAsync(
+            .GetByIdAndVpnServerIdAndCommonNameAndIsRevoked(
                 request.VpnServerId,
                 request.OvpnFileId,
                 request.CommonName,
@@ -280,14 +280,14 @@ public class OvpnFileApiService(
 
         revokeOvpnFileRequest.OvpnFilePath = issuedOvpnFile.FilePath;
             
-        var result = await ovpnFileApiClient.RevokeOvpnFileAsync(
+        var result = await ovpnFileApiClient.RevokeOvpnFile(
             request.VpnServerId,
             revokeOvpnFileRequest,
             ct);
 
         issuedOvpnFile.IsRevoked = result;
         
-        await issuedOvpnFileCommandService.UpdateAsync(
+        await issuedOvpnFileCommandService.Update(
             issuedOvpnFile,
             true,
             ct);
@@ -301,7 +301,7 @@ public class OvpnFileApiService(
             issuedOvpnFile.ExternalId,
             issuedOvpnFile.IsRevoked);
         
-        await ovpnFileNotificationService.NotifyRevokedAsync(
+        await ovpnFileNotificationService.NotifyRevoked(
             issuedOvpnFile.VpnServerId,
             issuedOvpnFile.Id,
             issuedOvpnFile.FileName,
@@ -309,7 +309,7 @@ public class OvpnFileApiService(
             /* todo: user ID*/ ct);
 
         return await issuedOvpnFileQueryService
-                   .GetByVpnServerIdAndCommonNameAsync(
+                   .GetByVpnServerIdAndCommonName(
                        issuedOvpnFile.Id,
                        request.VpnServerId,
                        request.CommonName,
@@ -323,7 +323,7 @@ public class OvpnFileApiService(
                    "(server id / common name / revoked state) are correct.");
     }
 
-    public async Task<DownloadFileResponse> DownloadOvpnFileAsync(DownloadFileRequest request, 
+    public async Task<DownloadFileResponse> DownloadOvpnFile(DownloadFileRequest request, 
         CancellationToken ct, bool isRevoked = false)
     {
         logger.LogInformation("Start downloading OVPN file:" +
@@ -331,7 +331,7 @@ public class OvpnFileApiService(
             request.VpnServerId, request.IssuedOvpnFileId);
 
         var issuedOvpnFile = await issuedOvpnFileQueryService
-                .GetByIdAndVpnServerIdAndIsRevokedAsync(
+                .GetByIdAndVpnServerIdAndIsRevoked(
                     request.IssuedOvpnFileId,
                     request.VpnServerId,
                     isRevoked,
@@ -351,7 +351,7 @@ public class OvpnFileApiService(
                 FileName = issuedOvpnFile.FileName,
                 FilePath = issuedOvpnFile.FilePath
             };
-        var result = await ovpnFileApiClient.DownloadOvpnFileAsync(
+        var result = await ovpnFileApiClient.DownloadOvpnFile(
             request.VpnServerId, requestApi, ct);
 
         if (result.Content == null)
@@ -369,7 +369,7 @@ public class OvpnFileApiService(
         logger.LogInformation("Successfully downloaded OVPN file: FileName={FileName}, Size={Size} bytes",
             result.FileName, result.Content.LongLength);
         
-        await ovpnFileNotificationService.NotifyDownloadedAsync(
+        await ovpnFileNotificationService.NotifyDownloaded(
             issuedOvpnFile.VpnServerId, issuedOvpnFile.FileName, issuedOvpnFile.ExternalId,
             isRevoked, /* todo: user ID*/ ct);
 
@@ -381,7 +381,7 @@ public class OvpnFileApiService(
         };
     }
 
-    private async Task<IssuedOvpnFileToken> MakeTokenForFileAsync(IssuedOvpnFile issuedOvpnFile, CancellationToken ct)
+    private async Task<IssuedOvpnFileToken> MakeTokenForFile(IssuedOvpnFile issuedOvpnFile, CancellationToken ct)
     {
         var token = new IssuedOvpnFileToken
         {
@@ -393,20 +393,20 @@ public class OvpnFileApiService(
             Purpose = "download"
         };
 
-        await issuedOvpnFileTokenCommandService.AddAsync(token, true, ct);
+        await issuedOvpnFileTokenCommandService.Add(token, true, ct);
         return token;
     }
 
     private async Task<OpenVpnServerOvpnFileConfig> GetOpenVpnServerOvpnFileConfig(int vpnServerId, 
         CancellationToken ct)
     {
-        return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdIdAsync(vpnServerId, ct) 
+        return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(vpnServerId, ct) 
                ?? throw new InvalidOperationException("OpenVPN File Server Config not found");
     }
     
     private async Task<string> MakeFriendlyName(int vpnServerId, string commonName, CancellationToken ct)
     {
-        var vpnServer = await openVpnServerQueryService.GetByIdAsync(vpnServerId, ct)
+        var vpnServer = await openVpnServerQueryService.GetById(vpnServerId, ct)
                         ?? throw new InvalidOperationException("OpenVPN Server not found");
 
         var lastNumber = ExtractLastNumber(commonName);
@@ -420,5 +420,10 @@ public class OvpnFileApiService(
     {
         var match = Regex.Match(input, @"(\d+)$");
         return match.Success ? match.Value : null;
+    }
+    
+    public Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileRequest request, CancellationToken cancellationToken, bool isRevoked = false)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
@@ -422,8 +422,61 @@ public class OvpnFileApiService(
         return match.Success ? match.Value : null;
     }
     
-    public Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileRequest request, CancellationToken cancellationToken, bool isRevoked = false)
+    public async Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileRequest request, CancellationToken ct, 
+        bool isRevoked = false)
     {
-        throw new NotImplementedException();
+        logger.LogInformation("Start downloading OVPN file:" +
+                              " VpnServerId={VpnServerId}, IssuedOvpnFileId={IssuedOvpnFileId}",
+            request.VpnServerId, request.IssuedOvpnFileId);
+
+        var issuedOvpnFile = await issuedOvpnFileQueryService
+                .GetByIdAndVpnServerIdAndIsRevoked(
+                    request.IssuedOvpnFileId,
+                    request.VpnServerId,
+                    isRevoked,
+                    ct)
+            ?? throw new InvalidOperationException(
+                $"Issued OVPN file not found. " +
+                $"Requested IssuedOvpnFileId={request.IssuedOvpnFileId}, " +
+                $"VpnServerId={request.VpnServerId}, " +
+                $"IsRevoked={isRevoked}. " +
+                "Possible reasons: the file does not exist, belongs to another server, " +
+                "or its revoke state does not match the requested one.");
+
+        var requestApi =
+            new DownloadOvpnFileRequest()
+            {
+                CommonName = issuedOvpnFile.CommonName,
+                FileName = issuedOvpnFile.FileName,
+                FilePath = issuedOvpnFile.FilePath
+            };
+        var result = await ovpnFileApiClient.DownloadOvpnFile(
+            request.VpnServerId, requestApi, ct);
+
+        if (result.Content == null)
+        {
+            logger.LogError(
+                "Downloaded OVPN file content is null: FileName={FileName}, CommonName={CommonName}",
+                result.FileName,
+                result.CommonName);
+
+            throw new InvalidOperationException(
+                "Downloaded OVPN file content is null. " +
+                $"FileName={result.FileName}, CommonName={result.CommonName}.");
+        }
+
+        logger.LogInformation("Successfully downloaded OVPN file: FileName={FileName}, Size={Size} bytes",
+            result.FileName, result.Content.LongLength);
+        
+        await ovpnFileNotificationService.NotifyDownloaded(
+            issuedOvpnFile.VpnServerId, issuedOvpnFile.FileName, issuedOvpnFile.ExternalId,
+            isRevoked, /* todo: user ID*/ ct);
+
+        return new DownloadFileResponse
+        {
+            IssuedOvpn = issuedOvpnFile.Adapt<IssuedOvpnFileDto>(),
+            FileSizeBytes = result.Content.LongLength,
+            Content = result.Content
+        };
     }
 }

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
@@ -426,18 +426,18 @@ public class OvpnFileApiService(
         bool isRevoked = false)
     {
         logger.LogInformation("Start downloading OVPN file:" +
-                              " VpnServerId={VpnServerId}, IssuedOvpnFileId={IssuedOvpnFileId}",
-            request.VpnServerId, request.IssuedOvpnFileId);
+                              " VpnServerId={VpnServerId}, CommonName={CommonName}",
+            request.VpnServerId, request.CommonName);
 
         var issuedOvpnFile = await issuedOvpnFileQueryService
-                .GetByIdAndVpnServerIdAndIsRevoked(
-                    request.IssuedOvpnFileId,
+                .GetByCommonNameAndVpnServerIdAndIsRevoked(
+                    request.CommonName,
                     request.VpnServerId,
                     isRevoked,
                     ct)
             ?? throw new InvalidOperationException(
                 $"Issued OVPN file not found. " +
-                $"Requested IssuedOvpnFileId={request.IssuedOvpnFileId}, " +
+                $"Requested CommonName={request.CommonName}, " +
                 $"VpnServerId={request.VpnServerId}, " +
                 $"IsRevoked={isRevoked}. " +
                 "Possible reasons: the file does not exist, belongs to another server, " +

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
@@ -422,7 +422,7 @@ public class OvpnFileApiService(
         return match.Success ? match.Value : null;
     }
     
-    public async Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileRequest request, CancellationToken ct, 
+    public async Task<DownloadFileResponse> DownloadOvpnFileByCn(DownloadFileByCnRequest request, CancellationToken ct, 
         bool isRevoked = false)
     {
         logger.LogInformation("Start downloading OVPN file:" +

--- a/OpenVPNGateMonitor/Services/Others/INotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/INotificationService.cs
@@ -12,7 +12,7 @@ public interface INotificationService
     /// If <paramref name="channels"/> is null or empty, all available channels are used.
     /// Returns the created notification ID.
     /// </summary>
-    Task<int> NotifyAdminsAsync(
+    Task<int> NotifyAdmins(
         NotificationRequest request,
         IEnumerable<string>? channels = null,
         CancellationToken ct = default);
@@ -20,7 +20,7 @@ public interface INotificationService
     /// <summary>
     /// Marks a notification as successfully delivered ("sent") for a specific admin and channel.
     /// </summary>
-    Task MarkDeliveredAsync(
+    Task MarkDelivered(
         int notificationId,
         int adminUserId,
         string channel,
@@ -29,7 +29,7 @@ public interface INotificationService
     /// <summary>
     /// Marks a notification as read by the specified admin (for all channels).
     /// </summary>
-    Task MarkReadAsync(
+    Task MarkRead(
         int notificationId,
         int adminUserId,
         CancellationToken ct = default);

--- a/OpenVPNGateMonitor/Services/Others/INotifier.cs
+++ b/OpenVPNGateMonitor/Services/Others/INotifier.cs
@@ -15,5 +15,5 @@ public interface INotifier
     /// <param name="notification">Notification entity to send.</param>
     /// <param name="adminUserId">Recipient admin user ID.</param>
     /// <param name="ct">Cancellation token.</param>
-    Task SendAsync(Notification notification, int adminUserId, CancellationToken ct);
+    Task Send(Notification notification, int adminUserId, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor/Services/Others/NotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/NotificationService.cs
@@ -15,13 +15,13 @@ public class NotificationService(
     ILogger<NotificationService> logger
 ) : INotificationService
 {
-    public async Task<int> NotifyAdminsAsync(
+    public async Task<int> NotifyAdmins(
         NotificationRequest request,
         IEnumerable<string>? channels = null,
         CancellationToken ct = default)
     {
         // 1) Resolve recipients (all admins from Telegram users for now)
-        var admins = await telegramBotUserQueryService.GetAllAdminsAsync(ct) ?? new List<TelegramBotUser>();
+        var admins = await telegramBotUserQueryService.GetAllAdmins(ct) ?? new List<TelegramBotUser>();
         if (admins.Count == 0)
         {
             logger.LogError("No admins found. Skipping notification: {Type} - {Title}", request.Type, request.Title);
@@ -61,7 +61,7 @@ public class NotificationService(
             LastUpdate = now
         };
 
-        var created = await notificationCommandServices.AddAsync(notification, saveChanges: true, ct);
+        var created = await notificationCommandServices.Add(notification, saveChanges: true, ct);
         var notificationId = created.Id;
 
         // 4) Persist recipients (admin × channel)
@@ -78,7 +78,7 @@ public class NotificationService(
                           }).ToList();
 
         if (recipients.Count > 0)
-            await notificationRecipientCommandServices.AddRangeAsync(recipients, saveChanges: true, ct);
+            await notificationRecipientCommandServices.AddRange(recipients, saveChanges: true, ct);
 
         // 5) Fan-out sending (best-effort)
         if (activeNotifiers.Count > 0)
@@ -88,7 +88,7 @@ public class NotificationService(
             {
                 foreach (var notifier in activeNotifiers)
                 {
-                    tasks.Add(SendSafeAsync(notifier, created, admin.Id, ct));
+                    tasks.Add(SendSafe(notifier, created, admin.Id, ct));
                 }
             }
 
@@ -105,10 +105,10 @@ public class NotificationService(
         return notificationId;
     }
 
-    public Task MarkDeliveredAsync(int notificationId, int adminUserId, string channel, CancellationToken ct = default)
+    public Task MarkDelivered(int notificationId, int adminUserId, string channel, CancellationToken ct = default)
     {
         // Update status to Sent (successfully delivered)
-        return notificationRecipientCommandServices.UpdateWhereAsync(
+        return notificationRecipientCommandServices.UpdateWhere(
             predicate: r => r.NotificationId == notificationId
                             && r.AdminUserId == adminUserId
                             && r.DeliveryChannel == channel,
@@ -120,10 +120,10 @@ public class NotificationService(
         );
     }
 
-    public Task MarkReadAsync(int notificationId, int adminUserId, CancellationToken ct = default)
+    public Task MarkRead(int notificationId, int adminUserId, CancellationToken ct = default)
     {
         // Mark as read (applies to all recipient channels for this admin)
-        return notificationRecipientCommandServices.UpdateWhereAsync(
+        return notificationRecipientCommandServices.UpdateWhere(
             predicate: r => r.NotificationId == notificationId
                             && r.AdminUserId == adminUserId,
             set: calls => calls
@@ -137,14 +137,14 @@ public class NotificationService(
     // ----------------------
     // Helpers
     // ----------------------
-    private async Task SendSafeAsync(INotifier notifier, Notification notification, int adminUserId, CancellationToken ct)
+    private async Task SendSafe(INotifier notifier, Notification notification, int adminUserId, CancellationToken ct)
     {
         try
         {
-            await notifier.SendAsync(notification, adminUserId, ct);
+            await notifier.Send(notification, adminUserId, ct);
 
             // mark as Sent on success
-            await notificationRecipientCommandServices.UpdateWhereAsync(
+            await notificationRecipientCommandServices.UpdateWhere(
                 predicate: r => r.NotificationId == notification.Id
                                 && r.AdminUserId == adminUserId
                                 && r.DeliveryChannel == notifier.Channel,
@@ -169,7 +169,7 @@ public class NotificationService(
                 notification.Id, notifier.Channel, adminUserId);
 
             // mark as Failed
-            await notificationRecipientCommandServices.UpdateWhereAsync(
+            await notificationRecipientCommandServices.UpdateWhere(
                 predicate: r => r.NotificationId == notification.Id
                                 && r.AdminUserId == adminUserId
                                 && r.DeliveryChannel == notifier.Channel,

--- a/OpenVPNGateMonitor/Services/Others/Notifications/AppNotificationFacade.cs
+++ b/OpenVPNGateMonitor/Services/Others/Notifications/AppNotificationFacade.cs
@@ -4,33 +4,33 @@ public class AppNotificationFacade(
     INotificationService notificationService,
     INotificationCatalog catalog) : IAppNotificationFacade
 {
-    public Task SystemExceptionAsync(Exception ex, CancellationToken ct)
+    public Task SystemException(Exception ex, CancellationToken ct)
     {
         var env = catalog.SystemException(ex);
-        return notificationService.NotifyAdminsAsync(env.Request, env.Channels, ct);
+        return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
     }
 
-    public Task FileCreatedAsync(int actorUserId, string fileName, CancellationToken ct)
+    public Task FileCreated(int actorUserId, string fileName, CancellationToken ct)
     {
         var env = catalog.FileCreated(actorUserId, fileName);
-        return notificationService.NotifyAdminsAsync(env.Request, env.Channels, ct);
+        return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
     }
 
-    public Task CertIssuedAsync(int actorUserId, string commonName, int? serverId, CancellationToken ct)
+    public Task CertIssued(int actorUserId, string commonName, int? serverId, CancellationToken ct)
     {
         var env = catalog.CertIssued(actorUserId, commonName, serverId);
-        return notificationService.NotifyAdminsAsync(env.Request, env.Channels, ct);
+        return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
     }
 
-    public Task ServerDownAsync(int serverId, string serverName, CancellationToken ct)
+    public Task ServerDown(int serverId, string serverName, CancellationToken ct)
     {
         var env = catalog.ServerDown(serverId, serverName);
-        return notificationService.NotifyAdminsAsync(env.Request, env.Channels, ct);
+        return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
     }
 
-    public Task ServerUpAsync(int serverId, string serverName, CancellationToken ct)
+    public Task ServerUp(int serverId, string serverName, CancellationToken ct)
     {
         var env = catalog.ServerUp(serverId, serverName);
-        return notificationService.NotifyAdminsAsync(env.Request, env.Channels, ct);
+        return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
     }
 }

--- a/OpenVPNGateMonitor/Services/Others/Notifications/CertApiClient/CertificateNotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/Notifications/CertApiClient/CertificateNotificationService.cs
@@ -49,7 +49,7 @@ public class CertificateNotificationService(INotificationService notifications)
     // ---- helper ----
     private Task Notify(string type, string title, string message, int serverId,
         NotificationSeverity severity, string[] channels, CancellationToken ct, int? actorUserId = null)
-        => notifications.NotifyAdminsAsync(new NotificationRequest
+        => notifications.NotifyAdmins(new NotificationRequest
         {
             Type = type,
             Title = title,

--- a/OpenVPNGateMonitor/Services/Others/Notifications/IAppNotificationFacade.cs
+++ b/OpenVPNGateMonitor/Services/Others/Notifications/IAppNotificationFacade.cs
@@ -2,9 +2,9 @@ namespace OpenVPNGateMonitor.Services.Others.Notifications;
 
 public interface IAppNotificationFacade
 {
-    Task SystemExceptionAsync(Exception ex, CancellationToken ct);
-    Task FileCreatedAsync(int actorUserId, string fileName, CancellationToken ct);
-    Task CertIssuedAsync(int actorUserId, string commonName, int? serverId, CancellationToken ct);
-    Task ServerDownAsync(int serverId, string serverName, CancellationToken ct);
-    Task ServerUpAsync(int serverId, string serverName, CancellationToken ct);
+    Task SystemException(Exception ex, CancellationToken ct);
+    Task FileCreated(int actorUserId, string fileName, CancellationToken ct);
+    Task CertIssued(int actorUserId, string commonName, int? serverId, CancellationToken ct);
+    Task ServerDown(int serverId, string serverName, CancellationToken ct);
+    Task ServerUp(int serverId, string serverName, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor/Services/Others/Notifications/OvpnFileApi/IOvpnFileNotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/Notifications/OvpnFileApi/IOvpnFileNotificationService.cs
@@ -3,26 +3,26 @@
 
 public interface IOvpnFileNotificationService
 {
-    Task NotifyReadByTokenAsync(string token, int fileId, int vpnServerId, bool isRevoked, CancellationToken ct);
-    Task NotifyReadAllAsync(int vpnServerId, int count, CancellationToken ct);
-    Task NotifyReadAllWithTokenAsync(int vpnServerId, int count, bool isRevoked, CancellationToken ct);
+    Task NotifyReadByToken(string token, int fileId, int vpnServerId, bool isRevoked, CancellationToken ct);
+    Task NotifyReadAll(int vpnServerId, int count, CancellationToken ct);
+    Task NotifyReadAllWithToken(int vpnServerId, int count, bool isRevoked, CancellationToken ct);
 
-    Task NotifyReadByExternalIdAsync(string externalId, int count, CancellationToken ct);
-    Task NotifyReadByExternalIdAndVpnServerIdAsync(int vpnServerId, string externalId, int count, bool isRevoked,
+    Task NotifyReadByExternalId(string externalId, int count, CancellationToken ct);
+    Task NotifyReadByExternalIdAndVpnServerId(int vpnServerId, string externalId, int count, bool isRevoked,
         CancellationToken ct);
 
-    Task NotifyReadByExternalIdWithTokenAsync(int vpnServerId, string externalId, int count, bool isRevoked,
+    Task NotifyReadByExternalIdWithToken(int vpnServerId, string externalId, int count, bool isRevoked,
         CancellationToken ct);
 
-    Task NotifyIssuedAsync(int vpnServerId, int fileId, string fileName, string externalId, /*todo: int actorUserId,*/
+    Task NotifyIssued(int vpnServerId, int fileId, string fileName, string externalId, /*todo: int actorUserId,*/
         CancellationToken ct);
 
-    Task NotifyIssuedWithTokenAsync(int vpnServerId, int fileId, string fileName, string externalId,
+    Task NotifyIssuedWithToken(int vpnServerId, int fileId, string fileName, string externalId,
         int tokenId, /*todo: int actorUserId,*/ CancellationToken ct);
 
-    Task NotifyRevokedAsync(int vpnServerId, int fileId, string fileName, string externalId, /*todo: int actorUserId,*/
+    Task NotifyRevoked(int vpnServerId, int fileId, string fileName, string externalId, /*todo: int actorUserId,*/
         CancellationToken ct);
 
-    Task NotifyDownloadedAsync(int vpnServerId, string fileName, string externalId, /*todo: int actorUserId,*/
+    Task NotifyDownloaded(int vpnServerId, string fileName, string externalId, /*todo: int actorUserId,*/
         bool isRevoked, CancellationToken ct);
 }

--- a/OpenVPNGateMonitor/Services/Others/Notifications/OvpnFileApi/OvpnFileNotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/Notifications/OvpnFileApi/OvpnFileNotificationService.cs
@@ -8,56 +8,56 @@ public class OvpnFileNotificationService(INotificationService notifications) : I
     private static readonly string[] ReadChannels = ["web"];
     private static readonly string[] ChangeChannels = ["web", "telegram"];
 
-    public Task NotifyReadByTokenAsync(string token, int fileId, int vpnServerId, bool isRevoked, CancellationToken ct)
+    public Task NotifyReadByToken(string token, int fileId, int vpnServerId, bool isRevoked, CancellationToken ct)
         => Notify("ovpn.read.by-token", "OVPN file requested by token",
             $"Token={Short(token)}; FileId={fileId}; Revoked={isRevoked}", vpnServerId, NotificationSeverity.Info,
             ReadChannels, ct);
 
-    public Task NotifyReadAllAsync(int vpnServerId, int count, CancellationToken ct)
+    public Task NotifyReadAll(int vpnServerId, int count, CancellationToken ct)
         => Notify("ovpn.read.all", "All OVPN files requested",
             $"ServerId={vpnServerId}; Count={count}", vpnServerId, NotificationSeverity.Info, ReadChannels, ct);
 
-    public Task NotifyReadAllWithTokenAsync(int vpnServerId, int count, bool isRevoked, CancellationToken ct)
+    public Task NotifyReadAllWithToken(int vpnServerId, int count, bool isRevoked, CancellationToken ct)
         => Notify("ovpn.read.all-with-token", "All OVPN files with tokens requested",
             $"ServerId={vpnServerId}; Count={count}; Revoked={isRevoked}", vpnServerId, NotificationSeverity.Info,
             ReadChannels, ct);
 
-    public Task NotifyReadByExternalIdAsync(string externalId, int count,
+    public Task NotifyReadByExternalId(string externalId, int count,
         CancellationToken ct)
         => Notify("ovpn.read.by-external", "OVPN files requested by ExternalId",
             $"ExternalId={externalId}; Count={count};", null,
             NotificationSeverity.Info, ReadChannels, ct);
-    public Task NotifyReadByExternalIdAndVpnServerIdAsync(int vpnServerId, string externalId, int count, bool isRevoked,
+    public Task NotifyReadByExternalIdAndVpnServerId(int vpnServerId, string externalId, int count, bool isRevoked,
         CancellationToken ct)
         => Notify("ovpn.read.by-external", "OVPN files requested by ExternalId",
             $"ServerId={vpnServerId}; ExternalId={externalId}; Count={count}; Revoked={isRevoked}", vpnServerId,
             NotificationSeverity.Info, ReadChannels, ct);
 
-    public Task NotifyReadByExternalIdWithTokenAsync(int vpnServerId, string externalId, int count, bool isRevoked,
+    public Task NotifyReadByExternalIdWithToken(int vpnServerId, string externalId, int count, bool isRevoked,
         CancellationToken ct)
         => Notify("ovpn.read.by-external-with-token", "OVPN files (with tokens) requested by ExternalId",
             $"ServerId={vpnServerId}; ExternalId={externalId}; Count={count}; Revoked={isRevoked}", vpnServerId,
             NotificationSeverity.Info, ReadChannels, ct);
 
-    public Task NotifyIssuedAsync(int vpnServerId, int fileId, string fileName, string externalId, 
+    public Task NotifyIssued(int vpnServerId, int fileId, string fileName, string externalId, 
         CancellationToken ct)
         => Notify("ovpn.issued", "OVPN file issued",
             $"FileId={fileId}; FileName={fileName}; ExternalId={externalId}", vpnServerId, NotificationSeverity.Info,
             ChangeChannels, ct);
 
-    public Task NotifyIssuedWithTokenAsync(int vpnServerId, int fileId, string fileName, string externalId, int tokenId, 
+    public Task NotifyIssuedWithToken(int vpnServerId, int fileId, string fileName, string externalId, int tokenId, 
         CancellationToken ct)
         => Notify("ovpn.issued", "OVPN file (with token) issued",
             $"FileId={fileId}; FileName={fileName}; ExternalId={externalId}; TokenId={tokenId}", vpnServerId,
             NotificationSeverity.Info, ChangeChannels, ct);
 
-    public Task NotifyRevokedAsync(int vpnServerId, int fileId, string fileName, string externalId,
+    public Task NotifyRevoked(int vpnServerId, int fileId, string fileName, string externalId,
         CancellationToken ct)
         => Notify("ovpn.revoked", "OVPN file revoked",
             $"FileId={fileId}; FileName={fileName}; ExternalId={externalId}", vpnServerId, NotificationSeverity.Warning,
             ChangeChannels, ct);
 
-    public Task NotifyDownloadedAsync(int vpnServerId, string fileName, string externalId,
+    public Task NotifyDownloaded(int vpnServerId, string fileName, string externalId,
         bool isRevoked, CancellationToken ct)
         => Notify("ovpn.downloaded", "OVPN file downloaded",
             $"FileName={fileName}; ExternalId={externalId}; Revoked={isRevoked}", vpnServerId,
@@ -66,7 +66,7 @@ public class OvpnFileNotificationService(INotificationService notifications) : I
     // ---- helper ----
     private Task Notify(string type, string title, string message, int? serverId, NotificationSeverity severity,
         string[] channels, CancellationToken ct, int? actorUserId = null)
-        => notifications.NotifyAdminsAsync(new NotificationRequest
+        => notifications.NotifyAdmins(new NotificationRequest
         {
             Type = type,
             Title = title,

--- a/OpenVPNGateMonitor/Services/Others/SettingsService.cs
+++ b/OpenVPNGateMonitor/Services/Others/SettingsService.cs
@@ -13,7 +13,7 @@ public class SettingsService(
 {
     public async Task<T?> GetValueAsync<T>(string key, CancellationToken ct)
     {
-        var setting = await q.FirstOrDefaultAsync(
+        var setting = await q.FirstOrDefault(
             x => x.Key == key,
             asNoTracking: true,
             ct: ct);
@@ -35,7 +35,7 @@ public class SettingsService(
     public async Task SetValueAsync<T>(string key, T value, CancellationToken ct)
     {
         // tracked query so we can update the loaded entity
-        var setting = await q.FirstOrDefaultAsync(
+        var setting = await q.FirstOrDefault(
             x => x.Key == key,
             asNoTracking: false,
             ct: ct);
@@ -89,11 +89,11 @@ public class SettingsService(
 
         if (setting.Id.Equals(default(int)))
         {
-            await cmd.AddAsync(setting, saveChanges: true, ct);
+            await cmd.Add(setting, saveChanges: true, ct);
         }
         else
         {
-            await cmd.UpdateAsync(setting, saveChanges: true, ct);
+            await cmd.Update(setting, saveChanges: true, ct);
         }
     }
 }

--- a/OpenVPNGateMonitor/Services/Others/TelegramNotifier.cs
+++ b/OpenVPNGateMonitor/Services/Others/TelegramNotifier.cs
@@ -13,7 +13,7 @@ public class TelegramNotifier(
     private readonly ITelegramUserService _telegramUserService = telegramUserService;
     private readonly ILogger<TelegramNotifier> _logger = logger;
 
-    public Task SendAsync(Notification notification, int adminUserId, CancellationToken ct)
+    public Task Send(Notification notification, int adminUserId, CancellationToken ct)
     {
         throw new NotImplementedException();
         // var user = await _telegramUserService.GetUserByAdminIdAsync(adminUserId, ct);

--- a/OpenVPNGateMonitor/Services/Others/WebNotifier.cs
+++ b/OpenVPNGateMonitor/Services/Others/WebNotifier.cs
@@ -3,28 +3,19 @@ using OpenVPNGateMonitor.Models;
 
 namespace OpenVPNGateMonitor.Services.Others;
 
-public class WebNotifier : INotifier
+public class WebNotifier(IAdminNotificationHub hub, ILogger<WebNotifier> logger) : INotifier
 {
     public string Channel => "web";
 
-    private readonly IAdminNotificationHub _hub;
-    private readonly ILogger<WebNotifier> _logger;
-
-    public WebNotifier(IAdminNotificationHub hub, ILogger<WebNotifier> logger)
-    {
-        _hub = hub;
-        _logger = logger;
-    }
-
-    public async Task SendAsync(Notification notification, int adminUserId, CancellationToken ct)
+    public async Task Send(Notification notification, int adminUserId, CancellationToken ct)
     {
         try
         {
-            await _hub.SendNotificationAsync(adminUserId, notification, ct);
+            await hub.SendNotificationAsync(adminUserId, notification, ct);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send web notification to admin {AdminUserId}", adminUserId);
+            logger.LogError(ex, "Failed to send web notification to admin {AdminUserId}", adminUserId);
         }
     }
 }

--- a/OpenVPNGateMonitor/Services/QuotaPlans/QuotaPlanService.cs
+++ b/OpenVPNGateMonitor/Services/QuotaPlans/QuotaPlanService.cs
@@ -19,17 +19,17 @@ public class QuotaPlanService(
     // ---------- Read ----------
 
     public Task<List<QuotaPlan>> GetAllAsync(CancellationToken ct = default) =>
-        quotaPlanQueryService.GetAllAsync(ct);
+        quotaPlanQueryService.GetAll(ct);
 
     public Task<QuotaPlan?> GetByIdAsync(int id, CancellationToken ct = default) =>
-        quotaPlanQueryService.GetByIdAsync(id, ct);
+        quotaPlanQueryService.GetById(id, ct);
 
     public Task<IPagedResult<QuotaPlan>> GetPageAsync(int page, int pageSize, CancellationToken ct = default) =>
-        quotaPlanQueryService.GetPageAsync(page, pageSize, ct);
+        quotaPlanQueryService.GetPage(page, pageSize, ct);
 
     public async Task<QuotaPlan?> GetDefaultAsync(CancellationToken ct = default)
     {
-        var all = await quotaPlanQueryService.GetAllAsync(ct);
+        var all = await quotaPlanQueryService.GetAll(ct);
         return all.FirstOrDefault(x => x.IsDefault);
     }
 
@@ -48,7 +48,7 @@ public class QuotaPlanService(
             input.IsDefault = true;
         }
 
-        var created = await quotaPlanCommandService.AddAsync(input, saveChanges: true, ct);
+        var created = await quotaPlanCommandService.Add(input, saveChanges: true, ct);
         logger.LogInformation("QuotaPlan created: {Id} ({Name})", created.Id, created.Name);
         return created;
     }
@@ -65,19 +65,19 @@ public class QuotaPlanService(
             input.IsDefault = true;
         }
 
-        var affected = await quotaPlanCommandService.UpdateAsync(input, saveChanges: true, ct);
+        var affected = await quotaPlanCommandService.Update(input, saveChanges: true, ct);
         logger.LogInformation("QuotaPlan updated: {Id} ({Name}), rows: {Rows}", input.Id, input.Name, affected);
         return affected;
     }
 
     public Task<int> DeleteAsync(int id, CancellationToken ct = default) =>
-        quotaPlanCommandService.DeleteByIdAsync(id, ct);
+        quotaPlanCommandService.DeleteById(id, ct);
 
     // ---------- State toggles ----------
 
     public async Task<int> ActivateAsync(int id, CancellationToken ct = default)
     {
-        var rows = await quotaPlanCommandService.UpdateWhereAsync(
+        var rows = await quotaPlanCommandService.UpdateWhere(
             p => p.Id == id,
             set => set.SetProperty(x => x.IsActive, true),
             ct);
@@ -87,7 +87,7 @@ public class QuotaPlanService(
 
     public async Task<int> DeactivateAsync(int id, CancellationToken ct = default)
     {
-        var rows = await quotaPlanCommandService.UpdateWhereAsync(
+        var rows = await quotaPlanCommandService.UpdateWhere(
             p => p.Id == id,
             set => set.SetProperty(x => x.IsActive, false),
             ct);
@@ -106,7 +106,7 @@ public class QuotaPlanService(
         await UnsetDefaultForAllAsync(ct);
 
         // Set target plan as default
-        var rows = await quotaPlanCommandService.UpdateWhereAsync(
+        var rows = await quotaPlanCommandService.UpdateWhere(
             p => p.Id == id,
             set => set.SetProperty(x => x.IsDefault, true),
             ct);
@@ -122,7 +122,7 @@ public class QuotaPlanService(
     /// </summary>
     private Task<int> UnsetDefaultForAllAsync(CancellationToken ct)
     {
-        return quotaPlanCommandService.UpdateWhereAsync(
+        return quotaPlanCommandService.UpdateWhere(
             p => p.IsDefault,
             set => set.SetProperty(x => x.IsDefault, false),
             ct);

--- a/OpenVPNGateMonitor/Services/TelegramBot/IncomingMessageLogService.cs
+++ b/OpenVPNGateMonitor/Services/TelegramBot/IncomingMessageLogService.cs
@@ -21,7 +21,7 @@ public class IncomingMessageLogService(ILogger<IncomingMessageLogService> logger
         var incomingMessageLog = request.Message.Adapt<IncomingMessageLog>();
 
         // Save message to DB
-        await incomingMessageLogCommandService.AddAsync(incomingMessageLog, true, ct);
+        await incomingMessageLogCommandService.Add(incomingMessageLog, true, ct);
     
         logger.LogInformation($"Saved incoming message from TelegramId: {request.Message!.TelegramId}");
 
@@ -36,7 +36,7 @@ public class IncomingMessageLogService(ILogger<IncomingMessageLogService> logger
 
     public async Task<MessageDto?> GetByIdAsync(int id, CancellationToken ct)
     {
-        var message = await incomingMessageLogQueryService.GetByIdAsync(id, ct);
+        var message = await incomingMessageLogQueryService.GetById(id, ct);
         if (message == null)
             return null;
 

--- a/OpenVPNGateMonitor/Services/TelegramBot/LocalizationService.cs
+++ b/OpenVPNGateMonitor/Services/TelegramBot/LocalizationService.cs
@@ -31,7 +31,7 @@ public class LocalizationService(ILogger<LocalizationService> logger,
             userPreference = request.Adapt<TelegramUserLanguagePreference>();
             logger.LogInformation($"New language preference created for TelegramId: {userPreference.TelegramId} " +
                                   $"with language: {userPreference.PreferredLanguage}.");
-            await telegramUserLanguagePreferenceCommandService.AddAsync(userPreference, true, ct);
+            await telegramUserLanguagePreferenceCommandService.Add(userPreference, true, ct);
         
 
         }
@@ -41,7 +41,7 @@ public class LocalizationService(ILogger<LocalizationService> logger,
                                   $"Updating language to: {request.PreferredLanguage}.");
         
             userPreference.PreferredLanguage = request.PreferredLanguage;
-            await telegramUserLanguagePreferenceCommandService.UpdateAsync(userPreference, true, ct);
+            await telegramUserLanguagePreferenceCommandService.Update(userPreference, true, ct);
 
         }
         
@@ -82,7 +82,7 @@ public class LocalizationService(ILogger<LocalizationService> logger,
             language = telegramUserLanguagePreference?.PreferredLanguage ?? Language.English;
         }
 
-        var text = await localizationTextQueryService.GetTextValueByKeyAndLanguageAsync(key, (Language)language, ct);
+        var text = await localizationTextQueryService.GetTextValueByKeyAndLanguage(key, (Language)language, ct);
 
         return text ?? $"[Translation missing for key: {key}, language: {language}]";
     }

--- a/OpenVPNGateMonitor/Services/TelegramBot/TelegramUserService.cs
+++ b/OpenVPNGateMonitor/Services/TelegramBot/TelegramUserService.cs
@@ -18,7 +18,7 @@ public class TelegramUserService(
         CancellationToken ct)
     {
         var telegramBotUser = await telegramBotUserQueryService
-            .GetByTelegramIdAsync(telegramBotUserRequest.TelegramId, ct);
+            .GetByTelegramId(telegramBotUserRequest.TelegramId, ct);
 
         var now = DateTimeOffset.UtcNow;
 
@@ -28,7 +28,7 @@ public class TelegramUserService(
             user.CreateDate = now;
             user.LastUpdate = now;
 
-            await telegramBotUserCommandService.AddAsync(user, saveChanges: true, ct);
+            await telegramBotUserCommandService.Add(user, saveChanges: true, ct);
             logger.LogInformation("User {TelegramId} registered", telegramBotUserRequest.TelegramId);
             return user;
         }
@@ -36,7 +36,7 @@ public class TelegramUserService(
         telegramBotUserRequest.Adapt(telegramBotUser);
         telegramBotUser.LastUpdate = now;
 
-        await telegramBotUserCommandService.UpdateAsync(telegramBotUser, saveChanges: true, ct);
+        await telegramBotUserCommandService.Update(telegramBotUser, saveChanges: true, ct);
         logger.LogInformation("User {TelegramId} updated", telegramBotUserRequest.TelegramId);
 
         return telegramBotUser;
@@ -45,7 +45,7 @@ public class TelegramUserService(
     public async Task<TelegramBotUser> GetUserAsync(long telegramId, CancellationToken cancellationToken)
     {
         return await telegramBotUserQueryService
-            .GetByTelegramIdAsync(telegramId, cancellationToken) 
+            .GetByTelegramId(telegramId, cancellationToken) 
                ?? throw new InvalidOperationException("Telegram user not found");
     }
 
@@ -57,7 +57,7 @@ public class TelegramUserService(
 
     public async Task<List<TelegramBotUser>?> GetAdminsAsync(CancellationToken ct)
     {
-        var telegramBotUser = await telegramBotUserQueryService.GetAllAdminsAsync(ct);
+        var telegramBotUser = await telegramBotUserQueryService.GetAllAdmins(ct);
 
         if (telegramBotUser is { Count: 0 })
         {
@@ -70,20 +70,20 @@ public class TelegramUserService(
 
     public async Task<List<TelegramBotUser>?> GetAllUsersAsync(CancellationToken ct)
     {
-        var telegramBotUser = await telegramBotUserQueryService.GetAllAsync(ct);
+        var telegramBotUser = await telegramBotUserQueryService.GetAll(ct);
         return telegramBotUser.OrderBy(x => x.Id).ToList();
     }
 
     public async Task<TelegramBotUser?> GetUserByTelegramIdAsync(long telegramId, CancellationToken ct)
     {
-        var user = await telegramBotUserQueryService.GetByTelegramIdAsync(telegramId, ct);
+        var user = await telegramBotUserQueryService.GetByTelegramId(telegramId, ct);
 
         return user;
     }
 
     public async Task<bool> BlockUserAsync(long telegramId, CancellationToken ct)
     {
-        var user = await telegramBotUserQueryService.GetByTelegramIdAsync(telegramId, ct);
+        var user = await telegramBotUserQueryService.GetByTelegramId(telegramId, ct);
         if (user == null)
         {
             logger.LogWarning("Attempted to block non-existent user with TelegramId: {TelegramId}", telegramId);
@@ -98,14 +98,14 @@ public class TelegramUserService(
 
         user.IsBlocked = true;
         user.LastUpdate = DateTimeOffset.UtcNow;
-        await telegramBotUserCommandService.UpdateAsync(user, saveChanges: true, ct);
+        await telegramBotUserCommandService.Update(user, saveChanges: true, ct);
         logger.LogInformation("User {TelegramId} has been blocked.", telegramId);
         return true;
     }
 
     public async Task<bool> UnblockUserAsync(long telegramId, CancellationToken ct)
     {
-        var user = await telegramBotUserQueryService.GetByTelegramIdAsync(telegramId, ct);
+        var user = await telegramBotUserQueryService.GetByTelegramId(telegramId, ct);
         if (user == null)
         {
             logger.LogWarning("Attempted to unblock non-existent user with TelegramId: {TelegramId}", telegramId);
@@ -120,14 +120,14 @@ public class TelegramUserService(
 
         user.IsBlocked = false;
         user.LastUpdate = DateTimeOffset.UtcNow;
-        await telegramBotUserCommandService.UpdateAsync(user, saveChanges: true, ct);
+        await telegramBotUserCommandService.Update(user, saveChanges: true, ct);
         logger.LogInformation("User {TelegramId} has been unblocked.", telegramId);
         return true;
     }
 
     public async Task<bool> SetAdminAsync(long telegramId, CancellationToken ct)
     {
-        var user = await telegramBotUserQueryService.GetByTelegramIdAsync(telegramId, ct);
+        var user = await telegramBotUserQueryService.GetByTelegramId(telegramId, ct);
         if (user == null)
         {
             logger.LogWarning("Attempted to set admin for non-existent user with TelegramId: {TelegramId}", telegramId);
@@ -142,14 +142,14 @@ public class TelegramUserService(
 
         user.IsAdmin = true;
         user.LastUpdate = DateTimeOffset.UtcNow;
-        await telegramBotUserCommandService.UpdateAsync(user, saveChanges: true, ct);
+        await telegramBotUserCommandService.Update(user, saveChanges: true, ct);
         logger.LogInformation("User {TelegramId} has been set as admin.", telegramId);
         return true;
     }
 
     public async Task<bool> UnsetAdminAsync(long telegramId, CancellationToken ct)
     {
-        var user = await telegramBotUserQueryService.GetByTelegramIdAsync(telegramId, ct);
+        var user = await telegramBotUserQueryService.GetByTelegramId(telegramId, ct);
         if (user == null)
         {
             logger.LogWarning("Attempted to unset admin for non-existent user with TelegramId: {TelegramId}",
@@ -165,7 +165,7 @@ public class TelegramUserService(
 
         user.IsAdmin = false;
         user.LastUpdate = DateTimeOffset.UtcNow;
-        await telegramBotUserCommandService.UpdateAsync(user, saveChanges: true, ct);
+        await telegramBotUserCommandService.Update(user, saveChanges: true, ct);
         logger.LogInformation("Admin rights removed from user {TelegramId}.", telegramId);
         return true;
     }

--- a/OpenVPNGateMonitor/Services/Users/UserService.cs
+++ b/OpenVPNGateMonitor/Services/Users/UserService.cs
@@ -33,7 +33,7 @@ public class UserService(
 
         // 1) Ensure TelegramBotUser exists (read via query, mutate via command)
         var telegramBotUser = await telegramBotUserQueryService
-            .GetByTelegramIdAsync(request.TelegramId, cancellationToken);
+            .GetByTelegramId(request.TelegramId, cancellationToken);
 
         if (telegramBotUser == null)
         {
@@ -43,7 +43,7 @@ public class UserService(
             telegramBotUser.IsBlocked = false;
             telegramBotUser.IsAdmin = false;
 
-            telegramBotUser = await telegramBotUserCommandService.AddAsync(telegramBotUser, saveChanges: true,
+            telegramBotUser = await telegramBotUserCommandService.Add(telegramBotUser, saveChanges: true,
                 cancellationToken);
             logger.LogInformation("Telegram user {TelegramId} created", request.TelegramId);
         }
@@ -52,12 +52,12 @@ public class UserService(
             request.Adapt(telegramBotUser);
             telegramBotUser.LastUpdate = now;
 
-            await telegramBotUserCommandService.UpdateAsync(telegramBotUser, saveChanges: true, cancellationToken);
+            await telegramBotUserCommandService.Update(telegramBotUser, saveChanges: true, cancellationToken);
             logger.LogInformation("Telegram user {TelegramId} updated", request.TelegramId);
         }
 
         // 2) Resolve dashboard User via identity link (read via query)
-        var link = await userIdentityLinkQueryService.GetByProviderAndExternalIdAsync(
+        var link = await userIdentityLinkQueryService.GetByProviderAndExternalId(
             "telegram", request.TelegramId.ToString(), cancellationToken);
 
         User user;
@@ -83,7 +83,7 @@ public class UserService(
                 LastUpdate = now
             };
 
-            user = await userCommandService.AddAsync(user, saveChanges: true, cancellationToken);
+            user = await userCommandService.Add(user, saveChanges: true, cancellationToken);
             logger.LogInformation("Dashboard user created for Telegram {TelegramId}", request.TelegramId);
 
             // Create identity link (mutate via command)
@@ -97,11 +97,11 @@ public class UserService(
                 LastUpdate = now
             };
 
-            await userIdentityLinkCommandService.AddAsync(identityLink, saveChanges: true, cancellationToken);
+            await userIdentityLinkCommandService.Add(identityLink, saveChanges: true, cancellationToken);
             logger.LogInformation("UserIdentityLink created for user {UserId}", user.Id);
 
             // Assign default quota (read default plan via query, mutate via command)
-            var defaultPlan = await quotaPlanQueryService.GetDefaultAsync(cancellationToken);
+            var defaultPlan = await quotaPlanQueryService.GetDefault(cancellationToken);
             if (defaultPlan != null)
             {
                 var quotaPlan = new UserQuotaPlan
@@ -115,14 +115,14 @@ public class UserService(
                     LastUpdate = now
                 };
 
-                await userQuotaPlanCommandService.AddAsync(quotaPlan, saveChanges: true, cancellationToken);
+                await userQuotaPlanCommandService.Add(quotaPlan, saveChanges: true, cancellationToken);
                 logger.LogInformation("Default quota plan {PlanId} assigned to user {UserId}", defaultPlan.Id, user.Id);
             }
         }
         else
         {
             // Load user via query by link.UserId
-            user = await userQueryService.GetByIdAsync(link.UserId, cancellationToken)
+            user = await userQueryService.GetById(link.UserId, cancellationToken)
                    ?? throw new InvalidOperationException($"Linked user not found: {link.UserId}");
         }
 
@@ -139,7 +139,7 @@ public class UserService(
     public async Task<GetAllUsersResponse> GetAllUsers(CancellationToken cancellationToken)
     {
         // Get all dashboard users
-        var users = await userQueryService.GetAllAsync(cancellationToken);
+        var users = await userQueryService.GetAll(cancellationToken);
 
         // NOTE: Simple and clear implementation.
         // If needed, this can be optimized later by adding a batch query for identity links.
@@ -156,7 +156,7 @@ public class UserService(
     public async Task<UsersResponse> GetUserById(GetUserByIdRequest request, CancellationToken cancellationToken)
     {
         // Load user by id or fail fast
-        var user = await userQueryService.GetByIdAsync(request.Id, cancellationToken)
+        var user = await userQueryService.GetById(request.Id, cancellationToken)
                    ?? throw new KeyNotFoundException($"User {request.Id} not found");
 
         var dto = await BuildUserDtoAsync(user, cancellationToken);
@@ -168,14 +168,14 @@ public class UserService(
     {
         // Resolve link first (provider + external id)
         var link = await userIdentityLinkQueryService
-            .GetByExternalIdAsync(request.ExternalId, cancellationToken);
+            .GetByExternalId(request.ExternalId, cancellationToken);
 
         if (link == null)
             throw new KeyNotFoundException(
                 $"Identity link not found for externalId '{request.ExternalId}'");
 
         // Load user by link
-        var user = await userQueryService.GetByIdAsync(link.UserId, cancellationToken)
+        var user = await userQueryService.GetById(link.UserId, cancellationToken)
                    ?? throw new InvalidOperationException($"Linked user not found: {link.UserId}");
 
         var dto = await BuildUserDtoAsync(user, cancellationToken);
@@ -191,7 +191,7 @@ public class UserService(
 
         // Try enrich with identity link (first link if multiple)
         // Requires IUserIdentityLinkQueryService.GetByUserIdAsync(int userId, CancellationToken ct)
-        var link = await userIdentityLinkQueryService.GetByUserIdAsync(user.Id, ct);
+        var link = await userIdentityLinkQueryService.GetByUserId(user.Id, ct);
 
         if (link != null)
         {


### PR DESCRIPTION
Removes the `Async` suffix from methods in the DataBase project.

This change provides:
- Code readability by removing the redundant suffix
- Consistency across the codebase by adopting a uniform naming convention.
- Updates download file by CN request.