### PR TITLE
Refactors notification recipient retrieval

### DIFF
--- a/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/INotificationRecipientQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/INotificationRecipientQueryService.cs
@@ -5,7 +5,7 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.NotificationRecipientTable;
 public interface INotificationRecipientQueryService
 {
     /// <summary>
-    /// Список уведомлений для админа с флагами IsRead/ReadAt (агрегация по БД).
+    /// List of notifications for an admin with IsRead/ReadAt flags (aggregation done in DB).
     /// </summary>
     Task<List<NotificationListRow>> GetNotificationListByAdminUserIdAsync(int adminUserId, CancellationToken ct = default);
     Task<int> GetUnreadCountByAdminUserIdAsync(int adminUserId, CancellationToken ct = default);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/NotificationListRow.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/NotificationListRow.cs
@@ -1,7 +1,7 @@
 namespace OpenVPNGateMonitor.DataBase.Services.Query.NotificationRecipientTable;
 
 /// <summary>
-/// Результат запроса: уведомление + агрегаты по получателю (IsRead, ReadAt) для одного admin user.
+/// Query result: notification plus recipient aggregates (IsRead, ReadAt) for one admin user.
 /// </summary>
 public record NotificationListRow(
     int Id,

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/IUserRoleQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/IUserRoleQueryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
@@ -14,4 +14,9 @@ public interface IUserRoleQueryService
     public Task<List<UserRole>> Search(
         Expression<Func<UserRole, bool>> predicate,
         CancellationToken ct);
+
+    /// <summary>
+    /// Returns list of UserIds that have the given role (e.g. dashboard admins).
+    /// </summary>
+    Task<List<int>> GetUserIdsByRoleIdAsync(int roleId, CancellationToken ct = default);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/UserRoleQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserRoleTable/UserRoleQueryService.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
@@ -26,4 +26,10 @@ public class UserRoleQueryService(
         Expression<Func<UserRole, bool>> predicate,
         CancellationToken ct)
         => q.Where(predicate, ct: ct);
+
+    public async Task<List<int>> GetUserIdsByRoleIdAsync(int roleId, CancellationToken ct = default)
+    {
+        var userRoles = await q.Where(ur => ur.RoleId == roleId, ct: ct);
+        return userRoles.Select(ur => ur.UserId).Distinct().ToList();
+    }
 }

--- a/OpenVPNGateMonitor/Controllers/AuthController.cs
+++ b/OpenVPNGateMonitor/Controllers/AuthController.cs
@@ -1,4 +1,4 @@
-﻿using System.IdentityModel.Tokens.Jwt;
+using System.IdentityModel.Tokens.Jwt;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using System.Security.Claims;

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.2.93</AssemblyVersion>
-        <FileVersion>1.0.2.93</FileVersion>
+        <AssemblyVersion>1.0.2.94</AssemblyVersion>
+        <FileVersion>1.0.2.94</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/OpenVPNGateMonitor/Services/Others/NotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/NotificationService.cs
@@ -1,8 +1,9 @@
 using OpenVPNGateMonitor.DataBase.Services.Command.Interfaces;
 using OpenVPNGateMonitor.DataBase.Services.Query.NotificationRecipientTable;
-using OpenVPNGateMonitor.DataBase.Services.Query.TelegramBotUserTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserRoleTable;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.Services.Others.Models;
+using OpenVPNGateMonitor.SharedModels.Auth;
 using OpenVPNGateMonitor.SharedModels.Enums;
 using OpenVPNGateMonitor.SharedModels.Notifications.Responses;
 
@@ -10,7 +11,7 @@ namespace OpenVPNGateMonitor.Services.Others;
 
 public class NotificationService(
     ICommandService<Notification, int> notificationCommandServices,
-    ITelegramBotUserQueryService telegramBotUserQueryService,
+    IUserRoleQueryService userRoleQueryService,
     ICommandService<NotificationRecipient, int> notificationRecipientCommandServices,
     INotificationRecipientQueryService notificationRecipientQueryService,
     Dictionary<string, INotifier> notifiersByChannel,
@@ -22,11 +23,11 @@ public class NotificationService(
         IEnumerable<string>? channels = null,
         CancellationToken ct = default)
     {
-        // 1) Resolve recipients (all admins from Telegram users for now)
-        var admins = await telegramBotUserQueryService.GetAllAdmins(ct) ?? new List<TelegramBotUser>();
-        if (admins.Count == 0)
+        // 1) Resolve recipients: users with Admin role (User.Id), same identity as dashboard and JWT
+        var adminUserIds = await userRoleQueryService.GetUserIdsByRoleIdAsync(SystemRoles.AdminId, ct);
+        if (adminUserIds.Count == 0)
         {
-            logger.LogError("No admins found. Skipping notification: {Type} - {Title}", request.Type, request.Title);
+            logger.LogError("No admins found (role Admin). Skipping notification: {Type} - {Title}", request.Type, request.Title);
             return 0;
         }
 
@@ -66,13 +67,13 @@ public class NotificationService(
         var created = await notificationCommandServices.Add(notification, saveChanges: true, ct);
         var notificationId = created.Id;
 
-        // 4) Persist recipients (admin × channel)
-        var recipients = (from admin in admins
+        // 4) Persist recipients (admin user id × channel)
+        var recipients = (from adminUserId in adminUserIds
                           from notifier in activeNotifiers
                           select new NotificationRecipient
                           {
                               NotificationId = notificationId,
-                              AdminUserId = admin.Id,
+                              AdminUserId = adminUserId,
                               DeliveryChannel = notifier.Channel,
                               DeliveryStatus = DeliveryStatus.Pending,
                               CreateDate = now,
@@ -85,12 +86,12 @@ public class NotificationService(
         // 5) Fan-out sending (best-effort)
         if (activeNotifiers.Count > 0)
         {
-            var tasks = new List<Task>(admins.Count * activeNotifiers.Count);
-            foreach (var admin in admins)
+            var tasks = new List<Task>(adminUserIds.Count * activeNotifiers.Count);
+            foreach (var adminUserId in adminUserIds)
             {
                 foreach (var notifier in activeNotifiers)
                 {
-                    tasks.Add(SendSafe(notifier, created, admin.Id, ct));
+                    tasks.Add(SendSafe(notifier, created, adminUserId, ct));
                 }
             }
 


### PR DESCRIPTION
Changes the notification service to retrieve admin user IDs based on their role,
rather than relying on a separate Telegram bot user table.

This aligns with the broader authentication strategy and allows for a unified
approach to identifying administrative users.
