### PR TITLE
Introduces OpenVPN microservice info API

### DIFF
--- a/OpenVPNGateMonitor.DataBase/ConfigurationModels/OpenVpnServerStatusLogConfiguration.cs
+++ b/OpenVPNGateMonitor.DataBase/ConfigurationModels/OpenVpnServerStatusLogConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using OpenVPNGateMonitor.Models;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="Mapster" Version="7.4.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.88" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.89" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.88" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.89" />
     </ItemGroup>
 
 </Project>

--- a/OpenVPNGateMonitor.Models/OpenVpnServerStatusLog.cs
+++ b/OpenVPNGateMonitor.Models/OpenVpnServerStatusLog.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace OpenVPNGateMonitor.Models;
 

--- a/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/Info/ConfigInfoResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/Info/ConfigInfoResponse.cs
@@ -1,0 +1,16 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+
+public class ConfigInfoResponse
+{
+    public string? Dns1 { get; set; }
+    public string? Dns2 { get; set; }
+    public string? VpnSubnet { get; set; }
+    public string? VpnNetmask { get; set; }
+    public string? EasyRsaPath { get; set; }
+    public string? DataDir { get; set; }
+    public string? Port { get; set; }
+    public string? ApiPort { get; set; }
+    public string? Proto { get; set; }
+    public OpenVpnManagementInfoResponse? OpenVpnManagement { get; set; }
+    public string? BackendBaseUrl { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/Info/OpenVpnManagementInfoResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/Info/OpenVpnManagementInfoResponse.cs
@@ -1,0 +1,7 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+
+public class OpenVpnManagementInfoResponse
+{
+    public string? Host { get; set; }
+    public string? Port { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/Info/RootInfoResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateOpenVpnManager/Info/RootInfoResponse.cs
@@ -1,0 +1,10 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+
+public class RootInfoResponse
+{
+    public string Version { get; set; } = string.Empty;
+    public string Environment { get; set; } = string.Empty;
+    public string Application { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public ConfigInfoResponse? Config { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -20,8 +20,8 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <Version>1.0.88</Version>
-        <AssemblyVersion>1.0.88.0</AssemblyVersion>
-        <FileVersion>1.0.88.0</FileVersion>
+        <AssemblyVersion>1.0.89.0</AssemblyVersion>
+        <FileVersion>1.0.89.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,7 +19,7 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.88</Version>
+        <Version>1.0.89</Version>
         <AssemblyVersion>1.0.89.0</AssemblyVersion>
         <FileVersion>1.0.89.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>

--- a/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
+++ b/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
@@ -18,7 +18,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="8.8.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/OpenVPNGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/ServiceConfiguration.cs
@@ -80,7 +80,8 @@ public static class ServiceConfiguration
         services.AddScoped<ICertApiClient, CertApiClient>();
         services.AddScoped<IOvpnFileApiClient, OvpnFileApiClient>();
         services.AddScoped<IOvpnFileApiService, OvpnFileApiService>();
-        
+        services.AddScoped<IMicroserviceInfoService, MicroserviceInfoService>();
+
         services.AddSingleton<IOpenVpnMicroserviceClientFactory, OpenVpnMicroserviceClientFactory>();
 
         #endregion

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
@@ -1,16 +1,17 @@
-﻿using System.Net.WebSockets;
+using System.Net.WebSockets;
 using System.Text;
 using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.Services.Api.Interfaces;
 using OpenVPNGateMonitor.Services.BackgroundServices.Interfaces;
+using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Requests;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
+using OpenVPNGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
 using OpenVPNGateMonitor.SharedModels.Enums;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
@@ -21,7 +22,8 @@ namespace OpenVPNGateMonitor.Controllers;
 [Authorize]
 public class OpenVpnServersController(IVpnDataService vpnDataService,
     IOpenVpnServerOverviewQuery openVpnServerOverviewQuery, IOpenVpnServerQueryService openVpnServerQueryService,
-    IOpenVpnBackgroundService openVpnBackgroundService) : BaseController
+    IOpenVpnBackgroundService openVpnBackgroundService,
+    IMicroserviceInfoService microserviceInfoService) : BaseController
 {
     [HttpGet("get-all-with-status")]
     public async Task<ActionResult<ApiResponse<OpenVpnServerWithStatusesResponse>>> GetAllServersWithStatus(
@@ -40,6 +42,23 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
 
         return Ok(ApiResponse<OpenVpnServerWithStatusResponse>.SuccessResponse(
             serverInfo.Adapt<OpenVpnServerWithStatusResponse>()));
+    }
+
+    [HttpGet("get-microservice-info/{VpnServerId:int}")]
+    public async Task<ActionResult<ApiResponse<RootInfoResponse>>> GetMicroserviceInfo(
+        [FromRoute] int vpnServerId, CancellationToken ct)
+    {
+        var info = await microserviceInfoService.GetInfoAsync(vpnServerId, ct);
+        return Ok(ApiResponse<RootInfoResponse>.SuccessResponse(info));
+    }
+
+    [Authorize(Roles = "Admin,App")]
+    [HttpGet("get-microservice-info-by-url")]
+    public async Task<ActionResult<ApiResponse<RootInfoResponse>>> GetMicroserviceInfoByUrl(
+        [FromQuery] string baseUrl, CancellationToken ct)
+    {
+        var info = await microserviceInfoService.GetInfoByUrlAsync(baseUrl, ct);
+        return Ok(ApiResponse<RootInfoResponse>.SuccessResponse(info));
     }
 
     [HttpGet("get-all")]

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.2.98</AssemblyVersion>
-        <FileVersion>1.0.2.98</FileVersion>
+        <AssemblyVersion>1.0.2.99</AssemblyVersion>
+        <FileVersion>1.0.2.99</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -11,8 +11,8 @@
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
-        <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.0" />
+        <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.1" />
         <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
@@ -27,14 +27,14 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.88" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.89" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.4" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     </ItemGroup>
 

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IMicroserviceInfoService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/Interfaces/IMicroserviceInfoService.cs
@@ -1,0 +1,12 @@
+using OpenVPNGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+
+namespace OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+
+public interface IMicroserviceInfoService
+{
+    /// <summary>Get microservice info by VPN server id (ApiUrl from database).</summary>
+    Task<RootInfoResponse> GetInfoAsync(int vpnServerId, CancellationToken cancellationToken);
+
+    /// <summary>Get microservice info by base URL. HTTP and HTTPS allowed (endpoint is Admin/App only).</summary>
+    Task<RootInfoResponse> GetInfoByUrlAsync(string baseUrl, CancellationToken cancellationToken);
+}

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/MicroserviceInfoService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/MicroserviceInfoService.cs
@@ -1,0 +1,63 @@
+using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
+using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using OpenVPNGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+
+namespace OpenVPNGateMonitor.Services.DataGateOpenVpnManager;
+
+public class MicroserviceInfoService(
+    IHttpClientFactory httpClientFactory,
+    IOpenVpnServerQueryService openVpnServerQueryService,
+    ILogger<MicroserviceInfoService> logger) : IMicroserviceInfoService
+{
+    private const string EndpointInfo = "api/info";
+
+    public async Task<RootInfoResponse> GetInfoAsync(int vpnServerId, CancellationToken cancellationToken)
+    {
+        var server = await openVpnServerQueryService.GetById(vpnServerId, cancellationToken)
+                     ?? throw new InvalidOperationException($"OpenVPN server not found: {vpnServerId}");
+
+        if (string.IsNullOrWhiteSpace(server.ApiUrl))
+            throw new InvalidOperationException("API URL is not set for the server");
+
+        using var client = httpClientFactory.CreateClient();
+        client.BaseAddress = new Uri(server.ApiUrl.TrimEnd('/') + "/");
+
+        var response = await client.GetAsync(EndpointInfo, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<RootInfoResponse>(cancellationToken)
+                     ?? throw new InvalidOperationException("Microservice returned empty info response");
+
+        logger.LogDebug("Retrieved microservice info for VpnServerId={VpnServerId}, Version={Version}",
+            vpnServerId, result.Version);
+
+        return result;
+    }
+
+    public async Task<RootInfoResponse> GetInfoByUrlAsync(string baseUrl, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            throw new ArgumentException("Base URL is required.", nameof(baseUrl));
+
+        if (!Uri.TryCreate(baseUrl.TrimEnd('/') + "/", UriKind.Absolute, out var uri) || !uri.IsAbsoluteUri)
+            throw new ArgumentException("Invalid or relative URL.", nameof(baseUrl));
+
+        if (!string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(uri.Scheme, "http", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("Only HTTP and HTTPS URLs are allowed.", nameof(baseUrl));
+
+        using var client = httpClientFactory.CreateClient();
+        client.BaseAddress = uri;
+
+        var response = await client.GetAsync(EndpointInfo, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<RootInfoResponse>(cancellationToken)
+                     ?? throw new InvalidOperationException("Microservice returned empty info response");
+
+        logger.LogDebug("Retrieved microservice info by URL for {Host}, Version={Version}",
+            uri.Host, result.Version);
+
+        return result;
+    }
+}


### PR DESCRIPTION
Enables retrieving detailed configuration and status information from individual OpenVPN manager microservices.

*   Adds new shared models for standardizing microservice information responses.
*   Implements a dedicated service for fetching OpenVPN microservice information by server ID or directly via URL.
*   Exposes new API endpoints in the `OpenVpnServersController` to provide access to this microservice data, including an admin-only endpoint for URL-based queries.
*   Updates several NuGet packages across projects for maintenance and compatibility.
*   Bumps `OpenVPNGateMonitor.SharedModels` to version 1.0.89.