### PR TITLE
1.0.3.3

### DIFF
--- a/OpenVPNGateMonitor.DataBase/ConfigurationModels/OpenVpnServerConfiguration.cs
+++ b/OpenVPNGateMonitor.DataBase/ConfigurationModels/OpenVpnServerConfiguration.cs
@@ -31,6 +31,8 @@ public class OpenVpnServerConfiguration : BaseEntityConfiguration<OpenVpnServer,
         entity.Property(e => e.IsDeleted)
             .HasDefaultValue(false);
 
+        entity.Property(e => e.DcoIsEnabled);
+
         // Indexes
         entity.HasIndex(e => e.ServerName)
             .IsUnique();

--- a/OpenVPNGateMonitor.DataBase/Migrations/20260303163705_OpenVpnServer_DcoIsEnabled.Designer.cs
+++ b/OpenVPNGateMonitor.DataBase/Migrations/20260303163705_OpenVpnServer_DcoIsEnabled.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OpenVPNGateMonitor.DataBase.Contexts;
@@ -11,9 +12,11 @@ using OpenVPNGateMonitor.DataBase.Contexts;
 namespace OpenVPNGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260303163705_OpenVpnServer_DcoIsEnabled")]
+    partial class OpenVpnServer_DcoIsEnabled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OpenVPNGateMonitor.DataBase/Migrations/20260303163705_OpenVpnServer_DcoIsEnabled.cs
+++ b/OpenVPNGateMonitor.DataBase/Migrations/20260303163705_OpenVpnServer_DcoIsEnabled.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OpenVPNGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class OpenVpnServer_DcoIsEnabled : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "DcoIsEnabled",
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "DcoIsEnabled",
+                value: null);
+
+            migrationBuilder.UpdateData(
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "DcoIsEnabled",
+                value: null);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DcoIsEnabled",
+                schema: "xgb_dashopnvpn",
+                table: "OpenVpnServers");
+        }
+    }
+}

--- a/OpenVPNGateMonitor.Mapping/OpenVpnServers/Mappings/VpnServerMapping.cs
+++ b/OpenVPNGateMonitor.Mapping/OpenVpnServers/Mappings/VpnServerMapping.cs
@@ -19,7 +19,8 @@ public class VpnServerMapping : IRegister
             .Map(dest => dest.ApiUrl, src => src.ApiUrl)
             .Map(dest => dest.CreateDate, src => src.CreateDate)
             .Map(dest => dest.LastUpdate, src => src.LastUpdate)
-            .Map(dest => dest.IsDeleted, src => src.IsDeleted);
+            .Map(dest => dest.IsDeleted, src => src.IsDeleted)
+            .Map(dest => dest.DcoIsEnabled, src => src.DcoIsEnabled);
 
         // Mapping list → response wrapper
         config.NewConfig<List<OpenVpnServer>, OpenVpnServersResponse>()

--- a/OpenVPNGateMonitor.Models/OpenVpnManagementStatusResult.cs
+++ b/OpenVPNGateMonitor.Models/OpenVpnManagementStatusResult.cs
@@ -1,0 +1,9 @@
+namespace OpenVPNGateMonitor.Models;
+
+/// <summary>Result of parsing OpenVPN "status 3" response: client list and optional GLOBAL_STATS (e.g. dco_enabled).</summary>
+public class OpenVpnManagementStatusResult
+{
+    public List<OpenVpnServerClient> Clients { get; set; } = [];
+    /// <summary>From GLOBAL_STATS dco_enabled (0/1). Null if not present in response.</summary>
+    public bool? DcoEnabled { get; set; }
+}

--- a/OpenVPNGateMonitor.Models/OpenVpnServer.cs
+++ b/OpenVPNGateMonitor.Models/OpenVpnServer.cs
@@ -11,4 +11,6 @@ public class OpenVpnServer : BaseEntity<int>
     public double? Longitude { get; set; }
     public bool IsEnableWss { get; set; } = false;
     public bool IsDeleted { get; set; } = false;
+    /// <summary>DCO (Data Channel Offload) enabled; from OpenVPN "status 3" GLOBAL_STATS dco_enabled. Not required in DB.</summary>
+    public bool? DcoIsEnabled { get; set; }
 }

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerDto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerDto.cs
@@ -13,5 +13,7 @@ public class OpenVpnServerDto
     public DateTimeOffset CreateDate { get; set; }
     public DateTimeOffset LastUpdate { get; set; }
     public bool IsDeleted { get; set; }
+    /// <summary>DCO (Data Channel Offload) enabled; optional, not required in DB.</summary>
+    public bool? DcoIsEnabled { get; set; }
     public List<string> Tags { get; set; } = [];
 }

