### PR TITLE
Enables pagination for message retrieval.

### DIFF
--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Requests/GetAllByTelegramIdMessagesRequest.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/TelegramBotIncomingMessageLog/Requests/GetAllByTelegramIdMessagesRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 
 namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.TelegramBotIncomingMessageLog.Requests;

--- a/OpenVPNGateMonitor.Tests/Controllers/TelegramBotIncomingMessageLogControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/TelegramBotIncomingMessageLogControllerTests.cs
@@ -126,14 +126,7 @@ public class TelegramBotIncomingMessageLogControllerTests
             .Setup(q => q.GetPageByTelegramId(777, 1, 10, It.IsAny<CancellationToken>()))
             .ReturnsAsync(paged);
 
-        var req = new GetAllByTelegramIdMessagesRequest
-        {
-            TelegramId = 777,
-            Page = 1,
-            PageSize = 10
-        };
-
-        var result = await _controller.GetAllMessages(req, CancellationToken.None);
+        var result = await _controller.GetByTelegramUserId(777, 1, 10, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<GetByTelegramIdMessagesResponse>>(ok.Value);
@@ -145,6 +138,32 @@ public class TelegramBotIncomingMessageLogControllerTests
         Assert.Equal(777, response.Data!.Messages.Items[0].TelegramId);
 
         _query.Verify(q => q.GetPageByTelegramId(777, 1, 10, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByTelegramUserId_WithPageAndPageSize_PassesThemToQuery()
+    {
+        var paged = new PagedResponse<IncomingMessageLog>
+        {
+            Page = 2,
+            PageSize = 10,
+            TotalCount = 25,
+            Items = []
+        };
+        _query
+            .Setup(q => q.GetPageByTelegramId(189149160, 2, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paged);
+
+        var result = await _controller.GetByTelegramUserId(189149160, 2, 10, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<GetByTelegramIdMessagesResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data);
+        Assert.Equal(2, response.Data!.Messages.Page);
+        Assert.Equal(10, response.Data!.Messages.PageSize);
+        Assert.Equal(25, response.Data!.Messages.TotalCount);
+        _query.Verify(q => q.GetPageByTelegramId(189149160, 2, 10, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/OpenVPNGateMonitor/Controllers/TelegramBotIncomingMessageLogController.cs
+++ b/OpenVPNGateMonitor/Controllers/TelegramBotIncomingMessageLogController.cs
@@ -1,4 +1,4 @@
-﻿using Mapster;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenVPNGateMonitor.DataBase.Services.Query.IncomingMessageLogTable;
@@ -44,12 +44,14 @@ public class TelegramBotIncomingMessageLogController(
     }
     [Authorize(Roles = "Admin,App")]
     [HttpGet("get-by-telegram-userid/{telegramId}")]
-    public async Task<ActionResult<ApiResponse<GetByTelegramIdMessagesResponse>>> GetAllMessages(
-        [FromRoute] GetAllByTelegramIdMessagesRequest request, CancellationToken ct)
+    public async Task<ActionResult<ApiResponse<GetByTelegramIdMessagesResponse>>> GetByTelegramUserId(
+        [FromRoute] long telegramId,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10,
+        CancellationToken ct = default)
     {
-        var messages= await incomingMessageLogQueryService.GetPageByTelegramId(
-            request.TelegramId, request.Page, request.PageSize, ct);
-        
+        var messages = await incomingMessageLogQueryService.GetPageByTelegramId(telegramId, page, pageSize, ct);
+
         var response = new GetByTelegramIdMessagesResponse
         {
             Messages = messages.Adapt<PagedResponse<MessageDto>>()

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.2.97</AssemblyVersion>
-        <FileVersion>1.0.2.97</FileVersion>
+        <AssemblyVersion>1.0.2.98</AssemblyVersion>
+        <FileVersion>1.0.2.98</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 


### PR DESCRIPTION
Adds pagination support to the GetByTelegramUserId endpoint,
allowing users to retrieve messages in chunks.
The changes include updating the request model to accept page
and page size parameters via query parameters.
This improves performance and reduces the amount of data transferred.
