### PR TITLE
Adds active user series reporting

### DIFF
--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\OpenVPNGateMonitor.Models\OpenVPNGateMonitor.Models.csproj" />
+      <ProjectReference Include="..\OpenVPNGateMonitor.SharedModels\OpenVPNGateMonitor.SharedModels.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/IOpenVpnOverviewSeriesQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/IOpenVpnOverviewSeriesQuery.cs
@@ -1,4 +1,4 @@
-﻿using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerClients.Responses;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerClients.Responses;
 using OpenVPNGateMonitor.SharedModels.Enums;
 
 namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerClientTable;
@@ -25,6 +25,17 @@ public interface IOpenVpnOverviewSeriesQuery
     Task<OverviewUsersResponse> GetOverviewUsersFromSessionsAsync(
         DateTimeOffset fromUtc,
         DateTimeOffset toUtc,
+        int? vpnServerId,
+        string? externalId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns time-bucketed series of session count and unique user count per bucket (same params as overview/series).
+    /// </summary>
+    Task<OverviewUsersSeriesResponse> GetOverviewUsersSeriesFromSessionsAsync(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        OverviewGrouping grouping,
         int? vpnServerId,
         string? externalId,
         CancellationToken ct = default);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnOverviewSeriesQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnOverviewSeriesQuery.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using Microsoft.EntityFrameworkCore;
 using OpenVPNGateMonitor.DataBase.UnitOfWork;
 using OpenVPNGateMonitor.Models;
@@ -269,15 +269,112 @@ public sealed class OpenVpnOverviewSeriesQuery(IUnitOfWork uow) : IOpenVpnOvervi
         return new OverviewUsersResponse() { OverviewUserItems = result };
     }
 
+    /// <summary>
+    /// Returns time-bucketed series: per bucket, count of sessions and unique users (same data source and params as overview/series).
+    /// </summary>
+    public async Task<OverviewUsersSeriesResponse> GetOverviewUsersSeriesFromSessionsAsync(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        OverviewGrouping grouping,
+        int? vpnServerId,
+        string? externalId,
+        CancellationToken ct = default)
+    {
+        if (toUtc < fromUtc) (fromUtc, toUtc) = (toUtc, fromUtc);
+
+        var offset = fromUtc.Offset;
+        var span = toUtc - fromUtc;
+        var mode = grouping == OverviewGrouping.Auto
+            ? span <= TimeSpan.FromDays(2)       ? OverviewGrouping.Hours
+            : span <= TimeSpan.FromDays(180)     ? OverviewGrouping.Days
+            : span <= TimeSpan.FromDays(36 * 30) ? OverviewGrouping.Months
+            : OverviewGrouping.Years
+            : grouping;
+
+        var q = uow.GetQuery<OpenVpnServerClientTraffic>().AsQueryable();
+
+        if (vpnServerId.HasValue)
+            q = q.Where(s => s.VpnServerId == vpnServerId.Value);
+
+        if (!string.IsNullOrWhiteSpace(externalId))
+            q = q.Where(s => s.ExternalId == externalId!);
+
+        q = q.Where(s => s.MeasuredAt >= fromUtc && s.MeasuredAt < toUtc)
+             .AsNoTracking();
+
+        var samples = await q
+            .Select(s => new TrafficSampleRow
+            {
+                VpnServerId = s.VpnServerId,
+                SessionId   = s.SessionId,
+                ExternalId  = s.ExternalId ?? "",
+                MeasuredAt  = s.MeasuredAt
+            })
+            .OrderBy(s => s.SessionId)
+            .ThenBy(s => s.MeasuredAt)
+            .ToListAsync(ct);
+
+        var buckets = new Dictionary<DateTimeOffset, UsersSeriesAccum>(capacity: 1024);
+
+        foreach (var s in samples)
+        {
+            var tsUtc = s.MeasuredAt.ToOffset(TimeSpan.Zero);
+            var bucket = AlignToBucketStartWithOffset(mode, tsUtc, offset);
+
+            ref var acc = ref GetOrAddUsersSeriesAccum(buckets, bucket);
+            acc.SeenSessions.Add(s.SessionId);
+            if (!string.IsNullOrWhiteSpace(s.ExternalId))
+                acc.SeenExternalIds.Add(s.ExternalId);
+        }
+
+        var series = buckets
+            .OrderBy(kv => kv.Key)
+            .Select(kv => new OverviewUsersSeriesRowDto
+            {
+                Ts              = kv.Key,
+                ActiveSessions  = kv.Value.SeenSessions.Count,
+                ActiveUsers     = kv.Value.SeenExternalIds.Count
+            })
+            .ToList();
+
+        series = FillMissingBucketsForUsersSeries(series, fromUtc, toUtc, mode, offset);
+
+        return new OverviewUsersSeriesResponse
+        {
+            Meta = new OverviewMetaDto
+            {
+                From        = fromUtc,
+                To          = toUtc,
+                Grouping    = mode.ToString().ToLowerInvariant(),
+                Timezone    = "UTC",
+                TrafficUnit = "bytes",
+                VpnServerId = vpnServerId
+            },
+            Summary = new OverviewUsersSeriesSummaryDto
+            {
+                PeakActiveSessions = series.Count == 0 ? 0 : series.Max(r => r.ActiveSessions),
+                PeakActiveUsers    = series.Count == 0 ? 0 : series.Max(r => r.ActiveUsers)
+            },
+            Rows = series
+        };
+    }
+
     /* ---------- internal helpers/types ---------- */
 
     private sealed class TrafficSampleRow
     {
         public int VpnServerId { get; set; }
         public Guid SessionId { get; set; }
+        public string ExternalId { get; set; } = "";
         public DateTimeOffset MeasuredAt { get; set; }
         public long BytesIn { get; set; }
         public long BytesOut { get; set; }
+    }
+
+    private sealed class UsersSeriesAccum
+    {
+        public HashSet<Guid> SeenSessions { get; } = new();
+        public HashSet<string> SeenExternalIds { get; } = new();
     }
 
     private sealed class Accum