--- a/OpenVPNGateMonitor.Tests/Services/OpenVpnManagementInterfaces/OpenVpnClientServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/OpenVpnManagementInterfaces/OpenVpnClientServiceTests.cs
@@ -23,11 +23,11 @@ public class OpenVpnClientServiceTests
         return new OpenVpnClientService(loggerMock.Object, factoryMock.Object, geoMock.Object);
     }
 
-    private static async Task<List<OpenVpnServerClient>> InvokeParseStatusAsync(OpenVpnClientService svc, string data)
+    private static async Task<OpenVpnManagementStatusResult> InvokeParseStatusAsync(OpenVpnClientService svc, string data)
     {
         var mi = typeof(OpenVpnClientService)
             .GetMethod("ParseStatus", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var task = (Task<List<OpenVpnServerClient>>)mi.Invoke(svc, new object[] { data, CancellationToken.None })!;
+        var task = (Task<OpenVpnManagementStatusResult>)mi.Invoke(svc, new object[] { data, CancellationToken.None })!;
         return await task.ConfigureAwait(false);
     }
 
@@ -70,10 +70,12 @@ public class OpenVpnClientServiceTests
                               "END\n";
 
         // Act
-        var clientsFirst = await InvokeParseStatusAsync(svc, sample);
+        var parseResult = await InvokeParseStatusAsync(svc, sample);
+        var clientsFirst = parseResult.Clients;
 
         // Assert base parsing
         Assert.Equal(2, clientsFirst.Count);
+        Assert.True(parseResult.DcoEnabled); // GLOBAL_STATS dco_enabled 1
 
         var c1 = clientsFirst[0];
         Assert.Equal("client-a", c1.CommonName);
@@ -107,14 +109,24 @@ public class OpenVpnClientServiceTests
         Assert.NotEqual(Guid.Empty, c2.SessionId);
 
         // Act again to verify SessionId stability
-        var clientsSecond = await InvokeParseStatusAsync(svc, sample);
-        Assert.Equal(2, clientsSecond.Count);
+        var resultSecond = await InvokeParseStatusAsync(svc, sample);
+        Assert.Equal(2, resultSecond.Clients.Count);
 
-        Assert.Equal(c1.SessionId, clientsSecond[0].SessionId);
-        Assert.Equal(c2.SessionId, clientsSecond[1].SessionId);
+        Assert.Equal(c1.SessionId, resultSecond.Clients[0].SessionId);
+        Assert.Equal(c2.SessionId, resultSecond.Clients[1].SessionId);
 
         // Verify geo lookup calls occurred (2 clients x 2 invocations = 4 calls)
         geoMock.Verify(x => x.GetGeoInfoAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(4));
+    }
+
+    [Fact]
+    public async Task ParseStatus_GLOBAL_STATS_DcoEnabledZero_SetsDcoEnabledFalse()
+    {
+        var svc = CreateService(out _, out _, out _);
+        const string sample = "GLOBAL_STATS\tdco_enabled\t0\nEND\n";
+        var result = await InvokeParseStatusAsync(svc, sample);
+        Assert.Empty(result.Clients);
+        Assert.False(result.DcoEnabled);
     }
 
     [Fact]
@@ -125,7 +137,8 @@ public class OpenVpnClientServiceTests
         const string sample = "TITLE\tOpenVPN\nHEADER\tROUTING_TABLE\t...\nEND\n";
         var result = await InvokeParseStatusAsync(svc, sample);
 
-        Assert.Empty(result);
+        Assert.Empty(result.Clients);
+        Assert.Null(result.DcoEnabled);
         geoMock.Verify(x => x.GetGeoInfoAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -141,8 +154,8 @@ public class OpenVpnClientServiceTests
             "CLIENT_LIST\tclient-x\t203.0.113.5:1111\t10.0.0.2\t\t100\t200\t2025-12-03 08:00:00\t1764751200\tUNDEF\t0\t0\tAES-256-GCM\n";
 
         var result = await InvokeParseStatusAsync(svc, sample);
-        Assert.Single(result);
-        var c = result[0];
+        Assert.Single(result.Clients);
+        var c = result.Clients[0];
         Assert.Equal("client-x", c.CommonName);
         Assert.Equal("203.0.113.5:1111", c.RemoteIp);
         Assert.Equal("10.0.0.2", c.LocalIp);
@@ -168,8 +181,8 @@ public class OpenVpnClientServiceTests
             "CLIENT_LIST\tclient-y\t198.51.100.10:2222\t10.0.0.3\t\t1\t2\t2025-12-03 09:10:11\t1764753011\tuser-y\t0\t0\tAES-256-GCM\n";
 
         var result = await InvokeParseStatusAsync(svc, sample);
-        Assert.Single(result);
-        Assert.Equal("user-y", result[0].Username);
+        Assert.Single(result.Clients);
+        Assert.Equal("user-y", result.Clients[0].Username);
     }
 
     [Fact]
@@ -178,7 +191,7 @@ public class OpenVpnClientServiceTests
         var svc = CreateService(out var geoMock, out _, out _);
         const string sample = "CLIENT_LIST\tclient-z\t203.0.113.9:3333\t10.0.0.4\n"; // < 8 columns
         var result = await InvokeParseStatusAsync(svc, sample);
-        Assert.Empty(result);
+        Assert.Empty(result.Clients);
         geoMock.Verify(x => x.GetGeoInfoAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -278,9 +291,9 @@ public class OpenVpnClientServiceTests
             "CLIENT_LIST\tok\t203.0.113.5:1234\t10.0.0.8\t\t10\t20\t2025-12-03 02:02:02\t1764750322\tUNDEF\t0\t0\tAES\n";
 
         var result = await InvokeParseStatusAsync(svc, sample);
-        Assert.Single(result);
-        Assert.Equal("ok", result[0].CommonName);
-        Assert.Equal("203.0.113.5:1234", result[0].RemoteIp);
+        Assert.Single(result.Clients);
+        Assert.Equal("ok", result.Clients[0].CommonName);
+        Assert.Equal("203.0.113.5:1234", result.Clients[0].RemoteIp);
         geoMock.Verify(x => x.GetGeoInfoAsync("203.0.113.5:1234", It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -341,11 +354,11 @@ public class OpenVpnClientServiceTests
         var result = await svc.GetClientsFromManagementAsync(server, CancellationToken.None);
 
         // Assert
-        Assert.Equal(2, result.Count);
-        Assert.Equal("client-a", result[0].CommonName);
-        Assert.Equal("client-b", result[1].CommonName);
-        Assert.Equal("DE", result[0].Country);
-        Assert.Equal("RU", result[1].Country);
+        Assert.Equal(2, result.Clients.Count);
+        Assert.Equal("client-a", result.Clients[0].CommonName);
+        Assert.Equal("client-b", result.Clients[1].CommonName);
+        Assert.Equal("DE", result.Clients[0].Country);
+        Assert.Equal("RU", result.Clients[1].Country);
 
         factory.Verify(f => f.Create(server), Times.Once);
         client.Verify(c => c.SendCommandWithResponseAsync("status 3", It.IsAny<CancellationToken>()), Times.Once);
@@ -388,7 +401,7 @@ public class OpenVpnClientServiceTests
         var result = await svc.GetClientsFromManagementAsync(server, CancellationToken.None);
 
         // Assert
-        Assert.Empty(result);
+        Assert.Empty(result.Clients);
         geo.Verify(g => g.GetGeoInfoAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         factory.VerifyAll();
         client.VerifyAll();

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.3.2</AssemblyVersion>
-        <FileVersion>1.0.3.2</FileVersion>
+        <AssemblyVersion>1.0.3.3</AssemblyVersion>
+        <FileVersion>1.0.3.3</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerService.cs
+++ b/OpenVPNGateMonitor/Services/BackgroundServices/OpenVpnServerService.cs
@@ -25,6 +25,7 @@ public class OpenVpnServerService(
     IExternalIpAddressService externalIpAddressService,
     ITransactionRunner transactionRunner,
     IUserQueryService userQueryService,
+    ICommandService<OpenVpnServer, int> openVpnServerCommandService,
     ICommandService<OpenVpnServerClient, int> openVpnServerClientCommandService,
     ICommandService<OpenVpnServerStatusLog, int> openVpnServerStatusLogCommandService,
     ICommandService<OpenVpnServerClientTraffic, int> openVpnClientTrafficCommandService) : IOpenVpnServerService
@@ -35,9 +36,19 @@ public class OpenVpnServerService(
 
         await transactionRunner.RunAsync(async _ =>
         {
-            var openVpnClientsFromMng = await openVpnClientService.GetClientsFromManagementAsync(openVpnServer, ct);
+            var statusResult = await openVpnClientService.GetClientsFromManagementAsync(openVpnServer, ct);
+            var openVpnClientsFromMng = statusResult.Clients;
             logger.LogInformation("VpnServerId: {Id}. Retrieved {Count} clients from OpenVPN.",
                 openVpnServer.Id, openVpnClientsFromMng.Count);
+
+            if (statusResult.DcoEnabled.HasValue)
+            {
+                await openVpnServerCommandService.UpdateWhere(
+                    s => s.Id == openVpnServer.Id,
+                    u => u.SetProperty(x => x.DcoIsEnabled, statusResult.DcoEnabled.Value)
+                        .SetProperty(x => x.LastUpdate, DateTimeOffset.UtcNow),
+                    ct);
+            }
 
             var nowUtc = DateTimeOffset.UtcNow;
             User? user;

--- a/OpenVPNGateMonitor/Services/OpenVpnManagementInterfaces/Interfaces/IOpenVpnClientService.cs
+++ b/OpenVPNGateMonitor/Services/OpenVpnManagementInterfaces/Interfaces/IOpenVpnClientService.cs
@@ -1,9 +1,9 @@
-﻿using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Models;
 
 namespace OpenVPNGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
 
 public interface IOpenVpnClientService
 {
-    Task<List<OpenVpnServerClient>> GetClientsFromManagementAsync(OpenVpnServer openVpnServer, 
+    Task<OpenVpnManagementStatusResult> GetClientsFromManagementAsync(OpenVpnServer openVpnServer,
         CancellationToken cancellationToken);
 }

--- a/OpenVPNGateMonitor/Services/OpenVpnManagementInterfaces/OpenVpnClientService.cs
+++ b/OpenVPNGateMonitor/Services/OpenVpnManagementInterfaces/OpenVpnClientService.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using OpenVPNGateMonitor.Models;
@@ -14,7 +14,7 @@ public class OpenVpnClientService(
     IGeoLiteQueryService geoLiteQueryService)
     : IOpenVpnClientService
 {
-    public async Task<List<OpenVpnServerClient>> GetClientsFromManagementAsync(OpenVpnServer openVpnServer, 
+    public async Task<OpenVpnManagementStatusResult> GetClientsFromManagementAsync(OpenVpnServer openVpnServer,
         CancellationToken cancellationToken)
     {
         var client = openVpnMicroserviceClientFactory.Create(openVpnServer);
@@ -22,25 +22,31 @@ public class OpenVpnClientService(
 
         logger.LogDebug("Received status response:\n{Response}", response);
 
-        var clients = await ParseStatus(response, cancellationToken);
-        logger.LogInformation("Found {ClientCount} connected clients", clients.Count);
+        var result = await ParseStatus(response, cancellationToken);
+        logger.LogInformation("Found {ClientCount} connected clients", result.Clients.Count);
 
-        if (clients.Any())
+        if (result.Clients.Any())
         {
             logger.LogDebug("Connected clients: {Clients}",
-                string.Join(", ", clients.Select(c => c.CommonName)));
+                string.Join(", ", result.Clients.Select(c => c.CommonName)));
         }
 
-        return clients;
+        return result;
     }
 
-    private async Task<List<OpenVpnServerClient>> ParseStatus(string data, CancellationToken cancellationToken)
+    private async Task<OpenVpnManagementStatusResult> ParseStatus(string data, CancellationToken cancellationToken)
     {
-        var clients = new List<OpenVpnServerClient>();
+        var result = new OpenVpnManagementStatusResult();
         var lines = data.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         foreach (var line in lines)
         {
+            if (line.StartsWith("GLOBAL_STATS", StringComparison.Ordinal))
+            {
+                TryParseDcoEnabled(line, result);
+                continue;
+            }
+
             if (!line.StartsWith("CLIENT_LIST", StringComparison.Ordinal)) continue;
 
             var parts = line.Split('\t');
@@ -60,10 +66,20 @@ public class OpenVpnClientService(
             }
 
             client.SessionId = GenerateSessionId(client.CommonName, client.RemoteIp, client.ConnectedSince);
-            clients.Add(client);
+            result.Clients.Add(client);
         }
 
-        return clients;
+        return result;
+    }
+
+    /// <summary>Parse GLOBAL_STATS line: "GLOBAL_STATS\tdco_enabled\t0" or "\t1".</summary>
+    private static void TryParseDcoEnabled(string line, OpenVpnManagementStatusResult result)
+    {
+        var parts = line.Split('\t');
+        if (parts.Length < 3) return;
+        if (!string.Equals(parts[1], "dco_enabled", StringComparison.OrdinalIgnoreCase)) return;
+        if (int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var value))
+            result.DcoEnabled = value != 0;
     }
 
     private OpenVpnServerClient? TryParseClient(string[] parts)


### PR DESCRIPTION
Introduces the functionality to parse and display the DCO (Data Channel Offload) enabled flag directly from the OpenVPN status output. This enhances monitoring capabilities by providing clear visibility into whether DCO is active, which is crucial for understanding OpenVPN server configuration and potential performance characteristics.