@@ -373,5 +470,64 @@ public sealed class OpenVpnOverviewSeriesQuery(IUnitOfWork uow) : IOpenVpnOvervi
         ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out var exists);
         if (!exists) entry = new Accum();
         return ref entry!;
+    }
+
+    private static ref UsersSeriesAccum GetOrAddUsersSeriesAccum(
+        Dictionary<DateTimeOffset, UsersSeriesAccum> dict,
+        DateTimeOffset key)
+    {
+        ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(dict, key, out var exists);
+        if (!exists) entry = new UsersSeriesAccum();
+        return ref entry!;
+    }
+
+    private static List<OverviewUsersSeriesRowDto> FillMissingBucketsForUsersSeries(
+        List<OverviewUsersSeriesRowDto> rows,
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        OverviewGrouping mode,
+        TimeSpan offset)
+    {
+        var dict = rows.ToDictionary(r => r.Ts);
+        var list = new List<OverviewUsersSeriesRowDto>();
+
+        if (mode == OverviewGrouping.Months)
+        {
+            var cur = AlignToBucketStartWithOffset(OverviewGrouping.Months, fromUtc, offset);
+            var end = AlignToBucketStartWithOffset(OverviewGrouping.Months, toUtc, offset);
+            while (cur <= end)
+            {
+                if (!dict.TryGetValue(cur, out var r))
+                    r = new OverviewUsersSeriesRowDto { Ts = cur };
+                list.Add(r);
+                cur = NextBucketWithOffset(OverviewGrouping.Months, cur, offset);
+            }
+            return list;
+        }
+
+        if (mode == OverviewGrouping.Years)
+        {
+            var cur = AlignToBucketStartWithOffset(OverviewGrouping.Years, fromUtc, offset);
+            var end = AlignToBucketStartWithOffset(OverviewGrouping.Years, toUtc, offset);
+            while (cur <= end)
+            {
+                if (!dict.TryGetValue(cur, out var r))
+                    r = new OverviewUsersSeriesRowDto { Ts = cur };
+                list.Add(r);
+                cur = NextBucketWithOffset(OverviewGrouping.Years, cur, offset);
+            }
+            return list;
+        }
+
+        var curBucket = AlignToBucketStartWithOffset(mode, fromUtc, offset);
+        var endBucket = AlignToBucketStartWithOffset(mode, toUtc, offset);
+        while (curBucket <= endBucket)
+        {
+            if (!dict.TryGetValue(curBucket, out var r))
+                r = new OverviewUsersSeriesRowDto { Ts = curBucket };
+            list.Add(r);
+            curBucket = NextBucketWithOffset(mode, curBucket, offset);
+        }
+        return list;
     }
 }

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.91" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.92" />
     </ItemGroup>
 
 </Project>

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServerClients/Dto/OverviewUsersSeriesRowDto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServerClients/Dto/OverviewUsersSeriesRowDto.cs
@@ -1,0 +1,11 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerClients.Dto;
+
+/// <summary>
+/// One time bucket for users/sessions series: count of sessions and unique users in that bucket.
+/// </summary>
+public sealed class OverviewUsersSeriesRowDto
+{
+    public DateTimeOffset Ts { get; set; }
+    public int ActiveSessions { get; set; }
+    public int ActiveUsers { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServerClients/Dto/OverviewUsersSeriesSummaryDto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServerClients/Dto/OverviewUsersSeriesSummaryDto.cs
@@ -1,0 +1,7 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerClients.Dto;
+
+public class OverviewUsersSeriesSummaryDto
+{
+    public int PeakActiveSessions { get; set; }
+    public int PeakActiveUsers { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServerClients/Responses/OverviewUsersSeriesResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServerClients/Responses/OverviewUsersSeriesResponse.cs
@@ -1,0 +1,10 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerClients.Dto;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerClients.Responses;
+
+public sealed class OverviewUsersSeriesResponse
+{
+    public OverviewMetaDto Meta { get; set; } = new();
+    public OverviewUsersSeriesSummaryDto Summary { get; set; } = new();
+    public List<OverviewUsersSeriesRowDto> Rows { get; set; } = new();
+}

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,9 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.91</Version>
-        <AssemblyVersion>1.0.91.0</AssemblyVersion>
-        <FileVersion>1.0.91.0</FileVersion>
+        <Version>1.0.92</Version>
+        <AssemblyVersion>1.0.92.0</AssemblyVersion>
+        <FileVersion>1.0.92.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerClientsControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerClientsControllerTests.cs
@@ -165,4 +165,33 @@ public class OpenVpnServerClientsControllerTests
         var response = Assert.IsType<ApiResponse<OverviewUsersResponse>>(ok.Value);
         Assert.True(response.Success);
     }
+
+    [Fact]
+    public async Task GetOverviewUsersSeries_Returns_Ok()
+    {
+        _seriesQuery
+            .Setup(s => s.GetOverviewUsersSeriesFromSessionsAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<OpenVPNGateMonitor.SharedModels.Enums.OverviewGrouping>(),
+                It.IsAny<int?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OverviewUsersSeriesResponse());
+
+        var req = new GetOverviewSeriesRequest
+        {
+            From = DateTimeOffset.UtcNow.AddDays(-7),
+            To = DateTimeOffset.UtcNow,
+            Grouping = OpenVPNGateMonitor.SharedModels.Enums.OverviewGrouping.Days,
+            VpnServerId = 3,
+            ExternalId = null
+        };
+
+        var result = await _controller.GetOverviewUsersSeries(req, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<OverviewUsersSeriesResponse>>(ok.Value);
+        Assert.True(response.Success);
+    }
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnOverviewSeriesQueryTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerClientTable/OpenVpnOverviewSeriesQueryTests.cs
@@ -158,4 +158,51 @@ public class OpenVpnOverviewSeriesQueryTests
         Assert.Equal(10, u2.TrafficOutBytes);
         Assert.True(u2.FirstSeen <= u2.LastSeen);
     }
+
+    [Fact]
+    public async Task GetOverviewUsersSeriesFromSessionsAsync_Buckets_ActiveSessions_And_ActiveUsers()
+    {
+        var (uow, ctx) = CreateUow();
+        var baseTs = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var from = baseTs;
+        var to = baseTs.AddHours(2);
+
+        var sA = Guid.NewGuid();
+        var sB = Guid.NewGuid();
+
+        // u1: one session in bucket 00:00
+        ctx.Traffic.Add(
+            new OpenVpnServerClientTraffic { Id = 1, VpnServerId = 1, ExternalId = "u1", SessionId = sA, BytesReceived = 10, BytesSent = 5, MeasuredAt = baseTs.AddMinutes(15) });
+
+        // u1 again + u2 in bucket 01:00 (two users, two sessions)
+        ctx.Traffic.AddRange(new[]
+        {
+            new OpenVpnServerClientTraffic { Id = 2, VpnServerId = 1, ExternalId = "u1", SessionId = sA, BytesReceived = 20, BytesSent = 10, MeasuredAt = baseTs.AddHours(1).AddMinutes(10) },
+            new OpenVpnServerClientTraffic { Id = 3, VpnServerId = 1, ExternalId = "u2", SessionId = sB, BytesReceived = 7, BytesSent = 3, MeasuredAt = baseTs.AddHours(1).AddMinutes(30) },
+        });
+        await ctx.SaveChangesAsync();
+
+        var sut = new OpenVpnOverviewSeriesQuery(uow.Object);
+        var res = await sut.GetOverviewUsersSeriesFromSessionsAsync(from, to, OverviewGrouping.Auto, vpnServerId: 1, externalId: null, CancellationToken.None);
+
+        Assert.Equal(3, res.Rows.Count); // 00:00, 01:00, 02:00 (zero-filled)
+
+        var b0 = res.Rows[0];
+        Assert.Equal(baseTs, b0.Ts);
+        Assert.Equal(1, b0.ActiveSessions);
+        Assert.Equal(1, b0.ActiveUsers);
+
+        var b1 = res.Rows[1];
+        Assert.Equal(baseTs.AddHours(1), b1.Ts);
+        Assert.Equal(2, b1.ActiveSessions);
+        Assert.Equal(2, b1.ActiveUsers);
+
+        var b2 = res.Rows[2];
+        Assert.Equal(baseTs.AddHours(2), b2.Ts);
+        Assert.Equal(0, b2.ActiveSessions);
+        Assert.Equal(0, b2.ActiveUsers);
+
+        Assert.Equal(2, res.Summary.PeakActiveSessions);
+        Assert.Equal(2, res.Summary.PeakActiveUsers);
+    }
 }

--- a/OpenVPNGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnServerConflogServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnServerConflogServiceTests.cs
@@ -96,4 +96,41 @@ public class OpenVpnServerConflogServiceTests
             () => sut.FetchAndSaveIfChangedByServerIdAsync(5, CancellationToken.None));
         Assert.Contains("ApiUrl", ex.Message);
     }
+
+    /// <summary>
+    /// After server recreate (delete + add): new server has new Id, no conflog by VpnServerId.
+    /// Old conflog by same RequestUrl may still exist (from deleted server). We must save a new record
+    /// for the new server and must NOT use the old record to skip saving.
+    /// </summary>
+    [Fact]
+    public async Task FetchAndSaveIfChangedAsync_WhenServerRecreated_WithOldConflogBySameUrl_StillSavesNewRecord()
+    {
+        var response = new RootInfoResponse();
+        var micro = new Mock<IMicroserviceInfoService>();
+        micro.Setup(m => m.GetInfoByUrlAsync("https://host", It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+        var jsonOptions = new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase, WriteIndented = false };
+        var samePayloadJson = System.Text.Json.JsonSerializer.Serialize(response, jsonOptions);
+        var oldConflogFromDeletedServer = new OpenVpnServerConflog { Id = 1, VpnServerId = 5, RequestUrl = "https://host", PayloadJson = samePayloadJson };
+
+        var conflogQ = new Mock<IOpenVpnServerConflogQueryService>();
+        conflogQ.Setup(q => q.GetLastByVpnServerId(10, It.IsAny<CancellationToken>())).ReturnsAsync((OpenVpnServerConflog?)null);
+        conflogQ.Setup(q => q.GetLastByRequestUrl("https://host", It.IsAny<CancellationToken>())).ReturnsAsync(oldConflogFromDeletedServer);
+
+        OpenVpnServerConflog? added = null;
+        var command = new Mock<ICommandService<OpenVpnServerConflog, int>>();
+        command.Setup(c => c.Add(It.IsAny<OpenVpnServerConflog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<OpenVpnServerConflog, bool, CancellationToken>((e, _, _) => added = e)
+            .ReturnsAsync((OpenVpnServerConflog e, bool _, CancellationToken _) => { e.Id = 100; return e; });
+
+        var sut = new OpenVpnServerConflogService(micro.Object, conflogQ.Object, command.Object, Mock.Of<IOpenVpnServerQueryService>());
+        var result = await sut.FetchAndSaveIfChangedAsync("https://host", 10, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.NotNull(added);
+        Assert.Equal(10, added!.VpnServerId);
+        Assert.Equal("https://host", added.RequestUrl);
+        command.Verify(c => c.Add(It.IsAny<OpenVpnServerConflog>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        conflogQ.Verify(q => q.GetLastByRequestUrl(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServerClientsController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServerClientsController.cs
@@ -1,4 +1,4 @@
-﻿using Mapster;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerClientTable;
@@ -99,5 +99,24 @@ public class OpenVpnServerClientsController(IOpenVpnServerClientOverviewQuery op
             ct);
 
         return Ok(ApiResponse<OverviewUsersResponse>.SuccessResponse(users));
+    }
+
+    /// <summary>
+    /// Time-bucketed series of session count and unique user count per bucket. Same query params as overview/series (From, To, Grouping, VpnServerId, ExternalId).
+    /// </summary>
+    [HttpGet("overview/users/series")]
+    public async Task<ActionResult<ApiResponse<OverviewUsersSeriesResponse>>> GetOverviewUsersSeries(
+        [FromQuery] GetOverviewSeriesRequest request,
+        CancellationToken ct = default)
+    {
+        var result = await openVpnOverviewSeriesQuery.GetOverviewUsersSeriesFromSessionsAsync(
+            request.From,
+            request.To,
+            request.Grouping,
+            request.VpnServerId,
+            request.ExternalId,
+            ct);
+
+        return Ok(ApiResponse<OverviewUsersSeriesResponse>.SuccessResponse(result));
     }
 }

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.3.5</AssemblyVersion>
-        <FileVersion>1.0.3.5</FileVersion>
+        <AssemblyVersion>1.0.3.6</AssemblyVersion>
+        <FileVersion>1.0.3.6</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.3.6</AssemblyVersion>
-        <FileVersion>1.0.3.6</FileVersion>
+        <AssemblyVersion>1.0.3.7</AssemblyVersion>
+        <FileVersion>1.0.3.7</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OpenVpnServerConflogService.cs
+++ b/OpenVPNGateMonitor/Services/DataGateOpenVpnManager/OpenVpnServerConflogService.cs
@@ -28,10 +28,13 @@ public class OpenVpnServerConflogService(
         var payloadJson = JsonSerializer.Serialize(response, JsonOptions);
         var requestUrl = baseUrl.TrimEnd('/').Trim();
 
+        // When called by server id: only compare with last record for THIS server (by VpnServerId).
+        // Do not fallback to GetLastByRequestUrl — after server recreate the same URL may have old
+        // conflog from the deleted server, so we would skip saving and the new server would never get history.
         OpenVpnServerConflog? last = null;
         if (vpnServerId.HasValue)
             last = await conflogQueryService.GetLastByVpnServerId(vpnServerId.Value, ct);
-        if (last == null)
+        if (last == null && !vpnServerId.HasValue)
             last = await conflogQueryService.GetLastByRequestUrl(requestUrl, ct);
 
         if (last != null && last.PayloadJson == payloadJson)


### PR DESCRIPTION
Introduces a new API endpoint and backend logic for retrieving time-bucketed series data on active VPN sessions and unique users.

-   **Active User Series Reporting:**
    -   Provides the `overview/users/series` endpoint, allowing clients to query session and unique user counts grouped by time (e.g., hours, days).
    -   Includes robust backend logic to aggregate traffic data, identify unique sessions and users within defined time buckets, and automatically adjust grouping based on the time range.
    -   Ensures data completeness by filling in time buckets with zero values when no activity is recorded.
    -   Adds new Data Transfer Objects (DTOs) in `SharedModels` to represent the series rows, summary, and full response.
    -   Includes comprehensive unit and integration tests for the new query and controller logic.

-   **Conflog Lookup Refinement:**
    -   Corrects a logic flaw in the OpenVPN server configuration log service.
    -   Ensures that a new configuration log is always saved for a newly created or re-created server, even if a configuration log with the same request URL exists from a *previously deleted* server. This prevents new servers from lacking a configuration history.

-   **Version Updates:**
    -   Updates internal project versions and the `OpenVPNGateMonitor.SharedModels` package.