### PR TITLE
feature/allowed-servers → develop: quota-plan server access, active plan fix, user roles API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 # Set the working directory
 WORKDIR /src
 
-# Copy the project file and restore dependencies
+# Copy project files for restore. SharedModels comes from NuGet (PackageReference); that package version must be published on nuget.org.
 COPY ["OpenVPNGateMonitor/OpenVPNGateMonitor.csproj", "OpenVPNGateMonitor/"]
+COPY ["OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj", "OpenVPNGateMonitor.Models/"]
+COPY ["OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj", "OpenVPNGateMonitor.DataBase/"]
+COPY ["OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj", "OpenVPNGateMonitor.Mapping/"]
 WORKDIR /src/OpenVPNGateMonitor
 RUN dotnet restore "OpenVPNGateMonitor.csproj"
 

--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.94" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
       <PackageReference Include="Mapster" Version="10.0.3" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />

--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />

--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
+      <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
       <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.5" />

--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />

--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
       <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
-      <PackageReference Include="Mapster" Version="10.0.3" />
+      <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerOverviewQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerOverviewQuery.cs
@@ -4,7 +4,9 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 
 public interface IOpenVpnServerOverviewQuery
 {
-    Task<List<OpenVpnServerWithStatusDto>> GetAllOpenVpnServersWithStatusAsync(bool includeDeleted = false, CancellationToken ct = default);
+    /// <param name="requireQuotaPlanAssignment">When true, only servers present in <c>QuotaPlanAllowedServers</c> are returned.</param>
+    Task<List<OpenVpnServerWithStatusDto>> GetAllOpenVpnServersWithStatusAsync(bool includeDeleted = false,
+        bool requireQuotaPlanAssignment = false, CancellationToken ct = default);
     Task<OpenVpnServerWithStatusDto> GetOpenVpnServerWithStatusAsync(int vpnServerId, CancellationToken ct = default);
     Task<(int CountConnectedClients, int CountSessions)> GetClientCountersAsync(
         int vpnServerId, CancellationToken ct = default);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerOverviewQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerOverviewQuery.cs
@@ -4,9 +4,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 
 public interface IOpenVpnServerOverviewQuery
 {
-    /// <param name="requireQuotaPlanAssignment">When true, only servers present in <c>QuotaPlanAllowedServers</c> are returned.</param>
+    /// <param name="requireQuotaPlanAssignment">When true, only servers present in <c>QuotaPlanAllowedServers</c> are returned. Ignored when <paramref name="restrictToQuotaPlanId"/> is set.</param>
+    /// <param name="restrictToQuotaPlanId">When set, only servers linked to this quota plan are returned.</param>
     Task<List<OpenVpnServerWithStatusDto>> GetAllOpenVpnServersWithStatusAsync(bool includeDeleted = false,
-        bool requireQuotaPlanAssignment = false, CancellationToken ct = default);
+        bool requireQuotaPlanAssignment = false, int? restrictToQuotaPlanId = null, CancellationToken ct = default);
     Task<OpenVpnServerWithStatusDto> GetOpenVpnServerWithStatusAsync(int vpnServerId, CancellationToken ct = default);
     Task<(int CountConnectedClients, int CountSessions)> GetClientCountersAsync(
         int vpnServerId, CancellationToken ct = default);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQueryService.cs
@@ -5,7 +5,9 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 
 public interface IOpenVpnServerQueryService
 {
-    Task<List<OpenVpnServer>> GetAll(bool includeDeleted = false, CancellationToken ct = default);
+    /// <param name="requireQuotaPlanAssignment">When true, only servers present in <c>QuotaPlanAllowedServers</c> are returned.</param>
+    Task<List<OpenVpnServer>> GetAll(bool includeDeleted = false, bool requireQuotaPlanAssignment = false,
+        CancellationToken ct = default);
 
     Task<OpenVpnServer?> GetById(int id, CancellationToken ct = default);
 
@@ -15,6 +17,7 @@ public interface IOpenVpnServerQueryService
         int page,
         int pageSize,
         bool includeDeleted = false,
+        bool requireQuotaPlanAssignment = false,
         CancellationToken ct = default);
 
     Task<bool> AnyByServerName(string serverName, CancellationToken ct = default);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQueryService.cs
@@ -5,9 +5,10 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 
 public interface IOpenVpnServerQueryService
 {
-    /// <param name="requireQuotaPlanAssignment">When true, only servers present in <c>QuotaPlanAllowedServers</c> are returned.</param>
+    /// <param name="requireQuotaPlanAssignment">When true, only servers present in <c>QuotaPlanAllowedServers</c> are returned. Ignored when <paramref name="restrictToQuotaPlanId"/> is set.</param>
+    /// <param name="restrictToQuotaPlanId">When set, only servers linked to this quota plan in <c>QuotaPlanAllowedServers</c> are returned.</param>
     Task<List<OpenVpnServer>> GetAll(bool includeDeleted = false, bool requireQuotaPlanAssignment = false,
-        CancellationToken ct = default);
+        int? restrictToQuotaPlanId = null, CancellationToken ct = default);
 
     Task<OpenVpnServer?> GetById(int id, CancellationToken ct = default);
 
@@ -18,6 +19,7 @@ public interface IOpenVpnServerQueryService
         int pageSize,
         bool includeDeleted = false,
         bool requireQuotaPlanAssignment = false,
+        int? restrictToQuotaPlanId = null,
         CancellationToken ct = default);
 
     Task<bool> AnyByServerName(string serverName, CancellationToken ct = default);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQuotaPlanGroupsQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/IOpenVpnServerQuotaPlanGroupsQuery.cs
@@ -1,0 +1,16 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
+
+/// <summary>
+/// Resolves quota plans ("groups") linked to VPN servers via <see cref="Models.QuotaPlanAllowedServer"/>.
+/// </summary>
+public interface IOpenVpnServerQuotaPlanGroupsQuery
+{
+    /// <summary>
+    /// For each server id, returns active quota plans that include this server.
+    /// </summary>
+    Task<Dictionary<int, List<QuotaPlanGroupDto>>> GetGroupsByVpnServerIdsAsync(
+        IReadOnlyCollection<int> vpnServerIds,
+        CancellationToken ct);
+}

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerOverviewQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerOverviewQuery.cs
@@ -13,11 +13,17 @@ public class OpenVpnServerOverviewQuery(IUnitOfWork uow) : IOpenVpnServerOvervie
     public async Task<List<OpenVpnServerWithStatusDto>> GetAllOpenVpnServersWithStatusAsync(
         bool includeDeleted = false,
         bool requireQuotaPlanAssignment = false,
+        int? restrictToQuotaPlanId = null,
         CancellationToken ct = default)
     {
         var serversBase = uow.GetQuery<OpenVpnServer>().AsQueryable();
         var servers = includeDeleted ? serversBase : serversBase.Where(s => !s.IsDeleted);
-        if (requireQuotaPlanAssignment)
+        if (restrictToQuotaPlanId is int pid)
+        {
+            var allowed = uow.GetQuery<QuotaPlanAllowedServer>().AsQueryable();
+            servers = servers.Where(s => allowed.Any(a => a.VpnServerId == s.Id && a.QuotaPlanId == pid));
+        }
+        else if (requireQuotaPlanAssignment)
         {
             var allowed = uow.GetQuery<QuotaPlanAllowedServer>().AsQueryable();
             servers = servers.Where(s => allowed.Any(a => a.VpnServerId == s.Id));

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerOverviewQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerOverviewQuery.cs
@@ -10,10 +10,18 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 public class OpenVpnServerOverviewQuery(IUnitOfWork uow) : IOpenVpnServerOverviewQuery
 {
     // Single roundtrip with correlated subqueries
-    public async Task<List<OpenVpnServerWithStatusDto>> GetAllOpenVpnServersWithStatusAsync(bool includeDeleted = false, CancellationToken ct = default)
+    public async Task<List<OpenVpnServerWithStatusDto>> GetAllOpenVpnServersWithStatusAsync(
+        bool includeDeleted = false,
+        bool requireQuotaPlanAssignment = false,
+        CancellationToken ct = default)
     {
         var serversBase = uow.GetQuery<OpenVpnServer>().AsQueryable();
         var servers = includeDeleted ? serversBase : serversBase.Where(s => !s.IsDeleted);
+        if (requireQuotaPlanAssignment)
+        {
+            var allowed = uow.GetQuery<QuotaPlanAllowedServer>().AsQueryable();
+            servers = servers.Where(s => allowed.Any(a => a.VpnServerId == s.Id));
+        }
         var clients = uow.GetQuery<OpenVpnServerClient>().AsQueryable();
         var logs = uow.GetQuery<OpenVpnServerStatusLog>().AsQueryable();
 

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryService.cs
@@ -1,14 +1,33 @@
+using System.Linq.Expressions;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 
-public class OpenVpnServerQueryService(IQueryService<OpenVpnServer, int> q) : IOpenVpnServerQueryService
+public class OpenVpnServerQueryService(
+    IQueryService<OpenVpnServer, int> q,
+    IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService) : IOpenVpnServerQueryService
 {
-    public Task<List<OpenVpnServer>> GetAll(bool includeDeleted = false, CancellationToken ct = default)
-        => includeDeleted
-            ? q.GetAll(ct: ct)
-            : q.Where(x => !x.IsDeleted, ct: ct);
+    public async Task<List<OpenVpnServer>> GetAll(bool includeDeleted = false, bool requireQuotaPlanAssignment = false,
+        CancellationToken ct = default)
+    {
+        if (!requireQuotaPlanAssignment)
+        {
+            return includeDeleted
+                ? await q.GetAll(ct: ct)
+                : await q.Where(x => !x.IsDeleted, ct: ct);
+        }
+
+        var allowedIds = await quotaPlanAllowedServerQueryService.GetDistinctVpnServerIds(ct);
+        if (allowedIds.Count == 0)
+            return [];
+
+        if (includeDeleted)
+            return await q.Where(x => allowedIds.Contains(x.Id), ct: ct);
+
+        return await q.Where(x => allowedIds.Contains(x.Id) && !x.IsDeleted, ct: ct);
+    }
 
     public Task<OpenVpnServer?> GetById(int id, CancellationToken ct = default)
         => q.FindById(id, ct: ct);
@@ -16,11 +35,34 @@ public class OpenVpnServerQueryService(IQueryService<OpenVpnServer, int> q) : IO
     public Task<List<OpenVpnServer>> GetDefaultExcept(int exceptId, CancellationToken ct = default)
         => q.Where(x => x.IsDefault && x.Id != exceptId && !x.IsDeleted, ct: ct);
 
-    public Task<IPagedResult<OpenVpnServer>> GetPage(int page, int pageSize, bool includeDeleted = false,
-        CancellationToken ct = default)
-        => includeDeleted
-            ? q.Page(page, pageSize, ct: ct)
-            : q.Page(page, pageSize, predicate: x => !x.IsDeleted, ct: ct);
+    public async Task<IPagedResult<OpenVpnServer>> GetPage(int page, int pageSize, bool includeDeleted = false,
+        bool requireQuotaPlanAssignment = false, CancellationToken ct = default)
+    {
+        if (!requireQuotaPlanAssignment)
+        {
+            return includeDeleted
+                ? await q.Page(page, pageSize, ct: ct)
+                : await q.Page(page, pageSize, predicate: x => !x.IsDeleted, ct: ct);
+        }
+
+        var allowedIds = await quotaPlanAllowedServerQueryService.GetDistinctVpnServerIds(ct);
+        if (allowedIds.Count == 0)
+        {
+            return new PagedResponse<OpenVpnServer>
+            {
+                Page = page,
+                PageSize = pageSize,
+                TotalCount = 0,
+                Items = []
+            };
+        }
+
+        Expression<Func<OpenVpnServer, bool>> predicate = includeDeleted
+            ? x => allowedIds.Contains(x.Id)
+            : x => allowedIds.Contains(x.Id) && !x.IsDeleted;
+
+        return await q.Page(page, pageSize, predicate: predicate, ct: ct);
+    }
 
     public Task<bool> AnyByServerName(string serverName, CancellationToken ct = default)
         => q.Any(x => x.ServerName == serverName && !x.IsDeleted, ct: ct);

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryService.cs
@@ -10,8 +10,19 @@ public class OpenVpnServerQueryService(
     IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService) : IOpenVpnServerQueryService
 {
     public async Task<List<OpenVpnServer>> GetAll(bool includeDeleted = false, bool requireQuotaPlanAssignment = false,
-        CancellationToken ct = default)
+        int? restrictToQuotaPlanId = null, CancellationToken ct = default)
     {
+        if (restrictToQuotaPlanId is int planId)
+        {
+            var ids = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(planId, ct);
+            if (ids.Count == 0)
+                return [];
+
+            return includeDeleted
+                ? await q.Where(x => ids.Contains(x.Id), ct: ct)
+                : await q.Where(x => ids.Contains(x.Id) && !x.IsDeleted, ct: ct);
+        }
+
         if (!requireQuotaPlanAssignment)
         {
             return includeDeleted
@@ -36,8 +47,29 @@ public class OpenVpnServerQueryService(
         => q.Where(x => x.IsDefault && x.Id != exceptId && !x.IsDeleted, ct: ct);
 
     public async Task<IPagedResult<OpenVpnServer>> GetPage(int page, int pageSize, bool includeDeleted = false,
-        bool requireQuotaPlanAssignment = false, CancellationToken ct = default)
+        bool requireQuotaPlanAssignment = false, int? restrictToQuotaPlanId = null, CancellationToken ct = default)
     {
+        if (restrictToQuotaPlanId is int planId)
+        {
+            var ids = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(planId, ct);
+            if (ids.Count == 0)
+            {
+                return new PagedResponse<OpenVpnServer>
+                {
+                    Page = page,
+                    PageSize = pageSize,
+                    TotalCount = 0,
+                    Items = []
+                };
+            }
+
+            Expression<Func<OpenVpnServer, bool>> predicate = includeDeleted
+                ? x => ids.Contains(x.Id)
+                : x => ids.Contains(x.Id) && !x.IsDeleted;
+
+            return await q.Page(page, pageSize, predicate: predicate, ct: ct);
+        }
+
         if (!requireQuotaPlanAssignment)
         {
             return includeDeleted
@@ -57,11 +89,11 @@ public class OpenVpnServerQueryService(
             };
         }
 
-        Expression<Func<OpenVpnServer, bool>> predicate = includeDeleted
+        Expression<Func<OpenVpnServer, bool>> predicate2 = includeDeleted
             ? x => allowedIds.Contains(x.Id)
             : x => allowedIds.Contains(x.Id) && !x.IsDeleted;
 
-        return await q.Page(page, pageSize, predicate: predicate, ct: ct);
+        return await q.Page(page, pageSize, predicate: predicate2, ct: ct);
     }
 
     public Task<bool> AnyByServerName(string serverName, CancellationToken ct = default)

--- a/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQuotaPlanGroupsQuery.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQuotaPlanGroupsQuery.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using OpenVPNGateMonitor.DataBase.UnitOfWork;
+using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+namespace OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
+
+public sealed class OpenVpnServerQuotaPlanGroupsQuery(IUnitOfWork uow) : IOpenVpnServerQuotaPlanGroupsQuery
+{
+    public async Task<Dictionary<int, List<QuotaPlanGroupDto>>> GetGroupsByVpnServerIdsAsync(
+        IReadOnlyCollection<int> vpnServerIds,
+        CancellationToken ct)
+    {
+        if (vpnServerIds.Count == 0)
+            return new Dictionary<int, List<QuotaPlanGroupDto>>();
+
+        var links = uow.GetQuery<QuotaPlanAllowedServer>().AsQueryable();
+        var plans = uow.GetQuery<QuotaPlan>().AsQueryable();
+
+        var rows = await (
+                from link in links
+                join plan in plans on link.QuotaPlanId equals plan.Id
+                where vpnServerIds.Contains(link.VpnServerId) && plan.IsActive
+                select new { link.VpnServerId, plan.Id, plan.Name })
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        return rows
+            .GroupBy(x => x.VpnServerId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(x => new QuotaPlanGroupDto { Id = x.Id, Name = x.Name }).ToList());
+    }
+}

--- a/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/IQuotaPlanAllowedServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/IQuotaPlanAllowedServerQueryService.cs
@@ -8,6 +8,9 @@ public interface IQuotaPlanAllowedServerQueryService
     /// <summary>Distinct VPN server ids that have at least one quota-plan assignment.</summary>
     Task<HashSet<int>> GetDistinctVpnServerIds(CancellationToken ct);
 
+    /// <summary>VPN server ids allowed for the given quota plan.</summary>
+    Task<HashSet<int>> GetVpnServerIdsByQuotaPlanId(int quotaPlanId, CancellationToken ct);
+
     Task<List<QuotaPlanAllowedServer>> GetAll(CancellationToken ct);
     Task<QuotaPlanAllowedServer?> GetById(int id, CancellationToken ct);
     Task<QuotaPlanAllowedServer?> GetByQuotaPlanIdAndServerId(int quotaPlanId, int vpnServerId,

--- a/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/IQuotaPlanAllowedServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/IQuotaPlanAllowedServerQueryService.cs
@@ -5,6 +5,9 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable
 
 public interface IQuotaPlanAllowedServerQueryService
 {
+    /// <summary>Distinct VPN server ids that have at least one quota-plan assignment.</summary>
+    Task<HashSet<int>> GetDistinctVpnServerIds(CancellationToken ct);
+
     Task<List<QuotaPlanAllowedServer>> GetAll(CancellationToken ct);
     Task<QuotaPlanAllowedServer?> GetById(int id, CancellationToken ct);
     Task<QuotaPlanAllowedServer?> GetByQuotaPlanIdAndServerId(int quotaPlanId, int vpnServerId,

--- a/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryService.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
@@ -6,6 +7,15 @@ namespace OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable
 public class QuotaPlanAllowedServerQueryService(
     IQueryService<QuotaPlanAllowedServer, int> q) : IQuotaPlanAllowedServerQueryService
 {
+    public async Task<HashSet<int>> GetDistinctVpnServerIds(CancellationToken ct)
+    {
+        var ids = await q.Query()
+            .Select(x => x.VpnServerId)
+            .Distinct()
+            .ToListAsync(ct);
+        return ids.ToHashSet();
+    }
+
     public Task<List<QuotaPlanAllowedServer>> GetAll(CancellationToken ct)
         => q.GetAll(ct: ct);
 

--- a/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryService.cs
@@ -16,6 +16,12 @@ public class QuotaPlanAllowedServerQueryService(
         return ids.ToHashSet();
     }
 
+    public async Task<HashSet<int>> GetVpnServerIdsByQuotaPlanId(int quotaPlanId, CancellationToken ct)
+    {
+        var list = await q.Where(x => x.QuotaPlanId == quotaPlanId, ct: ct);
+        return list.Select(x => x.VpnServerId).ToHashSet();
+    }
+
     public Task<List<QuotaPlanAllowedServer>> GetAll(CancellationToken ct)
         => q.GetAll(ct: ct);
 

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
       <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
-      <PackageReference Include="Mapster" Version="10.0.3" />
+      <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
+      <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
       <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.94" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
       <PackageReference Include="Mapster" Version="10.0.3" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/OpenVPNGateMonitor.Mapping/OpenVpnServers/Mappings/VpnServerMapping.cs
+++ b/OpenVPNGateMonitor.Mapping/OpenVpnServers/Mappings/VpnServerMapping.cs
@@ -25,6 +25,9 @@ public class VpnServerMapping : IRegister
         // Mapping list → response wrapper
         config.NewConfig<List<OpenVpnServer>, OpenVpnServersResponse>()
             .Map(dest => dest.OpenVpnServers, src => src);
+
+        config.NewConfig<OpenVpnServerDto, OpenVpnServerV2Dto>()
+            .Ignore(dest => dest.QuotaPlanGroups);
         #endregion
         #region "get-all-with-status"
         config.NewConfig<OpenVpnServer, OpenVpnServerDto>();

--- a/OpenVPNGateMonitor.Mapping/OpenVpnServers/Mappings/VpnServerMapping.cs
+++ b/OpenVPNGateMonitor.Mapping/OpenVpnServers/Mappings/VpnServerMapping.cs
@@ -27,7 +27,8 @@ public class VpnServerMapping : IRegister
             .Map(dest => dest.OpenVpnServers, src => src);
 
         config.NewConfig<OpenVpnServerDto, OpenVpnServerV2Dto>()
-            .Ignore(dest => dest.QuotaPlanGroups);
+            .Ignore(dest => dest.QuotaPlanGroups)
+            .Ignore(dest => dest.IsAccessibleForUserQuotaPlan);
         #endregion
         #region "get-all-with-status"
         config.NewConfig<OpenVpnServer, OpenVpnServerDto>();

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
+      <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
       <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.94" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerV2Dto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerV2Dto.cs
@@ -1,0 +1,22 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+/// <summary>
+/// OpenVPN server payload for API v2: same fields as <see cref="OpenVpnServerDto"/> plus quota-plan groups.
+/// </summary>
+public class OpenVpnServerV2Dto
+{
+    public int Id { get; set; }
+    public string ServerName { get; set; } = string.Empty;
+    public bool IsOnline { get; set; }
+    public bool IsDefault { get; set; }
+    public string ApiUrl { get; set; } = string.Empty;
+    public double? Latitude { get; set; }
+    public double? Longitude { get; set; }
+    public bool IsEnableWss { get; set; }
+    public DateTimeOffset CreateDate { get; set; }
+    public DateTimeOffset LastUpdate { get; set; }
+    public bool IsDeleted { get; set; }
+    public bool? DcoIsEnabled { get; set; }
+    public List<string> Tags { get; set; } = [];
+    public List<QuotaPlanGroupDto> QuotaPlanGroups { get; set; } = [];
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerV2Dto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerV2Dto.cs
@@ -19,4 +19,10 @@ public class OpenVpnServerV2Dto
     public bool? DcoIsEnabled { get; set; }
     public List<string> Tags { get; set; } = [];
     public List<QuotaPlanGroupDto> QuotaPlanGroups { get; set; } = [];
+
+    /// <summary>
+    /// Whether the current user may connect to this server (their quota plan includes it).
+    /// Always true for Admin/App. For users without a quota plan, false for all servers.
+    /// </summary>
+    public bool IsAccessibleForUserQuotaPlan { get; set; }
 }

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerWithStatusV2Dto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/OpenVpnServerWithStatusV2Dto.cs
@@ -1,0 +1,13 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+public class OpenVpnServerWithStatusV2Dto
+{
+    public OpenVpnServerV2Response OpenVpnServerResponses { get; set; } = new();
+    public OpenVpnServerStatusLogResponse? OpenVpnServerStatusLogResponse { get; set; }
+    public int CountConnectedClients { get; set; }
+    public int CountSessions { get; set; }
+    public long TotalBytesIn { get; set; }
+    public long TotalBytesOut { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/QuotaPlanGroupDto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Dto/QuotaPlanGroupDto.cs
@@ -1,0 +1,8 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+/// <summary>Quota plan a VPN server belongs to (for UI grouping).</summary>
+public class QuotaPlanGroupDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Responses/OpenVpnServerV2Response.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Responses/OpenVpnServerV2Response.cs
@@ -1,0 +1,8 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
+
+public class OpenVpnServerV2Response
+{
+    public OpenVpnServerV2Dto OpenVpnServer { get; set; } = new();
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Responses/OpenVpnServerWithStatusesV2Response.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Responses/OpenVpnServerWithStatusesV2Response.cs
@@ -1,0 +1,8 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
+
+public class OpenVpnServerWithStatusesV2Response
+{
+    public List<OpenVpnServerWithStatusV2Dto> OpenVpnServerWithStatuses { get; set; } = [];
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Responses/OpenVpnServersV2Response.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/OpenVpnServers/Responses/OpenVpnServersV2Response.cs
@@ -1,0 +1,8 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
+
+public class OpenVpnServersV2Response
+{
+    public List<OpenVpnServerV2Dto> OpenVpnServers { get; set; } = [];
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Dto/RoleDto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Dto/RoleDto.cs
@@ -1,0 +1,10 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Dto;
+
+public class RoleDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = null!;
+    public string NormalizedName { get; set; } = null!;
+    public string? Description { get; set; }
+    public bool IsSystem { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Dto/UserRoleAssignmentDto.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Dto/UserRoleAssignmentDto.cs
@@ -1,0 +1,8 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Dto;
+
+public class UserRoleAssignmentDto
+{
+    public int UserId { get; set; }
+    public int RoleId { get; set; }
+    public string RoleName { get; set; } = null!;
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Requests/SetUserRoleRequest.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Requests/SetUserRoleRequest.cs
@@ -1,0 +1,7 @@
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Requests;
+
+public class SetUserRoleRequest
+{
+    public int UserId { get; set; }
+    public int RoleId { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Responses/RolesResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Responses/RolesResponse.cs
@@ -1,0 +1,8 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Dto;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Responses;
+
+public class RolesResponse
+{
+    public List<RoleDto> Roles { get; set; } = [];
+}

--- a/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Responses/UserRoleAssignmentResponse.cs
+++ b/OpenVPNGateMonitor.SharedModels/DataGateMonitorBackend/UserRoles/Responses/UserRoleAssignmentResponse.cs
@@ -1,0 +1,9 @@
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Dto;
+
+namespace OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Responses;
+
+public class UserRoleAssignmentResponse
+{
+    /// <summary>Null when the user has no role row (unexpected for normal accounts).</summary>
+    public UserRoleAssignmentDto? Assignment { get; set; }
+}

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,10 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.96</Version>
-        <AssemblyVersion>1.0.96.0</AssemblyVersion>
-        <FileVersion>1.0.96.0</FileVersion>
+        <!-- Backend consumes this library via NuGet (PackageReference) only. After changes here: dotnet pack, publish to nuget.org, then bump package version in all referencing .csproj files. -->
+        <Version>1.0.97</Version>
+        <AssemblyVersion>1.0.97.0</AssemblyVersion>
+        <FileVersion>1.0.97.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,9 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.94</Version>
-        <AssemblyVersion>1.0.94.0</AssemblyVersion>
-        <FileVersion>1.0.94.0</FileVersion>
+        <Version>1.0.95</Version>
+        <AssemblyVersion>1.0.95.0</AssemblyVersion>
+        <FileVersion>1.0.95.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -19,9 +19,9 @@
         <PackageTags>#OpenVPNGateMonitor #OpenVpn #GateMonitor #Dashboard</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>1.0.95</Version>
-        <AssemblyVersion>1.0.95.0</AssemblyVersion>
-        <FileVersion>1.0.95.0</FileVersion>
+        <Version>1.0.96</Version>
+        <AssemblyVersion>1.0.96.0</AssemblyVersion>
+        <FileVersion>1.0.96.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/OpenVPNGateMonitor.Tests/Configurations/QueryCommandConfigurationTests.cs
+++ b/OpenVPNGateMonitor.Tests/Configurations/QueryCommandConfigurationTests.cs
@@ -39,6 +39,7 @@ public class QueryCommandConfigurationTests
         AssertRegistered(services, typeof(IOpenVpnServerQueryService));
         AssertRegistered(services, typeof(IOpenVpnServerOvpnFileConfigQueryService));
         AssertRegistered(services, typeof(IOpenVpnServerOverviewQuery));
+        AssertRegistered(services, typeof(IOpenVpnServerQuotaPlanGroupsQuery));
         AssertRegistered(services, typeof(ITagQueryService));
         AssertRegistered(services, typeof(IOpenVpnServerTagQueryService));
         AssertRegistered(services, typeof(IOpenVpnServerConflogQueryService));

--- a/OpenVPNGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
+++ b/OpenVPNGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
@@ -8,6 +8,7 @@ using OpenVPNGateMonitor.Services.Helpers.Interfaces;
 using OpenVPNGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
 using OpenVPNGateMonitor.Services.QuotaPlans;
 using OpenVPNGateMonitor.Services.Tags;
+using OpenVPNGateMonitor.Services.UserRoles;
 using OpenVPNGateMonitor.Services.Users;
 using OpenVPNGateMonitor.Services.Users.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
@@ -37,6 +38,7 @@ public class ServiceConfigurationTests
         AssertRegistered(services, typeof(IExternalIpAddressService));
         AssertRegistered(services, typeof(IUserService));
         AssertRegistered(services, typeof(IQuotaPlanService));
+        AssertRegistered(services, typeof(IUserRoleManagementService));
         AssertRegistered(services, typeof(ITagService));
         AssertRegistered(services, typeof(IMicroserviceInfoService));
         AssertRegistered(services, typeof(IOpenVpnServerConflogService));

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
@@ -27,14 +27,19 @@ public class OpenVpnFilesControllerTests
     {
         _controller = new OpenVpnFilesController(_service.Object, _logger.Object, _userQuotaPlan.Object,
             _quotaAllowed.Object, _vpnAccess.Object);
-        _controller.ControllerContext = new ControllerContext
+        SetUserAsAdmin(_controller);
+    }
+
+    private static void SetUserAsAdmin(OpenVpnFilesController controller) =>
+        SetUser(controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "Admin")],
+            "mock")));
+
+    private static void SetUser(OpenVpnFilesController controller, ClaimsPrincipal user)
+    {
+        controller.ControllerContext = new ControllerContext
         {
-            HttpContext = new DefaultHttpContext
-            {
-                User = new ClaimsPrincipal(new ClaimsIdentity(
-                    [new Claim(ClaimTypes.Role, "Admin")],
-                    "mock"))
-            }
+            HttpContext = new DefaultHttpContext { User = user }
         };
     }
 
@@ -308,5 +313,44 @@ public class OpenVpnFilesControllerTests
         var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<string>>(bad.Value);
         Assert.False(response.Success);
+    }
+
+    [Fact]
+    public async Task GetAllByVpnServerId_WhenVpnUserNoAccess_Returns_Forbidden()
+    {
+        SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "900")
+            ],
+            "mock")));
+        _vpnAccess.Setup(a => a.UserHasAccessAsync(900, 5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _controller.GetAllByVpnServerId(new ByVpnServerIdRequest { VpnServerId = 5 }, CancellationToken.None);
+
+        var forbid = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, forbid.StatusCode);
+        _service.Verify(s => s.GetAllByVpnServerId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetByToken_WhenVpnUserNoAccess_Returns_Forbidden()
+    {
+        SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "901")
+            ],
+            "mock")));
+        _service.Setup(s => s.GetByToken("tok", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync(new OpenVPNGateMonitor.Models.IssuedOvpnFile { VpnServerId = 12 });
+        _vpnAccess.Setup(a => a.UserHasAccessAsync(901, 12, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _controller.GetByToken(new ByTokenRequest { Token = "tok" }, CancellationToken.None);
+
+        var forbid = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, forbid.StatusCode);
     }
 }

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
@@ -1,7 +1,12 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using OpenVPNGateMonitor.Controllers;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnFiles.Requests;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnFiles.Responses;
@@ -13,11 +18,24 @@ public class OpenVpnFilesControllerTests
 {
     private readonly Mock<IOvpnFileApiService> _service = new();
     private readonly Mock<ILogger<OpenVpnFilesController>> _logger = new();
+    private readonly Mock<IUserQuotaPlanQueryService> _userQuotaPlan = new();
+    private readonly Mock<IQuotaPlanAllowedServerQueryService> _quotaAllowed = new();
+    private readonly Mock<IVpnServerAccessQueryService> _vpnAccess = new();
     private readonly OpenVpnFilesController _controller;
 
     public OpenVpnFilesControllerTests()
     {
-        _controller = new OpenVpnFilesController(_service.Object, _logger.Object);
+        _controller = new OpenVpnFilesController(_service.Object, _logger.Object, _userQuotaPlan.Object,
+            _quotaAllowed.Object, _vpnAccess.Object);
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Role, "Admin")],
+                    "mock"))
+            }
+        };
     }
 
     [Fact]

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerAuthorizationHelperTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerAuthorizationHelperTests.cs
@@ -1,0 +1,57 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using OpenVPNGateMonitor.Controllers;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
+using OpenVPNGateMonitor.SharedModels.Responses;
+
+namespace OpenVPNGateMonitor.Tests.Controllers;
+
+public class OpenVpnServerAuthorizationHelperTests
+{
+    [Fact]
+    public async Task RequireVpnServerAccessOrForbidAsync_WhenAdmin_ReturnsNull()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Role, "Admin")], "mock"));
+        var access = new Mock<IVpnServerAccessQueryService>(MockBehavior.Strict);
+
+        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(
+            user, access.Object, 1, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task RequireVpnServerAccessOrForbidAsync_WhenVpnUserMissingUserId_ReturnsUnauthorized()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Role, "VpnUser")], "mock"));
+        var access = new Mock<IVpnServerAccessQueryService>(MockBehavior.Strict);
+
+        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(
+            user, access.Object, 1, CancellationToken.None);
+
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result);
+        var api = Assert.IsType<ApiResponse<string>>(unauthorized.Value);
+        Assert.False(api.Success);
+    }
+
+    [Fact]
+    public async Task RequireVpnServerAccessOrForbidAsync_WhenNoAccess_ReturnsForbidden()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "42")
+            ],
+            "mock"));
+        var access = new Mock<IVpnServerAccessQueryService>();
+        access.Setup(a => a.UserHasAccessAsync(42, 7, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(
+            user, access.Object, 7, CancellationToken.None);
+
+        var forbid = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, forbid.StatusCode);
+    }
+}

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerAuthorizationHelperTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerAuthorizationHelperTests.cs
@@ -16,7 +16,7 @@ public class OpenVpnServerAuthorizationHelperTests
         var user = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Role, "Admin")], "mock"));
         var access = new Mock<IVpnServerAccessQueryService>(MockBehavior.Strict);
 
-        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(
+        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<string>(
             user, access.Object, 1, CancellationToken.None);
 
         Assert.Null(result);
@@ -28,10 +28,11 @@ public class OpenVpnServerAuthorizationHelperTests
         var user = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Role, "VpnUser")], "mock"));
         var access = new Mock<IVpnServerAccessQueryService>(MockBehavior.Strict);
 
-        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(
+        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<string>(
             user, access.Object, 1, CancellationToken.None);
 
-        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result);
+        Assert.NotNull(result);
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result!.Result);
         var api = Assert.IsType<ApiResponse<string>>(unauthorized.Value);
         Assert.False(api.Success);
     }
@@ -48,10 +49,11 @@ public class OpenVpnServerAuthorizationHelperTests
         var access = new Mock<IVpnServerAccessQueryService>();
         access.Setup(a => a.UserHasAccessAsync(42, 7, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
-        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(
+        var result = await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<string>(
             user, access.Object, 7, CancellationToken.None);
 
-        var forbid = Assert.IsType<ObjectResult>(result);
+        Assert.NotNull(result);
+        var forbid = Assert.IsType<ObjectResult>(result!.Result);
         Assert.Equal(StatusCodes.Status403Forbidden, forbid.StatusCode);
     }
 }

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerCertsControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServerCertsControllerTests.cs
@@ -1,8 +1,11 @@
+using System.Security.Claims;
 using Mapster;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using OpenVPNGateMonitor.Controllers;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
 using OpenVPNGateMonitor.Mapping.OpenVpnServerCerts.Mappings;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerCerts.Requests;
@@ -17,6 +20,7 @@ public class OpenVpnServerCertsControllerTests
 {
     private readonly Mock<ICertApiClient> _certApiClient = new();
     private readonly Mock<ILogger<OpenVpnServerCertsController>> _logger = new();
+    private readonly Mock<IVpnServerAccessQueryService> _vpnAccess = new();
 
     public OpenVpnServerCertsControllerTests()
     {
@@ -24,8 +28,20 @@ public class OpenVpnServerCertsControllerTests
         new VpnServerCertificateMapping().Register(TypeAdapterConfig.GlobalSettings);
     }
 
-    private OpenVpnServerCertsController CreateController() =>
-        new(_certApiClient.Object, _logger.Object);
+    private OpenVpnServerCertsController CreateController()
+    {
+        var c = new OpenVpnServerCertsController(_certApiClient.Object, _logger.Object, _vpnAccess.Object);
+        c.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Role, "Admin")],
+                    "mock"))
+            }
+        };
+        return c;
+    }
 
     [Fact]
     public async Task GetAllCertificates_ReturnsOk_WithMappedResponse()

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
@@ -1,9 +1,13 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using OpenVPNGateMonitor.Controllers;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTagTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
 using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
 using OpenVPNGateMonitor.Services.Api.Interfaces;
 using OpenVPNGateMonitor.Services.BackgroundServices.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
@@ -24,6 +28,8 @@ public class OpenVpnServersControllerTests
     private readonly Mock<IOpenVpnServerTagQueryService> _tagQuery = new();
     private readonly Mock<IOpenVpnBackgroundService> _backgroundService = new();
     private readonly Mock<IMicroserviceInfoService> _microserviceInfo = new();
+    private readonly Mock<IUserQuotaPlanQueryService> _userQuotaPlan = new();
+    private readonly Mock<IVpnServerAccessQueryService> _vpnAccess = new();
 
     private readonly OpenVpnServersController _controller;
 
@@ -35,14 +41,25 @@ public class OpenVpnServersControllerTests
             _serverQuery.Object,
             _tagQuery.Object,
             _backgroundService.Object,
-            _microserviceInfo.Object);
+            _microserviceInfo.Object,
+            _userQuotaPlan.Object,
+            _vpnAccess.Object);
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Role, "Admin")],
+                    "mock"))
+            }
+        };
     }
 
     [Fact]
     public async Task GetAllServersWithStatus_Returns_Ok()
     {
         _overviewQuery
-            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<OpenVpnServerWithStatusDto>());
         _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, List<string>>());
@@ -52,21 +69,21 @@ public class OpenVpnServersControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<OpenVpnServerWithStatusesResponse>>(ok.Value);
         Assert.True(response.Success);
-        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(false, true, It.IsAny<CancellationToken>()), Times.Once);
+        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(false, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetAllServersWithStatus_WhenIncludeDeletedTrue_PassesTrue()
     {
         _overviewQuery
-            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(true, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(true, It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<OpenVpnServerWithStatusDto>());
         _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, List<string>>());
 
         await _controller.GetAllServersWithStatus(includeDeleted: true, CancellationToken.None);
 
-        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(true, true, It.IsAny<CancellationToken>()), Times.Once);
+        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(true, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -110,7 +127,7 @@ public class OpenVpnServersControllerTests
     [Fact]
     public async Task GetAllServers_Returns_Ok()
     {
-        _serverQuery.Setup(s => s.GetAll(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<OpenVpnServer>());
+        _serverQuery.Setup(s => s.GetAll(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<OpenVpnServer>());
         _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, List<string>>());
 
@@ -119,7 +136,7 @@ public class OpenVpnServersControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<OpenVpnServersResponse>>(ok.Value);
         Assert.True(response.Success);
-        _serverQuery.Verify(s => s.GetAll(false, true, It.IsAny<CancellationToken>()), Times.Once);
+        _serverQuery.Verify(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
@@ -325,7 +325,7 @@ public class OpenVpnServersControllerTests
                 new Claim(ClaimTypes.NameIdentifier, "50")
             ],
             "mock")));
-        _userQuotaPlan.Setup(u => u.GetByUserId(50, It.IsAny<CancellationToken>()))
+        _userQuotaPlan.Setup(u => u.GetActiveByUserId(50, It.IsAny<CancellationToken>()))
             .ReturnsAsync((UserQuotaPlan?)null);
 
         var result = await _controller.GetAllServers(false, CancellationToken.None);
@@ -346,7 +346,7 @@ public class OpenVpnServersControllerTests
                 new Claim(ClaimTypes.NameIdentifier, "51")
             ],
             "mock")));
-        _userQuotaPlan.Setup(u => u.GetByUserId(51, It.IsAny<CancellationToken>()))
+        _userQuotaPlan.Setup(u => u.GetActiveByUserId(51, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new UserQuotaPlan { Id = 1, UserId = 51, QuotaPlanId = 9 });
         _serverQuery.Setup(s => s.GetAll(false, false, 9, It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
@@ -44,14 +44,19 @@ public class OpenVpnServersControllerTests
             _microserviceInfo.Object,
             _userQuotaPlan.Object,
             _vpnAccess.Object);
-        _controller.ControllerContext = new ControllerContext
+        SetUserAsAdmin(_controller);
+    }
+
+    private static void SetUserAsAdmin(OpenVpnServersController controller) =>
+        SetUser(controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "Admin")],
+            "mock")));
+
+    private static void SetUser(OpenVpnServersController controller, ClaimsPrincipal user)
+    {
+        controller.ControllerContext = new ControllerContext
         {
-            HttpContext = new DefaultHttpContext
-            {
-                User = new ClaimsPrincipal(new ClaimsIdentity(
-                    [new Claim(ClaimTypes.Role, "Admin")],
-                    "mock"))
-            }
+            HttpContext = new DefaultHttpContext { User = user }
         };
     }
 
@@ -294,4 +299,86 @@ public class OpenVpnServersControllerTests
         _backgroundService.Verify(b => b.RunNow(It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task GetAllServersWithStatus_WhenVpnUserAndNoUserIdClaim_Returns_Unauthorized()
+    {
+        SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "VpnUser")],
+            "mock")));
+
+        var result = await _controller.GetAllServersWithStatus(false, CancellationToken.None);
+
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<OpenVpnServerWithStatusesResponse>>(unauthorized.Value);
+        Assert.False(response.Success);
+        _overviewQuery.Verify(
+            q => q.GetAllOpenVpnServersWithStatusAsync(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAllServers_WhenVpnUserAndNoQuotaPlan_Returns_EmptyList()
+    {
+        SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "50")
+            ],
+            "mock")));
+        _userQuotaPlan.Setup(u => u.GetByUserId(50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserQuotaPlan?)null);
+
+        var result = await _controller.GetAllServers(false, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<OpenVpnServersResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.Empty(response.Data!.OpenVpnServers);
+        _serverQuery.Verify(s => s.GetAll(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAllServers_WhenVpnUserWithQuotaPlan_PassesRestrictToQuotaPlanId()
+    {
+        SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "51")
+            ],
+            "mock")));
+        _userQuotaPlan.Setup(u => u.GetByUserId(51, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserQuotaPlan { Id = 1, UserId = 51, QuotaPlanId = 9 });
+        _serverQuery.Setup(s => s.GetAll(false, false, 9, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<string>>());
+
+        var result = await _controller.GetAllServers(false, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<OpenVpnServersResponse>>(ok.Value);
+        Assert.True(response.Success);
+        _serverQuery.Verify(s => s.GetAll(false, false, 9, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetServer_WhenVpnUserNoAccess_Returns_Forbidden()
+    {
+        SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "60")
+            ],
+            "mock")));
+        _vpnAccess.Setup(a => a.UserHasAccessAsync(60, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _controller.GetServer(new GetServerRequest { VpnServerId = 10 }, CancellationToken.None);
+
+        var forbid = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, forbid.StatusCode);
+        _serverQuery.Verify(s => s.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
 }
+

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersControllerTests.cs
@@ -42,7 +42,7 @@ public class OpenVpnServersControllerTests
     public async Task GetAllServersWithStatus_Returns_Ok()
     {
         _overviewQuery
-            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<OpenVpnServerWithStatusDto>());
         _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, List<string>>());
@@ -52,21 +52,21 @@ public class OpenVpnServersControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<OpenVpnServerWithStatusesResponse>>(ok.Value);
         Assert.True(response.Success);
-        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(false, It.IsAny<CancellationToken>()), Times.Once);
+        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(false, true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetAllServersWithStatus_WhenIncludeDeletedTrue_PassesTrue()
     {
         _overviewQuery
-            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(true, It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetAllOpenVpnServersWithStatusAsync(true, It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<OpenVpnServerWithStatusDto>());
         _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, List<string>>());
 
         await _controller.GetAllServersWithStatus(includeDeleted: true, CancellationToken.None);
 
-        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+        _overviewQuery.Verify(q => q.GetAllOpenVpnServersWithStatusAsync(true, true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -110,7 +110,7 @@ public class OpenVpnServersControllerTests
     [Fact]
     public async Task GetAllServers_Returns_Ok()
     {
-        _serverQuery.Setup(s => s.GetAll(It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<OpenVpnServer>());
+        _serverQuery.Setup(s => s.GetAll(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<OpenVpnServer>());
         _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, List<string>>());
 
@@ -119,7 +119,7 @@ public class OpenVpnServersControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<OpenVpnServersResponse>>(ok.Value);
         Assert.True(response.Success);
-        _serverQuery.Verify(s => s.GetAll(false, It.IsAny<CancellationToken>()), Times.Once);
+        _serverQuery.Verify(s => s.GetAll(false, true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersV2ControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersV2ControllerTests.cs
@@ -74,7 +74,7 @@ public class OpenVpnServersV2ControllerTests
             "mock"));
         var controller = CreateController(user);
 
-        _userQuotaPlan.Setup(u => u.GetByUserId(100, It.IsAny<CancellationToken>()))
+        _userQuotaPlan.Setup(u => u.GetActiveByUserId(100, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new UserQuotaPlan { Id = 1, UserId = 100, QuotaPlanId = 7 });
         _quotaAllowed.Setup(q => q.GetVpnServerIdsByQuotaPlanId(7, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new HashSet<int> { 1 });

--- a/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersV2ControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/OpenVpnServersV2ControllerTests.cs
@@ -1,0 +1,130 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using OpenVPNGateMonitor.Controllers;
+using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTagTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
+using OpenVPNGateMonitor.SharedModels.Responses;
+
+namespace OpenVPNGateMonitor.Tests.Controllers;
+
+public class OpenVpnServersV2ControllerTests
+{
+    private readonly Mock<IOpenVpnServerOverviewQuery> _overviewQuery = new();
+    private readonly Mock<IOpenVpnServerQueryService> _serverQuery = new();
+    private readonly Mock<IOpenVpnServerQuotaPlanGroupsQuery> _quotaGroups = new();
+    private readonly Mock<IOpenVpnServerTagQueryService> _tagQuery = new();
+    private readonly Mock<IUserQuotaPlanQueryService> _userQuotaPlan = new();
+    private readonly Mock<IQuotaPlanAllowedServerQueryService> _quotaAllowed = new();
+
+    private OpenVpnServersV2Controller CreateController(ClaimsPrincipal user)
+    {
+        var c = new OpenVpnServersV2Controller(
+            _overviewQuery.Object,
+            _serverQuery.Object,
+            _quotaGroups.Object,
+            _tagQuery.Object,
+            _userQuotaPlan.Object,
+            _quotaAllowed.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+        return c;
+    }
+
+    [Fact]
+    public async Task GetAllServers_WhenUserIdMissing_Returns_Unauthorized()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "VpnUser")],
+            "mock"));
+        var controller = CreateController(user);
+
+        _serverQuery.Setup(s => s.GetAll(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new OpenVpnServer { Id = 1, ServerName = "a" }]);
+        _quotaGroups.Setup(g => g.GetGroupsByVpnServerIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<QuotaPlanGroupDto>>());
+        _tagQuery.Setup(t => t.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<string>>());
+
+        var result = await controller.GetAllServers(includeDeleted: false, CancellationToken.None);
+
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result.Result);
+        var api = Assert.IsType<ApiResponse<OpenVpnServersV2Response>>(unauthorized.Value);
+        Assert.False(api.Success);
+    }
+
+    [Fact]
+    public async Task GetAllServers_WithVpnUser_MarksAccessibility_FromQuotaPlan()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "100")
+            ],
+            "mock"));
+        var controller = CreateController(user);
+
+        _userQuotaPlan.Setup(u => u.GetByUserId(100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserQuotaPlan { Id = 1, UserId = 100, QuotaPlanId = 7 });
+        _quotaAllowed.Setup(q => q.GetVpnServerIdsByQuotaPlanId(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HashSet<int> { 1 });
+
+        _serverQuery.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new OpenVpnServer { Id = 1, ServerName = "allowed" },
+                new OpenVpnServer { Id = 2, ServerName = "other" }
+            ]);
+        _quotaGroups.Setup(g => g.GetGroupsByVpnServerIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<QuotaPlanGroupDto>>());
+        _tagQuery.Setup(t => t.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<string>>());
+
+        var result = await controller.GetAllServers(false, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var api = Assert.IsType<ApiResponse<OpenVpnServersV2Response>>(ok.Value);
+        Assert.True(api.Success);
+        Assert.NotNull(api.Data);
+        Assert.Equal(2, api.Data!.OpenVpnServers.Count);
+        var s1 = api.Data.OpenVpnServers.Single(x => x.Id == 1);
+        var s2 = api.Data.OpenVpnServers.Single(x => x.Id == 2);
+        Assert.True(s1.IsAccessibleForUserQuotaPlan);
+        Assert.False(s2.IsAccessibleForUserQuotaPlan);
+    }
+
+    [Fact]
+    public async Task GetAllServersWithStatus_WhenUserIdMissing_Returns_Unauthorized()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Role, "VpnUser")],
+            "mock"));
+        var controller = CreateController(user);
+
+        _overviewQuery.Setup(o => o.GetAllOpenVpnServersWithStatusAsync(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new OpenVpnServerWithStatusDto
+                {
+                    OpenVpnServerResponses = new OpenVpnServerResponse
+                    {
+                        OpenVpnServer = new OpenVpnServerDto { Id = 1, ServerName = "x" }
+                    }
+                }
+            ]);
+
+        var result = await controller.GetAllServersWithStatus(false, CancellationToken.None);
+
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result.Result);
+        var api = Assert.IsType<ApiResponse<OpenVpnServerWithStatusesV2Response>>(unauthorized.Value);
+        Assert.False(api.Success);
+    }
+}

--- a/OpenVPNGateMonitor.Tests/Controllers/QuotaPlanAllowedServerControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/QuotaPlanAllowedServerControllerTests.cs
@@ -1,6 +1,10 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using OpenVPNGateMonitor.Controllers;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.Services.QuotaPlans;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.QuotaPlanAllowedServers.Dto;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.QuotaPlanAllowedServers.Requests;
@@ -12,11 +16,25 @@ namespace OpenVPNGateMonitor.Tests.Controllers;
 public class QuotaPlanAllowedServerControllerTests
 {
     private readonly Mock<IQuotaPlanAllowedServerService> _service = new(MockBehavior.Strict);
+    private readonly Mock<IUserQuotaPlanQueryService> _userQuotaPlanQuery = new(MockBehavior.Strict);
     private readonly QuotaPlanAllowedServerController _controller;
 
     public QuotaPlanAllowedServerControllerTests()
     {
-        _controller = new QuotaPlanAllowedServerController(_service.Object);
+        _controller = new QuotaPlanAllowedServerController(_service.Object, _userQuotaPlanQuery.Object);
+    }
+
+    private static void SetRole(QuotaPlanAllowedServerController controller, string role)
+    {
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Role, role)],
+                    "Test"))
+            }
+        };
     }
 
     [Fact]
@@ -89,6 +107,8 @@ public class QuotaPlanAllowedServerControllerTests
     [Fact]
     public async Task GetByQuotaPlanId_ReturnsOk_WithItems()
     {
+        SetRole(_controller, "Admin");
+
         var items = new List<QuotaPlanAllowedServerDto>
         {
             new() { Id = 1, QuotaPlanId = 10, VpnServerId = 5 }
@@ -106,6 +126,60 @@ public class QuotaPlanAllowedServerControllerTests
         Assert.NotNull(response.Data);
         Assert.Single(response.Data.Items);
         _service.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetByQuotaPlanId_WhenVpnUserAndOwnPlan_ReturnsOk()
+    {
+        SetRole(_controller, "VpnUser");
+        _controller.ControllerContext.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.Role, "VpnUser"),
+            new Claim(ClaimTypes.NameIdentifier, "42")
+        ], "Test"));
+
+        _userQuotaPlanQuery
+            .Setup(q => q.GetActiveByUserId(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserQuotaPlan { UserId = 42, QuotaPlanId = 7 });
+
+        var items = new List<QuotaPlanAllowedServerDto>
+        {
+            new() { Id = 1, QuotaPlanId = 7, VpnServerId = 5 }
+        };
+
+        _service
+            .Setup(s => s.GetListByQuotaPlanIdAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        var result = await _controller.GetByQuotaPlanId(7, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<GetQuotaPlanAllowedServersByQuotaPlanIdResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.Single(response.Data!.Items);
+        _service.VerifyAll();
+        _userQuotaPlanQuery.VerifyAll();
+    }
+
+    [Fact]
+    public async Task GetByQuotaPlanId_WhenVpnUserAndOtherPlan_Returns403()
+    {
+        SetRole(_controller, "VpnUser");
+        _controller.ControllerContext.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.Role, "VpnUser"),
+            new Claim(ClaimTypes.NameIdentifier, "42")
+        ], "Test"));
+
+        _userQuotaPlanQuery
+            .Setup(q => q.GetActiveByUserId(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserQuotaPlan { UserId = 42, QuotaPlanId = 7 });
+
+        var result = await _controller.GetByQuotaPlanId(99, CancellationToken.None);
+
+        var forbidden = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status403Forbidden, forbidden.StatusCode);
+        _userQuotaPlanQuery.VerifyAll();
     }
 
     [Fact]

--- a/OpenVPNGateMonitor.Tests/Controllers/UserRolesControllerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Controllers/UserRolesControllerTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using OpenVPNGateMonitor.Controllers;
+using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Services.UserRoles;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Requests;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Responses;
+using OpenVPNGateMonitor.SharedModels.Responses;
+using Xunit;
+
+namespace OpenVPNGateMonitor.Tests.Controllers;
+
+public class UserRolesControllerTests
+{
+    private readonly Mock<IUserRoleManagementService> _service = new(MockBehavior.Strict);
+    private readonly UserRolesController _controller;
+
+    public UserRolesControllerTests()
+    {
+        _controller = new UserRolesController(_service.Object);
+    }
+
+    [Fact]
+    public async Task GetAllRoles_Returns_Ok_WithRoles()
+    {
+        var roles = new List<Role>
+        {
+            new() { Id = 1, Name = "Admin", NormalizedName = "ADMIN", IsSystem = true }
+        };
+        _service.Setup(s => s.GetAllRolesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(roles);
+
+        var result = await _controller.GetAllRoles(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<RolesResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.Single(response.Data!.Roles);
+        Assert.Equal("Admin", response.Data.Roles[0].Name);
+        _service.Verify(s => s.GetAllRolesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetByUserId_WhenFound_Returns_Ok_WithAssignment()
+    {
+        var ur = new UserRole { UserId = 5, RoleId = 2 };
+        var role = new Role { Id = 2, Name = "VpnUser", NormalizedName = "VPNUSER", IsSystem = true };
+        _service.Setup(s => s.GetAssignmentByUserIdAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ur, role));
+
+        var result = await _controller.GetByUserId(5, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<UserRoleAssignmentResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.NotNull(response.Data?.Assignment);
+        Assert.Equal(5, response.Data.Assignment.UserId);
+        Assert.Equal(2, response.Data.Assignment.RoleId);
+        Assert.Equal("VpnUser", response.Data.Assignment.RoleName);
+    }
+
+    [Fact]
+    public async Task GetByUserId_WhenNoAssignment_Returns_Ok_WithNullAssignment()
+    {
+        _service.Setup(s => s.GetAssignmentByUserIdAsync(9, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(((UserRole, Role)?)null);
+
+        var result = await _controller.GetByUserId(9, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<UserRoleAssignmentResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.Null(response.Data?.Assignment);
+    }
+
+    [Fact]
+    public async Task GetByUserId_WhenUserNotFound_Returns_NotFound()
+    {
+        _service.Setup(s => s.GetAssignmentByUserIdAsync(99, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("missing"));
+
+        var result = await _controller.GetByUserId(99, CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task SetUserRole_Returns_Ok()
+    {
+        var ur = new UserRole { UserId = 1, RoleId = 2 };
+        var role = new Role { Id = 2, Name = "VpnUser", NormalizedName = "VPNUSER", IsSystem = true };
+        _service.Setup(s => s.SetUserRoleAsync(1, 2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ur, role));
+
+        var result = await _controller.SetUserRole(new SetUserRoleRequest { UserId = 1, RoleId = 2 },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<UserRoleAssignmentResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.Equal("VpnUser", response.Data!.Assignment!.RoleName);
+    }
+
+    [Fact]
+    public async Task SetUserRole_WhenNotFound_Returns_NotFound()
+    {
+        _service.Setup(s => s.SetUserRoleAsync(1, 2, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("User 1 not found."));
+
+        var result = await _controller.SetUserRole(new SetUserRoleRequest { UserId = 1, RoleId = 2 },
+            CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task SetUserRole_WhenInvalidOperation_Returns_BadRequest()
+    {
+        _service.Setup(s => s.SetUserRoleAsync(1, 2, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Cannot remove the last administrator."));
+
+        var result = await _controller.SetUserRole(new SetUserRoleRequest { UserId = 1, RoleId = 2 },
+            CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+}

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerOverviewQueryTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerOverviewQueryTests.cs
@@ -35,6 +35,10 @@ public class OpenVpnServerOverviewQueryTests
             .Setup(u => u.GetQuery<OpenVpnServerStatusLog>())
             .Returns(new TestQuery<OpenVpnServerStatusLog>(ctx.OpenVpnServerStatusLogs));
 
+        uowMock
+            .Setup(u => u.GetQuery<QuotaPlanAllowedServer>())
+            .Returns(new TestQuery<QuotaPlanAllowedServer>(ctx.QuotaPlanAllowedServers));
+
         var sut = new OpenVpnServerOverviewQuery(uowMock.Object);
         return (sut, ctx);
     }
@@ -356,6 +360,96 @@ public class OpenVpnServerOverviewQueryTests
         Assert.Equal(0, sessions);
     }
 
+    [Fact]
+    public async Task GetAllOpenVpnServersWithStatusAsync_WithRestrictToQuotaPlanId_ReturnsOnlyServersLinkedToPlan()
+    {
+        var (sut, ctx) = CreateSutWithContext();
+        var now = DateTimeOffset.UtcNow;
+
+        var sAllowed = new OpenVpnServer
+        {
+            Id = 301,
+            ServerName = "in-plan",
+            IsDeleted = false,
+            ApiUrl = "https://a",
+            CreateDate = now,
+            LastUpdate = now
+        };
+        var sOther = new OpenVpnServer
+        {
+            Id = 302,
+            ServerName = "not-in-plan",
+            IsDeleted = false,
+            ApiUrl = "https://b",
+            CreateDate = now,
+            LastUpdate = now
+        };
+        await ctx.OpenVpnServers.AddRangeAsync(sAllowed, sOther);
+        await ctx.QuotaPlanAllowedServers.AddAsync(new QuotaPlanAllowedServer
+        {
+            Id = 1,
+            QuotaPlanId = 77,
+            VpnServerId = 301,
+            CreateDate = now,
+            LastUpdate = now
+        });
+        await ctx.SaveChangesAsync();
+
+        var result = await sut.GetAllOpenVpnServersWithStatusAsync(
+            includeDeleted: false,
+            requireQuotaPlanAssignment: false,
+            restrictToQuotaPlanId: 77,
+            ct: CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal(301, result[0].OpenVpnServerResponses.OpenVpnServer.Id);
+    }
+
+    [Fact]
+    public async Task GetAllOpenVpnServersWithStatusAsync_WithRequireQuotaPlanAssignment_ReturnsOnlyServersWithAnyQuotaLink()
+    {
+        var (sut, ctx) = CreateSutWithContext();
+        var now = DateTimeOffset.UtcNow;
+
+        var sLinked = new OpenVpnServer
+        {
+            Id = 401,
+            ServerName = "linked",
+            IsDeleted = false,
+            ApiUrl = "https://l",
+            CreateDate = now,
+            LastUpdate = now
+        };
+        var sOrphan = new OpenVpnServer
+        {
+            Id = 402,
+            ServerName = "orphan",
+            IsDeleted = false,
+            ApiUrl = "https://o",
+            CreateDate = now,
+            LastUpdate = now
+        };
+        await ctx.OpenVpnServers.AddRangeAsync(sLinked, sOrphan);
+        await ctx.QuotaPlanAllowedServers.AddAsync(new QuotaPlanAllowedServer
+        {
+            Id = 2,
+            QuotaPlanId = 1,
+            VpnServerId = 401,
+            CreateDate = now,
+            LastUpdate = now
+        });
+        await ctx.SaveChangesAsync();
+
+        var result = await sut.GetAllOpenVpnServersWithStatusAsync(
+            includeDeleted: false,
+            requireQuotaPlanAssignment: true,
+            restrictToQuotaPlanId: null,
+            ct: CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal(401, result[0].OpenVpnServerResponses.OpenVpnServer.Id);
+    }
+
     // ---- Test DbContext ----
 
     private sealed class TestDbContext : DbContext
@@ -365,6 +459,7 @@ public class OpenVpnServerOverviewQueryTests
         public DbSet<OpenVpnServer> OpenVpnServers => Set<OpenVpnServer>();
         public DbSet<OpenVpnServerClient> OpenVpnServerClients => Set<OpenVpnServerClient>();
         public DbSet<OpenVpnServerStatusLog> OpenVpnServerStatusLogs => Set<OpenVpnServerStatusLog>();
+        public DbSet<QuotaPlanAllowedServer> QuotaPlanAllowedServers => Set<QuotaPlanAllowedServer>();
     }
 
     // ---- IQuery adapter for tests ----

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryServiceTests.cs
@@ -21,7 +21,8 @@ public class OpenVpnServerQueryServiceTests
 
         var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
         var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
-        var result = await sut.GetAll(includeDeleted: false, CancellationToken.None);
+        var result = await sut.GetAll(includeDeleted: false, requireQuotaPlanAssignment: false,
+            restrictToQuotaPlanId: null, CancellationToken.None);
 
         Assert.Single(result);
         Assert.False(result[0].IsDeleted);
@@ -41,7 +42,8 @@ public class OpenVpnServerQueryServiceTests
 
         var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
         var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
-        var result = await sut.GetAll(includeDeleted: true, CancellationToken.None);
+        var result = await sut.GetAll(includeDeleted: true, requireQuotaPlanAssignment: false,
+            restrictToQuotaPlanId: null, CancellationToken.None);
 
         Assert.Equal(2, result.Count);
         q.Verify(x => x.GetAll(It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Once);
@@ -91,7 +93,8 @@ public class OpenVpnServerQueryServiceTests
 
         var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
         var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
-        var result = await sut.GetPage(1, 10, includeDeleted: false, CancellationToken.None);
+        var result = await sut.GetPage(1, 10, includeDeleted: false, requireQuotaPlanAssignment: false,
+            restrictToQuotaPlanId: null, CancellationToken.None);
 
         Assert.NotNull(result);
         Assert.Equal(1, result.Page);
@@ -108,7 +111,8 @@ public class OpenVpnServerQueryServiceTests
 
         var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
         var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
-        var result = await sut.GetPage(1, 10, includeDeleted: true, CancellationToken.None);
+        var result = await sut.GetPage(1, 10, includeDeleted: true, requireQuotaPlanAssignment: false,
+            restrictToQuotaPlanId: null, CancellationToken.None);
 
         Assert.Equal(2, result.TotalCount);
         q.Verify(x => x.Page(1, 10, null, null, It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<System.Linq.Expressions.Expression<Func<OpenVpnServer, object>>[]>()), Times.Once);

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/OpenVpnServerTable/OpenVpnServerQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using Moq;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Responses;
@@ -18,7 +19,8 @@ public class OpenVpnServerQueryServiceTests
             .ReturnsAsync(list)
             .Verifiable();
 
-        var sut = new OpenVpnServerQueryService(q.Object);
+        var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+        var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
         var result = await sut.GetAll(includeDeleted: false, CancellationToken.None);
 
         Assert.Single(result);
@@ -37,7 +39,8 @@ public class OpenVpnServerQueryServiceTests
         var q = new Mock<IQueryService<OpenVpnServer, int>>();
         q.Setup(x => x.GetAll(It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(list);
 
-        var sut = new OpenVpnServerQueryService(q.Object);
+        var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+        var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
         var result = await sut.GetAll(includeDeleted: true, CancellationToken.None);
 
         Assert.Equal(2, result.Count);
@@ -52,7 +55,8 @@ public class OpenVpnServerQueryServiceTests
         q.Setup(x => x.FindById(10, It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<System.Linq.Expressions.Expression<Func<OpenVpnServer, object>>[]>()))
             .ReturnsAsync(server);
 
-        var sut = new OpenVpnServerQueryService(q.Object);
+        var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+        var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
         var result = await sut.GetById(10, CancellationToken.None);
 
         Assert.NotNull(result);
@@ -67,7 +71,8 @@ public class OpenVpnServerQueryServiceTests
         q.Setup(x => x.Where(It.IsAny<System.Linq.Expressions.Expression<Func<OpenVpnServer, bool>>>(), null, true, It.IsAny<CancellationToken>(), It.IsAny<System.Linq.Expressions.Expression<Func<OpenVpnServer, object>>[]>()))
             .ReturnsAsync(list);
 
-        var sut = new OpenVpnServerQueryService(q.Object);
+        var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+        var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
         var result = await sut.GetDefaultExcept(5, CancellationToken.None);
 
         Assert.Single(result);
@@ -84,7 +89,8 @@ public class OpenVpnServerQueryServiceTests
         q.Setup(x => x.Page(1, 10, It.IsAny<System.Linq.Expressions.Expression<Func<OpenVpnServer, bool>>>(), null, It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<System.Linq.Expressions.Expression<Func<OpenVpnServer, object>>[]>()))
             .ReturnsAsync(paged);
 
-        var sut = new OpenVpnServerQueryService(q.Object);
+        var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+        var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
         var result = await sut.GetPage(1, 10, includeDeleted: false, CancellationToken.None);
 
         Assert.NotNull(result);
@@ -100,7 +106,8 @@ public class OpenVpnServerQueryServiceTests
         q.Setup(x => x.Page(1, 10, null, null, It.IsAny<bool>(), It.IsAny<CancellationToken>(), It.IsAny<System.Linq.Expressions.Expression<Func<OpenVpnServer, object>>[]>()))
             .ReturnsAsync(paged);
 
-        var sut = new OpenVpnServerQueryService(q.Object);
+        var allowed = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+        var sut = new OpenVpnServerQueryService(q.Object, allowed.Object);
         var result = await sut.GetPage(1, 10, includeDeleted: true, CancellationToken.None);
 
         Assert.Equal(2, result.TotalCount);

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/QuotaPlanAllowedServerTable/QuotaPlanAllowedServerQueryServiceTests.cs
@@ -1,5 +1,9 @@
+using Microsoft.EntityFrameworkCore;
 using Moq;
+using OpenVPNGateMonitor.DataBase.Repositories.Queries.Interfaces;
+using OpenVPNGateMonitor.DataBase.Services.Query;
 using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using OpenVPNGateMonitor.DataBase.UnitOfWork;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Responses;
 using OpenVPNGateMonitor.Tests.Helpers;
@@ -74,5 +78,72 @@ public class QuotaPlanAllowedServerQueryServiceTests
         Assert.Single(result);
         Assert.Equal(5, result[0].VpnServerId);
         q.Verify();
+    }
+
+    [Fact]
+    public async Task GetVpnServerIdsByQuotaPlanId_ReturnsDistinctVpnServerIds()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var rows = new List<QuotaPlanAllowedServer>
+        {
+            new() { Id = 1, QuotaPlanId = 3, VpnServerId = 10, CreateDate = now, LastUpdate = now },
+            new() { Id = 2, QuotaPlanId = 3, VpnServerId = 10, CreateDate = now, LastUpdate = now },
+            new() { Id = 3, QuotaPlanId = 3, VpnServerId = 20, CreateDate = now, LastUpdate = now }
+        };
+
+        var q = new Mock<IQueryService<QuotaPlanAllowedServer, int>>();
+        q.Setup(x => x.Where(It.IsAny<System.Linq.Expressions.Expression<Func<QuotaPlanAllowedServer, bool>>>(), null, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rows);
+
+        var sut = new QuotaPlanAllowedServerQueryService(q.Object);
+        var set = await sut.GetVpnServerIdsByQuotaPlanId(3, CancellationToken.None);
+
+        Assert.Equal(2, set.Count);
+        Assert.Contains(10, set);
+        Assert.Contains(20, set);
+    }
+
+    [Fact]
+    public async Task GetDistinctVpnServerIds_UsesQueryAndDistinct()
+    {
+        var options = new DbContextOptionsBuilder<TestQuotaDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var ctx = new TestQuotaDbContext(options);
+        var now = DateTimeOffset.UtcNow;
+        ctx.QuotaPlanAllowedServers.AddRange(
+            new QuotaPlanAllowedServer { Id = 1, QuotaPlanId = 1, VpnServerId = 100, CreateDate = now, LastUpdate = now },
+            new QuotaPlanAllowedServer { Id = 2, QuotaPlanId = 1, VpnServerId = 100, CreateDate = now, LastUpdate = now },
+            new QuotaPlanAllowedServer { Id = 3, QuotaPlanId = 2, VpnServerId = 200, CreateDate = now, LastUpdate = now });
+        await ctx.SaveChangesAsync();
+
+        var uowMock = new Mock<IUnitOfWork>();
+        uowMock.Setup(u => u.GetQuery<QuotaPlanAllowedServer>())
+            .Returns(new TestQueryAdapter(ctx.QuotaPlanAllowedServers));
+
+        var ef = new EfQueryService<QuotaPlanAllowedServer, int>(uowMock.Object);
+        var sut = new QuotaPlanAllowedServerQueryService(ef);
+
+        var set = await sut.GetDistinctVpnServerIds(CancellationToken.None);
+
+        Assert.Equal(2, set.Count);
+        Assert.Contains(100, set);
+        Assert.Contains(200, set);
+    }
+
+    private sealed class TestQuotaDbContext : DbContext
+    {
+        public TestQuotaDbContext(DbContextOptions<TestQuotaDbContext> options) : base(options) { }
+
+        public DbSet<QuotaPlanAllowedServer> QuotaPlanAllowedServers => Set<QuotaPlanAllowedServer>();
+    }
+
+    private sealed class TestQueryAdapter : IQuery<QuotaPlanAllowedServer>
+    {
+        private readonly IQueryable<QuotaPlanAllowedServer> _query;
+
+        public TestQueryAdapter(IQueryable<QuotaPlanAllowedServer> query) => _query = query;
+
+        public IQueryable<QuotaPlanAllowedServer> AsQueryable() => _query;
     }
 }

--- a/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
+++ b/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.94" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
+++ b/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
+++ b/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
+        <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
         <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
+++ b/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/OpenVPNGateMonitor.Tests/Services/Api/Auth/Handlers/VpnServerAccessQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/Api/Auth/Handlers/VpnServerAccessQueryServiceTests.cs
@@ -16,7 +16,7 @@ public class VpnServerAccessQueryServiceTests
         var allowed = new QuotaPlanAllowedServer { QuotaPlanId = 5, VpnServerId = 10 };
 
         var quotaQuery = new Mock<IUserQuotaPlanQueryService>();
-        quotaQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync(userQuotaPlan);
+        quotaQuery.Setup(q => q.GetActiveByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync(userQuotaPlan);
         var allowedQuery = new Mock<IQuotaPlanAllowedServerQueryService>();
         allowedQuery.Setup(q => q.GetByQuotaPlanIdAndServerId(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync(allowed);
 
@@ -31,7 +31,7 @@ public class VpnServerAccessQueryServiceTests
     public async Task UserHasAccessAsync_When_UserHasNoQuotaPlan_Returns_False()
     {
         var quotaQuery = new Mock<IUserQuotaPlanQueryService>();
-        quotaQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync((UserQuotaPlan?)null);
+        quotaQuery.Setup(q => q.GetActiveByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync((UserQuotaPlan?)null);
         var allowedQuery = new Mock<IQuotaPlanAllowedServerQueryService>();
 
         var sut = new VpnServerAccessQueryService(quotaQuery.Object, allowedQuery.Object);
@@ -46,7 +46,7 @@ public class VpnServerAccessQueryServiceTests
     {
         var userQuotaPlan = new UserQuotaPlan { UserId = 1, QuotaPlanId = 5 };
         var quotaQuery = new Mock<IUserQuotaPlanQueryService>();
-        quotaQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync(userQuotaPlan);
+        quotaQuery.Setup(q => q.GetActiveByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync(userQuotaPlan);
         var allowedQuery = new Mock<IQuotaPlanAllowedServerQueryService>();
         allowedQuery.Setup(q => q.GetByQuotaPlanIdAndServerId(5, 10, It.IsAny<CancellationToken>())).ReturnsAsync((QuotaPlanAllowedServer?)null);
 

--- a/OpenVPNGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
@@ -147,10 +147,7 @@ public class VpnDataServiceTests
 
         quotaPlanCmd.Verify(c => c.AddRange(
             It.Is<IEnumerable<QuotaPlanAllowedServer>>(xs =>
-            {
-                var list = xs.ToList();
-                return list.Count == 1 && list[0].QuotaPlanId == 42 && list[0].VpnServerId == 101;
-            }),
+                xs.Single().QuotaPlanId == 42 && xs.Single().VpnServerId == 101),
             true,
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/OpenVPNGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Logging;
@@ -5,6 +6,7 @@ using Moq;
 using OpenVPNGateMonitor.DataBase.Services.Command.Interfaces;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerOvpnFileConfigTable;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanTable;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.Services.Api;
 using OpenVPNGateMonitor.Services.Api.Interfaces;
@@ -21,6 +23,7 @@ public class VpnDataServiceTests
     private static (VpnDataService svc,
         Mock<ILogger<IVpnDataService>> log,
         Mock<IExternalIpAddressService> ip,
+        Mock<IQuotaPlanQueryService> quotaPlanQ,
         Mock<IOpenVpnServerQueryService> serverQ,
         Mock<IOpenVpnServerOvpnFileConfigQueryService> cfgQ,
         Mock<ITransactionRunner> trx,
@@ -45,6 +48,8 @@ public class VpnDataServiceTests
         var notification = new Mock<IServerOpenVpnNotificationService>(MockBehavior.Loose);
         var microserviceFactory = new Mock<IOpenVpnMicroserviceClientFactory>(MockBehavior.Loose);
         var eventFactory = new Mock<IOpenVpnEventClientFactory>(MockBehavior.Loose);
+        var quotaPlanQ = new Mock<IQuotaPlanQueryService>(MockBehavior.Strict);
+        quotaPlanQ.Setup(q => q.GetDefault(It.IsAny<CancellationToken>())).ReturnsAsync((QuotaPlan?)null);
 
         trx.Setup(t => t.RunAsync(It.IsAny<Func<CancellationToken, Task<OpenVpnServer>>>(), It.IsAny<CancellationToken>()))
             .Returns<Func<CancellationToken, Task<OpenVpnServer>>, CancellationToken>(async (f, ct) => await f(ct));
@@ -54,6 +59,7 @@ public class VpnDataServiceTests
         var svc = new VpnDataService(
             log.Object,
             ip.Object,
+            quotaPlanQ.Object,
             serverQ.Object,
             cfgQ.Object,
             trx.Object,
@@ -65,13 +71,13 @@ public class VpnDataServiceTests
             microserviceFactory.Object,
             eventFactory.Object);
 
-        return (svc, log, ip, serverQ, cfgQ, trx, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, notification, microserviceFactory, eventFactory);
+        return (svc, log, ip, quotaPlanQ, serverQ, cfgQ, trx, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, notification, microserviceFactory, eventFactory);
     }
 
     [Fact]
     public async Task AddOpenVpnServer_Adds_Config_When_None_Exists_And_Not_Default()
     {
-        var (svc, _, ip, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
+        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
         var server = new OpenVpnServer { Id = 0, IsDefault = false, ServerName = "Srv" };
 
         var before = DateTimeOffset.UtcNow;
@@ -111,9 +117,48 @@ public class VpnDataServiceTests
     }
 
     [Fact]
+    public async Task AddOpenVpnServer_Links_DefaultQuotaPlan_When_List_Empty_And_Default_Exists()
+    {
+        var (svc, _, ip, quotaPlanQ, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
+        quotaPlanQ.Setup(q => q.GetDefault(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QuotaPlan { Id = 42, Name = "Default" });
+
+        var server = new OpenVpnServer { Id = 0, IsDefault = false, ServerName = "Srv" };
+
+        cfgQ.Setup(q => q.AnyByVpnServerId(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("203.0.113.10");
+        serverQ.Setup(q => q.AnyByServerName("Srv", It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        serverCmd.Setup(c => c.Add(It.IsAny<OpenVpnServer>(), true, It.IsAny<CancellationToken>()))
+            .Callback<OpenVpnServer, bool, CancellationToken>((s, _, _) => s.Id = 101)
+            .ReturnsAsync((OpenVpnServer s, bool _, CancellationToken _) => s);
+
+        cfgCmd.Setup(c => c.Add(It.IsAny<OpenVpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OpenVpnServerOvpnFileConfig e, bool _, CancellationToken _) => e);
+
+        serverQ.Setup(q => q.GetById(101, It.IsAny<CancellationToken>())).ReturnsAsync(server);
+
+        quotaPlanCmd.Setup(c => c.DeleteWhere(It.IsAny<Expression<Func<QuotaPlanAllowedServer, bool>>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(0));
+        quotaPlanCmd.Setup(c => c.AddRange(It.IsAny<IEnumerable<QuotaPlanAllowedServer>>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        tagCmd.Setup(c => c.DeleteWhere(It.IsAny<Expression<Func<OpenVpnServerTag, bool>>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(0));
+
+        await svc.AddOpenVpnServer(server, new List<int>(), new List<int>(), CancellationToken.None);
+
+        quotaPlanCmd.Verify(c => c.AddRange(
+            It.Is<IEnumerable<QuotaPlanAllowedServer>>(xs =>
+            {
+                var list = xs.ToList();
+                return list.Count == 1 && list[0].QuotaPlanId == 42 && list[0].VpnServerId == 101;
+            }),
+            true,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task AddOpenVpnServer_Unsets_Previous_Default_When_IsDefault_True()
     {
-        var (svc, _, ip, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
+        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
         var server = new OpenVpnServer { Id = 0, IsDefault = true, ServerName = "DefaultSrv" };
 
         cfgQ.Setup(q => q.AnyByVpnServerId(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
@@ -147,7 +192,7 @@ public class VpnDataServiceTests
     [Fact]
     public async Task UpdateOpenVpnServer_Updates_Entity_And_Adds_Config_When_Missing()
     {
-        var (svc, _, ip, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
+        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
         var server = new OpenVpnServer { Id = 51, IsDefault = false, ServerName = "Srv" };
 
         cfgQ.Setup(q => q.AnyByVpnServerId(51, It.IsAny<CancellationToken>())).ReturnsAsync(false);
@@ -174,7 +219,7 @@ public class VpnDataServiceTests
     [Fact]
     public async Task UpdateOpenVpnServer_Unsets_Other_Defaults_When_IsDefault_True()
     {
-        var (svc, _, ip, serverQ, cfgQ, _, serverCmd, _, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
+        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, _, quotaPlanCmd, tagCmd, _, _, _) = CreateService();
         var server = new OpenVpnServer { Id = 9, IsDefault = true, ServerName = "Srv" };
 
         cfgQ.Setup(q => q.AnyByVpnServerId(9, It.IsAny<CancellationToken>())).ReturnsAsync(true);
@@ -204,7 +249,7 @@ public class VpnDataServiceTests
     [Fact]
     public async Task DeleteOpenVpnServer_Performs_SoftDelete_WithUpdateWhere()
     {
-        var (svc, _, _, serverQ, _, _, serverCmd, _, _, _, _, _, _) = CreateService();
+        var (svc, _, _, _, serverQ, _, _, serverCmd, _, _, _, _, _, _) = CreateService();
         var entity = new OpenVpnServer { Id = 77, ServerName = "Srv" };
         serverQ.Setup(q => q.GetById(77, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
         serverCmd.Setup(c => c.UpdateWhere(
@@ -225,7 +270,7 @@ public class VpnDataServiceTests
     [Fact]
     public async Task DeleteOpenVpnServer_Throws_When_NotFound()
     {
-        var (svc, _, _, serverQ, _, _, _, _, _, _, _, _, _) = CreateService();
+        var (svc, _, _, _, serverQ, _, _, _, _, _, _, _, _, _) = CreateService();
         serverQ.Setup(q => q.GetById(555, It.IsAny<CancellationToken>())).ReturnsAsync((OpenVpnServer?)null);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteOpenVpnServer(555, CancellationToken.None));

--- a/OpenVPNGateMonitor.Tests/Services/UserRoles/UserRoleManagementServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/UserRoles/UserRoleManagementServiceTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OpenVPNGateMonitor.DataBase.Services.Command.Interfaces;
+using OpenVPNGateMonitor.DataBase.Services.Query.RoleTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserRoleTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserTable;
+using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Services.UserRoles;
+using OpenVPNGateMonitor.SharedModels.Auth;
+using Xunit;
+
+namespace OpenVPNGateMonitor.Tests.Services.UserRoles;
+
+public class UserRoleManagementServiceTests
+{
+    private readonly Mock<ICommandService<UserRole, int>> _cmd = new(MockBehavior.Strict);
+    private readonly Mock<IUserRoleQueryService> _userRoleQuery = new(MockBehavior.Strict);
+    private readonly Mock<IRoleQueryService> _roleQuery = new(MockBehavior.Strict);
+    private readonly Mock<IUserQueryService> _userQuery = new(MockBehavior.Strict);
+
+    private UserRoleManagementService CreateSut() =>
+        new(
+            NullLogger<UserRoleManagementService>.Instance,
+            _cmd.Object,
+            _userRoleQuery.Object,
+            _roleQuery.Object,
+            _userQuery.Object);
+
+    [Fact]
+    public async Task GetAllRolesAsync_Delegates_To_RoleQuery()
+    {
+        var list = new List<Role> { new() { Id = 1, Name = "A", NormalizedName = "A", IsSystem = true } };
+        _roleQuery.Setup(q => q.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync(list);
+
+        var sut = CreateSut();
+        var result = await sut.GetAllRolesAsync(CancellationToken.None);
+
+        Assert.Same(list, result);
+        _roleQuery.Verify(q => q.GetAll(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAssignmentByUserIdAsync_WhenUserMissing_Throws()
+    {
+        _userQuery.Setup(q => q.GetById(1, It.IsAny<CancellationToken>())).ReturnsAsync((User?)null);
+
+        var sut = CreateSut();
+        await Assert.ThrowsAsync<KeyNotFoundException>(() => sut.GetAssignmentByUserIdAsync(1, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetAssignmentByUserIdAsync_WhenNoRole_Returns_Null()
+    {
+        _userQuery.Setup(q => q.GetById(1, It.IsAny<CancellationToken>())).ReturnsAsync(new User { Id = 1 });
+        _userRoleQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync((UserRole?)null);
+
+        var sut = CreateSut();
+        var result = await sut.GetAssignmentByUserIdAsync(1, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SetUserRoleAsync_WhenServiceRole_Throws()
+    {
+        _userQuery.Setup(q => q.GetById(1, It.IsAny<CancellationToken>())).ReturnsAsync(new User { Id = 1 });
+        _roleQuery.Setup(q => q.GetById(SystemRoles.ServiceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Role { Id = SystemRoles.ServiceId, Name = SystemRoles.ServiceName, NormalizedName = SystemRoles.ServiceNormalizedName, IsSystem = true });
+
+        var sut = CreateSut();
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.SetUserRoleAsync(1, SystemRoles.ServiceId, CancellationToken.None));
+
+        Assert.Contains("Service role", ex.Message);
+    }
+
+    [Fact]
+    public async Task SetUserRoleAsync_WhenLastAdminDemoted_Throws()
+    {
+        _userQuery.Setup(q => q.GetById(1, It.IsAny<CancellationToken>())).ReturnsAsync(new User { Id = 1 });
+        _roleQuery.Setup(q => q.GetById(SystemRoles.VpnUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Role { Id = SystemRoles.VpnUserId, Name = "VpnUser", NormalizedName = "VPNUSER", IsSystem = true });
+
+        var existing = new UserRole { UserId = 1, RoleId = SystemRoles.AdminId };
+        _userRoleQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _userRoleQuery.Setup(q => q.GetUserIdsByRoleIdAsync(SystemRoles.AdminId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<int> { 1 });
+
+        var sut = CreateSut();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.SetUserRoleAsync(1, SystemRoles.VpnUserId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SetUserRoleAsync_WhenSameRole_Returns_WithoutWrites()
+    {
+        _userQuery.Setup(q => q.GetById(1, It.IsAny<CancellationToken>())).ReturnsAsync(new User { Id = 1 });
+        _roleQuery.Setup(q => q.GetById(SystemRoles.VpnUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Role { Id = SystemRoles.VpnUserId, Name = "VpnUser", NormalizedName = "VPNUSER", IsSystem = true });
+
+        var existing = new UserRole { UserId = 1, RoleId = SystemRoles.VpnUserId };
+        _userRoleQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+        var sut = CreateSut();
+        var (ur, role) = await sut.SetUserRoleAsync(1, SystemRoles.VpnUserId, CancellationToken.None);
+
+        Assert.Same(existing, ur);
+        Assert.Equal("VpnUser", role.Name);
+        _cmd.Verify(c => c.DeleteWhere(It.IsAny<System.Linq.Expressions.Expression<Func<UserRole, bool>>>(), It.IsAny<CancellationToken>()), Times.Never);
+        _cmd.Verify(c => c.Add(It.IsAny<UserRole>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SetUserRoleAsync_Replaces_Role()
+    {
+        _userQuery.Setup(q => q.GetById(1, It.IsAny<CancellationToken>())).ReturnsAsync(new User { Id = 1 });
+        var adminRole = new Role { Id = SystemRoles.AdminId, Name = "Admin", NormalizedName = "ADMIN", IsSystem = true };
+        _roleQuery.Setup(q => q.GetById(SystemRoles.AdminId, It.IsAny<CancellationToken>())).ReturnsAsync(adminRole);
+
+        var existing = new UserRole { UserId = 1, RoleId = SystemRoles.VpnUserId };
+        _userRoleQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+
+        _cmd.Setup(c => c.DeleteWhere(It.IsAny<System.Linq.Expressions.Expression<Func<UserRole, bool>>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _cmd.Setup(c => c.Add(It.IsAny<UserRole>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserRole ur, bool _, CancellationToken _) => ur);
+
+        var sut = CreateSut();
+        await sut.SetUserRoleAsync(1, SystemRoles.AdminId, CancellationToken.None);
+
+        _cmd.Verify(c => c.DeleteWhere(It.IsAny<System.Linq.Expressions.Expression<Func<UserRole, bool>>>(), It.IsAny<CancellationToken>()), Times.Once);
+        _cmd.Verify(c => c.Add(It.Is<UserRole>(ur => ur.UserId == 1 && ur.RoleId == SystemRoles.AdminId), true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/OpenVPNGateMonitor/Configurations/QueryCommandConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/QueryCommandConfiguration.cs
@@ -78,6 +78,7 @@ public static class QueryCommandConfiguration
 
         // Feature: overview queries
         services.AddScoped<IOpenVpnServerOverviewQuery, OpenVpnServerOverviewQuery>();
+        services.AddScoped<IOpenVpnServerQuotaPlanGroupsQuery, OpenVpnServerQuotaPlanGroupsQuery>();
 
     }
 }

--- a/OpenVPNGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/ServiceConfiguration.cs
@@ -15,6 +15,7 @@ using OpenVPNGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
 using OpenVPNGateMonitor.Services.Others;
 using OpenVPNGateMonitor.Services.QuotaPlans;
 using OpenVPNGateMonitor.Services.Tags;
+using OpenVPNGateMonitor.Services.UserRoles;
 using OpenVPNGateMonitor.Services.Users;
 using OpenVPNGateMonitor.Services.Users.Interfaces;
 
@@ -71,6 +72,7 @@ public static class ServiceConfiguration
         services.AddScoped<IUserService, UserService>();
         
         services.AddScoped<IQuotaPlanService, QuotaPlanService>();
+        services.AddScoped<IUserRoleManagementService, UserRoleManagementService>();
         services.AddScoped<IQuotaPlanAllowedServerService, QuotaPlanAllowedServerService>();
         services.AddScoped<ITagService, TagService>();
         

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -34,7 +34,7 @@ public class OpenVpnFilesController(
         try
         {
             var result = await ovpnFileApiService.GetByToken(request.Token, cancellationToken);
-            if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+            if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFileResponse>(User,
                     vpnServerAccessQueryService, result.VpnServerId, cancellationToken) is { } deny)
                 return deny;
             var response = result.Adapt<OvpnFileResponse>();
@@ -51,7 +51,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<OvpnFilesResponse>>> GetAllByVpnServerId(
         [FromRoute] ByVpnServerIdRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFilesResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -73,7 +73,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<OvpnFilesResponse>>> GetAllByExternalIdAndVpnServerId(
         [FromRoute] ByExternalIdAndVpnServerIdRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFilesResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -98,7 +98,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<OvpnFilesWithTokensResponse>>> GetAllWithToken(
         [FromRoute] ByVpnServerIdRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFilesWithTokensResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -122,7 +122,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<OvpnFilesWithTokensResponse>>> GetAllWithToken(
         [FromRoute] ByExternalIdAndVpnServerIdRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFilesWithTokensResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -169,7 +169,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<OvpnFileResponse>>> AddFile(
         [FromBody] AddFileRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFileResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -191,7 +191,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<OvpnFileWithTokenResponse>>> AddFileWithToken(
         [FromBody] AddFileRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFileWithTokenResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -215,7 +215,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<OvpnFileResponse>>> RevokeFile([FromBody] RevokeFileRequest request,
         CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OvpnFileResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -237,7 +237,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<DownloadFileResponse>>> DownloadFile(
         [FromBody] DownloadFileRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<DownloadFileResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -259,7 +259,7 @@ public class OpenVpnFilesController(
     public async Task<ActionResult<ApiResponse<DownloadFileResponse>>> DownloadFileByCn(
         [FromBody] DownloadFileByCnRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<DownloadFileResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -284,7 +284,7 @@ public class OpenVpnFilesController(
             return files;
         if (!HttpUserContext.TryGetUserId(User, out var userId))
             return files;
-        var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+        var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
         if (uqp is null)
             return [];
         var allowed = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(uqp.QuotaPlanId, ct);

--- a/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -1,6 +1,11 @@
-﻿using Mapster;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Services.Api;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnFiles.Requests;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnFiles.Responses;
@@ -12,14 +17,13 @@ namespace OpenVPNGateMonitor.Controllers;
 [Route("api/open-vpn-files")]
 [Authorize]
 [Authorize(Roles = "Admin,VpnUser,App")]
-public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService, 
-    ILogger<OpenVpnFilesController> logger) : BaseController
+public class OpenVpnFilesController(
+    IOvpnFileApiService ovpnFileApiService,
+    ILogger<OpenVpnFilesController> logger,
+    IUserQuotaPlanQueryService userQuotaPlanQueryService,
+    IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService,
+    IVpnServerAccessQueryService vpnServerAccessQueryService) : BaseController
 {
-// TODO: add pagination
-// TODO: deprecate all "*WithToken" endpoints/services.
-// TODO: move token creation into the regular Add method and
-//       return the token as part of the IssuedOvpnFile payload (embedded DTO).
-    
     [HttpGet("by-token/{token}")]
     public async Task<ActionResult<ApiResponse<OvpnFileResponse>>> GetByToken([FromRoute] ByTokenRequest request,
         CancellationToken cancellationToken)
@@ -30,6 +34,9 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
         try
         {
             var result = await ovpnFileApiService.GetByToken(request.Token, cancellationToken);
+            if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                    vpnServerAccessQueryService, result.VpnServerId, cancellationToken) is { } deny)
+                return deny;
             var response = result.Adapt<OvpnFileResponse>();
             return Ok(ApiResponse<OvpnFileResponse>.SuccessResponse(response));
         }
@@ -39,14 +46,18 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
             return BadRequest(ApiResponse<OvpnFileResponse>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpGet("get-all/{vpnServerId:int}")]
     public async Task<ActionResult<ApiResponse<OvpnFilesResponse>>> GetAllByVpnServerId(
         [FromRoute] ByVpnServerIdRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
-            var result = await ovpnFileApiService.GetAllByVpnServerId(request.VpnServerId, 
+            var result = await ovpnFileApiService.GetAllByVpnServerId(request.VpnServerId,
                 cancellationToken);
             var response = result.Adapt<OvpnFilesResponse>();
             return Ok(ApiResponse<OvpnFilesResponse>.SuccessResponse(response));
@@ -57,11 +68,15 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpGet("get-all/{vpnServerId:int}/{externalId}")]
     public async Task<ActionResult<ApiResponse<OvpnFilesResponse>>> GetAllByExternalIdAndVpnServerId(
         [FromRoute] ByExternalIdAndVpnServerIdRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var result = await ovpnFileApiService.GetAllByExternalIdAndVpnServerId(
@@ -73,16 +88,20 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get all ovpn files on server {VpnServerId} and {ExternalId}", 
+            logger.LogError(ex, "Failed to get all ovpn files on server {VpnServerId} and {ExternalId}",
                 request.VpnServerId, request.ExternalId);
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpGet("get-all-with-token/{vpnServerId:int}")]
     public async Task<ActionResult<ApiResponse<OvpnFilesWithTokensResponse>>> GetAllWithToken(
         [FromRoute] ByVpnServerIdRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var result = await ovpnFileApiService.GetAllByVpnServerIdWithToken(
@@ -93,16 +112,20 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get all ovpn files with token on server {VpnServerId}", 
+            logger.LogError(ex, "Failed to get all ovpn files with token on server {VpnServerId}",
                 request.VpnServerId);
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpGet("get-all-with-token/{vpnServerId:int}/{externalId}")]
     public async Task<ActionResult<ApiResponse<OvpnFilesWithTokensResponse>>> GetAllWithToken(
         [FromRoute] ByExternalIdAndVpnServerIdRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var result = await ovpnFileApiService.GetAllByExternalIdAndVpnServerIdWithToken(
@@ -120,7 +143,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpGet("get-files/{externalId}")]
     public async Task<ActionResult<ApiResponse<OvpnFilesResponse>>> GetFiles([FromRoute] ByExternalIdRequest request,
         CancellationToken cancellationToken)
@@ -129,6 +152,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
         {
             var result = await ovpnFileApiService.GetAllByExternalId(
                 request.ExternalId, cancellationToken);
+            result = await FilterIssuedFilesByQuotaPlanAsync(result, cancellationToken);
 
             var response = result.Adapt<OvpnFilesResponse>();
 
@@ -145,11 +169,15 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     public async Task<ActionResult<ApiResponse<OvpnFileResponse>>> AddFile(
         [FromBody] AddFileRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var result = await ovpnFileApiService.AddOvpnFile(request, cancellationToken);
 
-            return Ok(ApiResponse<OvpnFileResponse>.SuccessResponse( result.Adapt<OvpnFileResponse>()));
+            return Ok(ApiResponse<OvpnFileResponse>.SuccessResponse(result.Adapt<OvpnFileResponse>()));
         }
         catch (Exception ex)
         {
@@ -158,17 +186,21 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpPost("add-with-token")]
     public async Task<ActionResult<ApiResponse<OvpnFileWithTokenResponse>>> AddFileWithToken(
         [FromBody] AddFileRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var (file, token) = await ovpnFileApiService.AddOvpnFileWithToken(request, cancellationToken);
 
             var response = (file, token).Adapt<OvpnFileWithTokenResponse>();
-            
+
             return Ok(ApiResponse<OvpnFileWithTokenResponse>.SuccessResponse(response));
         }
         catch (Exception ex)
@@ -183,6 +215,10 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     public async Task<ActionResult<ApiResponse<OvpnFileResponse>>> RevokeFile([FromBody] RevokeFileRequest request,
         CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var result = await ovpnFileApiService.RevokeOvpnFile(request, cancellationToken);
@@ -191,7 +227,7 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to revoke OVPN for {CommonName} on server {VpnServerId}", 
+            logger.LogError(ex, "Failed to revoke OVPN for {CommonName} on server {VpnServerId}",
                 request.CommonName, request.VpnServerId);
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
@@ -201,35 +237,57 @@ public class OpenVpnFilesController(IOvpnFileApiService ovpnFileApiService,
     public async Task<ActionResult<ApiResponse<DownloadFileResponse>>> DownloadFile(
         [FromBody] DownloadFileRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
-            var content = await ovpnFileApiService.DownloadOvpnFile(request, 
+            var content = await ovpnFileApiService.DownloadOvpnFile(request,
                 cancellationToken);
             return Ok(ApiResponse<DownloadFileResponse>.SuccessResponse(content));
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to download OVPN file {IssuedOvpnFileId} for {VpnServerId}", 
+            logger.LogError(ex, "Failed to download OVPN file {IssuedOvpnFileId} for {VpnServerId}",
                 request.IssuedOvpnFileId, request.VpnServerId);
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpPost("download-file-by-cn")]
     public async Task<ActionResult<ApiResponse<DownloadFileResponse>>> DownloadFileByCn(
         [FromBody] DownloadFileByCnRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
-            var content = await ovpnFileApiService.DownloadOvpnFileByCn(request, 
+            var content = await ovpnFileApiService.DownloadOvpnFileByCn(request,
                 cancellationToken);
             return Ok(ApiResponse<DownloadFileResponse>.SuccessResponse(content));
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to download OVPN file {CommonName} for {VpnServerId}", 
+            logger.LogError(ex, "Failed to download OVPN file {CommonName} for {VpnServerId}",
                 request.CommonName, request.VpnServerId);
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
+    }
+
+    private async Task<List<IssuedOvpnFile>> FilterIssuedFilesByQuotaPlanAsync(List<IssuedOvpnFile> files,
+        CancellationToken ct)
+    {
+        if (HttpUserContext.IsPrivileged(User))
+            return files;
+        if (!HttpUserContext.TryGetUserId(User, out var userId))
+            return files;
+        var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+        if (uqp is null)
+            return [];
+        var allowed = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(uqp.QuotaPlanId, ct);
+        return files.Where(f => allowed.Contains(f.VpnServerId)).ToList();
     }
 }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServerAuthorizationHelper.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServerAuthorizationHelper.cs
@@ -1,0 +1,28 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.Services.Api;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
+using OpenVPNGateMonitor.SharedModels.Responses;
+
+namespace OpenVPNGateMonitor.Controllers;
+
+public static class OpenVpnServerAuthorizationHelper
+{
+    public static async Task<IActionResult?> RequireVpnServerAccessOrForbidAsync(
+        ClaimsPrincipal user,
+        IVpnServerAccessQueryService access,
+        int vpnServerId,
+        CancellationToken ct)
+    {
+        if (HttpUserContext.IsPrivileged(user))
+            return null;
+        if (!HttpUserContext.TryGetUserId(user, out var userId))
+            return new UnauthorizedObjectResult(ApiResponse<string>.ErrorResponse("User id missing from token."));
+        if (!await access.UserHasAccessAsync(userId, vpnServerId, ct))
+            return new ObjectResult(ApiResponse<string>.ErrorResponse(
+                    "Access to this VPN server is denied for your quota plan."))
+                { StatusCode = StatusCodes.Status403Forbidden };
+        return null;
+    }
+}

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServerAuthorizationHelper.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServerAuthorizationHelper.cs
@@ -9,7 +9,8 @@ namespace OpenVPNGateMonitor.Controllers;
 
 public static class OpenVpnServerAuthorizationHelper
 {
-    public static async Task<IActionResult?> RequireVpnServerAccessOrForbidAsync(
+    /// <typeparam name="T">Success payload type for <see cref="ApiResponse{T}"/> on this action (error bodies may still use <see cref="string"/>).</typeparam>
+    public static async Task<ActionResult<ApiResponse<T>>?> RequireVpnServerAccessOrForbidAsync<T>(
         ClaimsPrincipal user,
         IVpnServerAccessQueryService access,
         int vpnServerId,
@@ -18,11 +19,12 @@ public static class OpenVpnServerAuthorizationHelper
         if (HttpUserContext.IsPrivileged(user))
             return null;
         if (!HttpUserContext.TryGetUserId(user, out var userId))
-            return new UnauthorizedObjectResult(ApiResponse<string>.ErrorResponse("User id missing from token."));
+            return new ActionResult<ApiResponse<T>>(new UnauthorizedObjectResult(
+                ApiResponse<string>.ErrorResponse("User id missing from token.")));
         if (!await access.UserHasAccessAsync(userId, vpnServerId, ct))
-            return new ObjectResult(ApiResponse<string>.ErrorResponse(
+            return new ActionResult<ApiResponse<T>>(new ObjectResult(ApiResponse<string>.ErrorResponse(
                     "Access to this VPN server is denied for your quota plan."))
-                { StatusCode = StatusCodes.Status403Forbidden };
+                { StatusCode = StatusCodes.Status403Forbidden });
         return null;
     }
 }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServerCertsController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServerCertsController.cs
@@ -22,7 +22,7 @@ public class OpenVpnServerCertsController(ICertApiClient certApiClient,
     public async Task<ActionResult<ApiResponse<GetAllCertificatesResponse>>> GetAllCertificates(
         [FromRoute] GetAllCertificatesRequest request, CancellationToken ct)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<GetAllCertificatesResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, ct) is { } deny)
             return deny;
 
@@ -50,7 +50,7 @@ public class OpenVpnServerCertsController(ICertApiClient certApiClient,
     public async Task<ActionResult<ApiResponse<BuildCertificateResponse>>> BuildCertificate(
         [FromBody] BuildCertificateRequest request, CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<BuildCertificateResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 
@@ -82,7 +82,7 @@ public class OpenVpnServerCertsController(ICertApiClient certApiClient,
         [FromBody] RevokeCertificateRequest request,
         CancellationToken cancellationToken)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<RevokeCertificateResponse>(User,
                 vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
             return deny;
 

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServerCertsController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServerCertsController.cs
@@ -1,6 +1,7 @@
-﻿using Mapster;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerCerts.Requests;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServerCerts.Responses;
@@ -12,14 +13,19 @@ namespace OpenVPNGateMonitor.Controllers;
 [ApiController]
 [Route("api/open-vpn-certs")]
 [Authorize]
-[Authorize(Roles = "Admin,App")]
+[Authorize(Roles = "Admin,VpnUser,App")]
 public class OpenVpnServerCertsController(ICertApiClient certApiClient,
-    ILogger<OpenVpnServerCertsController> logger) : BaseController
+    ILogger<OpenVpnServerCertsController> logger,
+    IVpnServerAccessQueryService vpnServerAccessQueryService) : BaseController
 {
     [HttpGet("{vpnServerId}/get-all")]
     public async Task<ActionResult<ApiResponse<GetAllCertificatesResponse>>> GetAllCertificates(
         [FromRoute] GetAllCertificatesRequest request, CancellationToken ct)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, ct) is { } deny)
+            return deny;
+
         try
         {
             var certificates = await certApiClient.GetAllCertificatesAsync(request.VpnServerId, ct);
@@ -40,11 +46,14 @@ public class OpenVpnServerCertsController(ICertApiClient certApiClient,
         }
     }
 
-    
     [HttpPost("build")]
     public async Task<ActionResult<ApiResponse<BuildCertificateResponse>>> BuildCertificate(
         [FromBody] BuildCertificateRequest request, CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var result = await certApiClient.BuildCertificateAsync(
@@ -61,36 +70,40 @@ public class OpenVpnServerCertsController(ICertApiClient certApiClient,
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to build certificate for {CommonName} on server {VpnServerId}", 
+            logger.LogError(ex, "Failed to build certificate for {CommonName} on server {VpnServerId}",
                 request.CommonName, request.VpnServerId);
 
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }
-    
+
     [HttpPost("revoke")]
     public async Task<ActionResult<ApiResponse<RevokeCertificateResponse>>> RevokeCertificate(
         [FromBody] RevokeCertificateRequest request,
         CancellationToken cancellationToken)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User,
+                vpnServerAccessQueryService, request.VpnServerId, cancellationToken) is { } deny)
+            return deny;
+
         try
         {
             var result = await certApiClient.RevokeCertificateAsync(request, cancellationToken);
-    
+
             var mappedCertificate = (result, request.VpnServerId).Adapt<MonitorServerCertificate>();
-    
+
             var response = new RevokeCertificateResponse
             {
                 MonitorServerCertificate = mappedCertificate
             };
-    
+
             return Ok(ApiResponse<RevokeCertificateResponse>.SuccessResponse(response));
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to revoke certificate for {CommonName} on server {VpnServerId}", 
+            logger.LogError(ex, "Failed to revoke certificate for {CommonName} on server {VpnServerId}",
                 request.CommonName, request.VpnServerId);
-    
+
             return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
         }
     }

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
@@ -45,7 +45,7 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
         {
             if (!HttpUserContext.TryGetUserId(User, out var userId))
                 return Unauthorized(ApiResponse<OpenVpnServerWithStatusesResponse>.ErrorResponse("User id missing from token."));
-            var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+            var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
             if (uqp is null)
                 result = [];
             else
@@ -111,7 +111,7 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
         {
             if (!HttpUserContext.TryGetUserId(User, out var userId))
                 return Unauthorized(ApiResponse<OpenVpnServersResponse>.ErrorResponse("User id missing from token."));
-            var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+            var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
             if (uqp is null)
                 serversList = [];
             else

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
@@ -62,7 +62,7 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
     public async Task<ActionResult<ApiResponse<OpenVpnServerWithStatusResponse>>> GetServerWithStatus(
         [FromRoute] GetServerWithStatsRequest request, CancellationToken ct)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User, vpnServerAccessQueryService,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OpenVpnServerWithStatusResponse>(User, vpnServerAccessQueryService,
                 request.VpnServerId, ct) is { } denyStatus)
             return denyStatus;
 
@@ -77,7 +77,7 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
     public async Task<ActionResult<ApiResponse<RootInfoResponse>>> GetMicroserviceInfo(
         [FromRoute] int vpnServerId, CancellationToken ct)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User, vpnServerAccessQueryService,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<RootInfoResponse>(User, vpnServerAccessQueryService,
                 vpnServerId, ct) is { } denyMicro)
             return denyMicro;
 
@@ -133,7 +133,7 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
     public async Task<ActionResult<ApiResponse<OpenVpnServerResponse>>> GetServer(
         [FromRoute] GetServerRequest request, CancellationToken ct)
     {
-        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User, vpnServerAccessQueryService,
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<OpenVpnServerResponse>(User, vpnServerAccessQueryService,
                 request.VpnServerId, ct) is { } denyGet)
             return denyGet;
 

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
@@ -32,7 +32,8 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
         [FromQuery] bool includeDeleted = false,
         CancellationToken ct = default)
     {
-        var result = await openVpnServerOverviewQuery.GetAllOpenVpnServersWithStatusAsync(includeDeleted, ct);
+        var result = await openVpnServerOverviewQuery.GetAllOpenVpnServersWithStatusAsync(
+            includeDeleted, requireQuotaPlanAssignment: true, ct);
         var response = result.Adapt<OpenVpnServerWithStatusesResponse>();
         await FillTagsForOverviewResponse(response, ct);
         return Ok(ApiResponse<OpenVpnServerWithStatusesResponse>.SuccessResponse(response));
@@ -73,7 +74,7 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
         [FromQuery] bool includeDeleted = false,
         CancellationToken ct = default)
     {
-        var serversList = await openVpnServerQueryService.GetAll(includeDeleted, ct);
+        var serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: true, ct);
         var response = serversList.Adapt<OpenVpnServersResponse>();
         if (serversList.Count > 0)
         {

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersController.cs
@@ -1,11 +1,12 @@
-using System.Net.WebSockets;
-using System.Text;
 using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTagTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
 using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Services.Api;
+using OpenVPNGateMonitor.Services.Api.Auth.Handlers.Interfaces;
 using OpenVPNGateMonitor.Services.Api.Interfaces;
 using OpenVPNGateMonitor.Services.BackgroundServices.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
@@ -25,15 +26,33 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
     IOpenVpnServerOverviewQuery openVpnServerOverviewQuery, IOpenVpnServerQueryService openVpnServerQueryService,
     IOpenVpnServerTagQueryService openVpnServerTagQueryService,
     IOpenVpnBackgroundService openVpnBackgroundService,
-    IMicroserviceInfoService microserviceInfoService) : BaseController
+    IMicroserviceInfoService microserviceInfoService,
+    IUserQuotaPlanQueryService userQuotaPlanQueryService,
+    IVpnServerAccessQueryService vpnServerAccessQueryService) : BaseController
 {
     [HttpGet("get-all-with-status")]
     public async Task<ActionResult<ApiResponse<OpenVpnServerWithStatusesResponse>>> GetAllServersWithStatus(
         [FromQuery] bool includeDeleted = false,
         CancellationToken ct = default)
     {
-        var result = await openVpnServerOverviewQuery.GetAllOpenVpnServersWithStatusAsync(
-            includeDeleted, requireQuotaPlanAssignment: true, ct);
+        List<OpenVpnServerWithStatusDto> result;
+        if (HttpUserContext.IsPrivileged(User))
+        {
+            result = await openVpnServerOverviewQuery.GetAllOpenVpnServersWithStatusAsync(
+                includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId: null, ct);
+        }
+        else
+        {
+            if (!HttpUserContext.TryGetUserId(User, out var userId))
+                return Unauthorized(ApiResponse<OpenVpnServerWithStatusesResponse>.ErrorResponse("User id missing from token."));
+            var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+            if (uqp is null)
+                result = [];
+            else
+                result = await openVpnServerOverviewQuery.GetAllOpenVpnServersWithStatusAsync(
+                    includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId: uqp.QuotaPlanId, ct);
+        }
+
         var response = result.Adapt<OpenVpnServerWithStatusesResponse>();
         await FillTagsForOverviewResponse(response, ct);
         return Ok(ApiResponse<OpenVpnServerWithStatusesResponse>.SuccessResponse(response));
@@ -43,6 +62,10 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
     public async Task<ActionResult<ApiResponse<OpenVpnServerWithStatusResponse>>> GetServerWithStatus(
         [FromRoute] GetServerWithStatsRequest request, CancellationToken ct)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User, vpnServerAccessQueryService,
+                request.VpnServerId, ct) is { } denyStatus)
+            return denyStatus;
+
         var serverInfo = await openVpnServerOverviewQuery.GetOpenVpnServerWithStatusAsync(request.VpnServerId, ct);
         var response = serverInfo.Adapt<OpenVpnServerWithStatusResponse>();
         if (response.OpenVpnServerWithStatus?.OpenVpnServerResponses?.OpenVpnServer != null)
@@ -54,6 +77,10 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
     public async Task<ActionResult<ApiResponse<RootInfoResponse>>> GetMicroserviceInfo(
         [FromRoute] int vpnServerId, CancellationToken ct)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User, vpnServerAccessQueryService,
+                vpnServerId, ct) is { } denyMicro)
+            return denyMicro;
+
         var info = await microserviceInfoService.GetInfoAsync(vpnServerId, ct);
         return Ok(ApiResponse<RootInfoResponse>.SuccessResponse(info));
     }
@@ -74,7 +101,24 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
         [FromQuery] bool includeDeleted = false,
         CancellationToken ct = default)
     {
-        var serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: true, ct);
+        List<OpenVpnServer> serversList;
+        if (HttpUserContext.IsPrivileged(User))
+        {
+            serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: false,
+                restrictToQuotaPlanId: null, ct);
+        }
+        else
+        {
+            if (!HttpUserContext.TryGetUserId(User, out var userId))
+                return Unauthorized(ApiResponse<OpenVpnServersResponse>.ErrorResponse("User id missing from token."));
+            var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+            if (uqp is null)
+                serversList = [];
+            else
+                serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: false,
+                    restrictToQuotaPlanId: uqp.QuotaPlanId, ct);
+        }
+
         var response = serversList.Adapt<OpenVpnServersResponse>();
         if (serversList.Count > 0)
         {
@@ -89,6 +133,10 @@ public class OpenVpnServersController(IVpnDataService vpnDataService,
     public async Task<ActionResult<ApiResponse<OpenVpnServerResponse>>> GetServer(
         [FromRoute] GetServerRequest request, CancellationToken ct)
     {
+        if (await OpenVpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync(User, vpnServerAccessQueryService,
+                request.VpnServerId, ct) is { } denyGet)
+            return denyGet;
+
         var server = await openVpnServerQueryService.GetById(request.VpnServerId, ct);
         if (server == null)
             return NotFound();

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersV2Controller.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersV2Controller.cs
@@ -3,6 +3,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTagTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using OpenVPNGateMonitor.Services.Api;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
 using OpenVPNGateMonitor.SharedModels.Responses;
@@ -10,8 +13,8 @@ using OpenVPNGateMonitor.SharedModels.Responses;
 namespace OpenVPNGateMonitor.Controllers;
 
 /// <summary>
-/// API v2: same server lists as v1, plus <see cref="OpenVpnServerV2Dto.QuotaPlanGroups"/> for UI grouping.
-/// Lists only include servers linked to at least one quota plan via <c>QuotaPlanAllowedServers</c>.
+/// API v2: all servers (non-deleted) with quota-plan groups and <see cref="OpenVpnServerV2Dto.IsAccessibleForUserQuotaPlan"/>.
+/// Admin/App see every server with accessibility true; other users see all servers but only their plan's servers are marked accessible.
 /// </summary>
 [ApiController]
 [Route("api/v2/open-vpn-servers")]
@@ -20,14 +23,17 @@ public class OpenVpnServersV2Controller(
     IOpenVpnServerOverviewQuery openVpnServerOverviewQuery,
     IOpenVpnServerQueryService openVpnServerQueryService,
     IOpenVpnServerQuotaPlanGroupsQuery quotaPlanGroupsQuery,
-    IOpenVpnServerTagQueryService openVpnServerTagQueryService) : BaseController
+    IOpenVpnServerTagQueryService openVpnServerTagQueryService,
+    IUserQuotaPlanQueryService userQuotaPlanQueryService,
+    IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService) : BaseController
 {
     [HttpGet("get-all")]
     public async Task<ActionResult<ApiResponse<OpenVpnServersV2Response>>> GetAllServers(
         [FromQuery] bool includeDeleted = false,
         CancellationToken ct = default)
     {
-        var serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: true, ct);
+        var serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: false,
+            restrictToQuotaPlanId: null, ct);
         var response = new OpenVpnServersV2Response();
         if (serversList.Count == 0)
             return Ok(ApiResponse<OpenVpnServersV2Response>.SuccessResponse(response));
@@ -36,12 +42,17 @@ public class OpenVpnServersV2Controller(
         var groups = await quotaPlanGroupsQuery.GetGroupsByVpnServerIdsAsync(ids, ct);
         var tagNamesByServer = await openVpnServerTagQueryService.GetTagNamesByVpnServerIds(ids, ct);
 
+        var (allowedSet, hasUserContext) = await ResolveAccessibleServerIdsAsync(ct);
+        if (!hasUserContext)
+            return Unauthorized(ApiResponse<OpenVpnServersV2Response>.ErrorResponse("User id missing from token."));
+
         foreach (var server in serversList)
         {
             var dto = server.Adapt<OpenVpnServerDto>();
             dto.Tags = tagNamesByServer.GetValueOrDefault(server.Id, []);
             var v2 = dto.Adapt<OpenVpnServerV2Dto>();
             v2.QuotaPlanGroups = groups.GetValueOrDefault(server.Id, []);
+            v2.IsAccessibleForUserQuotaPlan = allowedSet is null || allowedSet.Contains(server.Id);
             response.OpenVpnServers.Add(v2);
         }
 
@@ -54,11 +65,15 @@ public class OpenVpnServersV2Controller(
         CancellationToken ct = default)
     {
         var result = await openVpnServerOverviewQuery.GetAllOpenVpnServersWithStatusAsync(
-            includeDeleted, requireQuotaPlanAssignment: true, ct);
+            includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId: null, ct);
         var response = new OpenVpnServerWithStatusesV2Response();
 
         if (result.Count == 0)
             return Ok(ApiResponse<OpenVpnServerWithStatusesV2Response>.SuccessResponse(response));
+
+        var (allowedSet, hasUserContext) = await ResolveAccessibleServerIdsAsync(ct);
+        if (!hasUserContext)
+            return Unauthorized(ApiResponse<OpenVpnServerWithStatusesV2Response>.ErrorResponse("User id missing from token."));
 
         var ids = result.Select(x => x.OpenVpnServerResponses.OpenVpnServer.Id).ToList();
         var groups = await quotaPlanGroupsQuery.GetGroupsByVpnServerIdsAsync(ids, ct);
@@ -81,9 +96,27 @@ public class OpenVpnServersV2Controller(
                 TotalBytesOut = item.TotalBytesOut
             };
             v2.OpenVpnServerResponses.OpenVpnServer.QuotaPlanGroups = groups.GetValueOrDefault(id, []);
+            v2.OpenVpnServerResponses.OpenVpnServer.IsAccessibleForUserQuotaPlan =
+                allowedSet is null || allowedSet.Contains(id);
             response.OpenVpnServerWithStatuses.Add(v2);
         }
 
         return Ok(ApiResponse<OpenVpnServerWithStatusesV2Response>.SuccessResponse(response));
     }
+
+    /// <returns>Privileged: (null, true). Non-privileged: (allowed ids for user's plan, true). Missing user id: (_, false).</returns>
+    private async Task<(HashSet<int>? AllowedServerIds, bool HasUserContext)> ResolveAccessibleServerIdsAsync(
+        CancellationToken ct)
+    {
+        if (HttpUserContext.IsPrivileged(User))
+            return (null, true);
+        if (!HttpUserContext.TryGetUserId(User, out var userId))
+            return (null, false);
+        var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+        if (uqp is null)
+            return (new HashSet<int>(), true);
+        var set = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(uqp.QuotaPlanId, ct);
+        return (set, true);
+    }
 }
+

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersV2Controller.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersV2Controller.cs
@@ -1,0 +1,89 @@
+using Mapster;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTagTable;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Dto;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.OpenVpnServers.Responses;
+using OpenVPNGateMonitor.SharedModels.Responses;
+
+namespace OpenVPNGateMonitor.Controllers;
+
+/// <summary>
+/// API v2: same server lists as v1, plus <see cref="OpenVpnServerV2Dto.QuotaPlanGroups"/> for UI grouping.
+/// Lists only include servers linked to at least one quota plan via <c>QuotaPlanAllowedServers</c>.
+/// </summary>
+[ApiController]
+[Route("api/v2/open-vpn-servers")]
+[Authorize]
+public class OpenVpnServersV2Controller(
+    IOpenVpnServerOverviewQuery openVpnServerOverviewQuery,
+    IOpenVpnServerQueryService openVpnServerQueryService,
+    IOpenVpnServerQuotaPlanGroupsQuery quotaPlanGroupsQuery,
+    IOpenVpnServerTagQueryService openVpnServerTagQueryService) : BaseController
+{
+    [HttpGet("get-all")]
+    public async Task<ActionResult<ApiResponse<OpenVpnServersV2Response>>> GetAllServers(
+        [FromQuery] bool includeDeleted = false,
+        CancellationToken ct = default)
+    {
+        var serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: true, ct);
+        var response = new OpenVpnServersV2Response();
+        if (serversList.Count == 0)
+            return Ok(ApiResponse<OpenVpnServersV2Response>.SuccessResponse(response));
+
+        var ids = serversList.Select(s => s.Id).ToList();
+        var groups = await quotaPlanGroupsQuery.GetGroupsByVpnServerIdsAsync(ids, ct);
+        var tagNamesByServer = await openVpnServerTagQueryService.GetTagNamesByVpnServerIds(ids, ct);
+
+        foreach (var server in serversList)
+        {
+            var dto = server.Adapt<OpenVpnServerDto>();
+            dto.Tags = tagNamesByServer.GetValueOrDefault(server.Id, []);
+            var v2 = dto.Adapt<OpenVpnServerV2Dto>();
+            v2.QuotaPlanGroups = groups.GetValueOrDefault(server.Id, []);
+            response.OpenVpnServers.Add(v2);
+        }
+
+        return Ok(ApiResponse<OpenVpnServersV2Response>.SuccessResponse(response));
+    }
+
+    [HttpGet("get-all-with-status")]
+    public async Task<ActionResult<ApiResponse<OpenVpnServerWithStatusesV2Response>>> GetAllServersWithStatus(
+        [FromQuery] bool includeDeleted = false,
+        CancellationToken ct = default)
+    {
+        var result = await openVpnServerOverviewQuery.GetAllOpenVpnServersWithStatusAsync(
+            includeDeleted, requireQuotaPlanAssignment: true, ct);
+        var response = new OpenVpnServerWithStatusesV2Response();
+
+        if (result.Count == 0)
+            return Ok(ApiResponse<OpenVpnServerWithStatusesV2Response>.SuccessResponse(response));
+
+        var ids = result.Select(x => x.OpenVpnServerResponses.OpenVpnServer.Id).ToList();
+        var groups = await quotaPlanGroupsQuery.GetGroupsByVpnServerIdsAsync(ids, ct);
+        var tagNamesByServer = await openVpnServerTagQueryService.GetTagNamesByVpnServerIds(ids, ct);
+
+        foreach (var item in result)
+        {
+            var id = item.OpenVpnServerResponses.OpenVpnServer.Id;
+            item.OpenVpnServerResponses.OpenVpnServer.Tags = tagNamesByServer.GetValueOrDefault(id, []);
+            var v2 = new OpenVpnServerWithStatusV2Dto
+            {
+                OpenVpnServerResponses = new OpenVpnServerV2Response
+                {
+                    OpenVpnServer = item.OpenVpnServerResponses.OpenVpnServer.Adapt<OpenVpnServerV2Dto>()
+                },
+                OpenVpnServerStatusLogResponse = item.OpenVpnServerStatusLogResponse,
+                CountConnectedClients = item.CountConnectedClients,
+                CountSessions = item.CountSessions,
+                TotalBytesIn = item.TotalBytesIn,
+                TotalBytesOut = item.TotalBytesOut
+            };
+            v2.OpenVpnServerResponses.OpenVpnServer.QuotaPlanGroups = groups.GetValueOrDefault(id, []);
+            response.OpenVpnServerWithStatuses.Add(v2);
+        }
+
+        return Ok(ApiResponse<OpenVpnServerWithStatusesV2Response>.SuccessResponse(response));
+    }
+}

--- a/OpenVPNGateMonitor/Controllers/OpenVpnServersV2Controller.cs
+++ b/OpenVPNGateMonitor/Controllers/OpenVpnServersV2Controller.cs
@@ -112,7 +112,7 @@ public class OpenVpnServersV2Controller(
             return (null, true);
         if (!HttpUserContext.TryGetUserId(User, out var userId))
             return (null, false);
-        var uqp = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+        var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
         if (uqp is null)
             return (new HashSet<int>(), true);
         var set = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(uqp.QuotaPlanId, ct);

--- a/OpenVPNGateMonitor/Controllers/QuotaPlanAllowedServerController.cs
+++ b/OpenVPNGateMonitor/Controllers/QuotaPlanAllowedServerController.cs
@@ -1,5 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using OpenVPNGateMonitor.Services.Api;
 using OpenVPNGateMonitor.Services.QuotaPlans;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.QuotaPlanAllowedServers.Requests;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.QuotaPlanAllowedServers.Responses;
@@ -10,10 +13,12 @@ namespace OpenVPNGateMonitor.Controllers;
 [ApiController]
 [Route("api/quota-plan-allowed-servers")]
 [Authorize]
-[Authorize(Roles = "Admin,App")]
-public class QuotaPlanAllowedServerController(IQuotaPlanAllowedServerService service) : BaseController
+public class QuotaPlanAllowedServerController(
+    IQuotaPlanAllowedServerService service,
+    IUserQuotaPlanQueryService userQuotaPlanQueryService) : BaseController
 {
     /// <summary>Get paged list. Optional filter by quotaPlanId and/or vpnServerId (query).</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpGet("get-all")]
     public async Task<ActionResult<ApiResponse<GetAllQuotaPlanAllowedServersResponse>>> GetAll(
         [FromQuery] GetAllQuotaPlanAllowedServersRequest request,
@@ -24,6 +29,7 @@ public class QuotaPlanAllowedServerController(IQuotaPlanAllowedServerService ser
     }
 
     /// <summary>Get by id.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpGet("get/{id:int}")]
     public async Task<ActionResult<ApiResponse<QuotaPlanAllowedServerResponse>>> GetById(int id, CancellationToken ct)
     {
@@ -34,18 +40,32 @@ public class QuotaPlanAllowedServerController(IQuotaPlanAllowedServerService ser
         return Ok(ApiResponse<QuotaPlanAllowedServerResponse>.SuccessResponse(response));
     }
 
-    /// <summary>Get all allowed servers for a quota plan.</summary>
+    /// <summary>Get all allowed servers for a quota plan. VpnUser may only query their own active plan.</summary>
+    [Authorize(Roles = "Admin,App,VpnUser")]
     [HttpGet("get-by-quota-plan-id/{quotaPlanId:int}")]
     public async Task<ActionResult<ApiResponse<GetQuotaPlanAllowedServersByQuotaPlanIdResponse>>> GetByQuotaPlanId(
         int quotaPlanId,
         CancellationToken ct)
     {
+        if (!HttpUserContext.IsPrivileged(User))
+        {
+            if (!HttpUserContext.TryGetUserId(User, out var userId))
+                return Unauthorized(ApiResponse<GetQuotaPlanAllowedServersByQuotaPlanIdResponse>.ErrorResponse(
+                    "User id missing from token."));
+            var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
+            if (uqp is null || uqp.QuotaPlanId != quotaPlanId)
+                return StatusCode(StatusCodes.Status403Forbidden,
+                    ApiResponse<GetQuotaPlanAllowedServersByQuotaPlanIdResponse>.ErrorResponse(
+                        "You can only load allowed servers for your own quota plan."));
+        }
+
         var items = await service.GetListByQuotaPlanIdAsync(quotaPlanId, ct);
         return Ok(ApiResponse<GetQuotaPlanAllowedServersByQuotaPlanIdResponse>.SuccessResponse(
             new GetQuotaPlanAllowedServersByQuotaPlanIdResponse { Items = items }));
     }
 
     /// <summary>Get all quota plans that allow a VPN server.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpGet("get-by-vpn-server-id/{vpnServerId:int}")]
     public async Task<ActionResult<ApiResponse<GetQuotaPlanAllowedServersByVpnServerIdResponse>>> GetByVpnServerId(
         int vpnServerId,
@@ -57,6 +77,7 @@ public class QuotaPlanAllowedServerController(IQuotaPlanAllowedServerService ser
     }
 
     /// <summary>Create a new assignment (allow server for plan).</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpPost("create")]
     public async Task<ActionResult<ApiResponse<QuotaPlanAllowedServerResponse>>> Create(
         [FromBody] CreateOrUpdateQuotaPlanAllowedServerRequest request,
@@ -67,6 +88,7 @@ public class QuotaPlanAllowedServerController(IQuotaPlanAllowedServerService ser
     }
 
     /// <summary>Update an existing assignment.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpPut("update")]
     public async Task<ActionResult<ApiResponse<string>>> Update(
         [FromBody] CreateOrUpdateQuotaPlanAllowedServerRequest request,
@@ -77,6 +99,7 @@ public class QuotaPlanAllowedServerController(IQuotaPlanAllowedServerService ser
     }
 
     /// <summary>Delete an assignment by id.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpDelete("delete/{id:int}")]
     public async Task<ActionResult<ApiResponse<string>>> Delete(int id, CancellationToken ct)
     {

--- a/OpenVPNGateMonitor/Controllers/QuotaPlanController.cs
+++ b/OpenVPNGateMonitor/Controllers/QuotaPlanController.cs
@@ -1,4 +1,4 @@
-﻿using Mapster;
+using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OpenVPNGateMonitor.Models;
@@ -13,10 +13,10 @@ namespace OpenVPNGateMonitor.Controllers;
 [ApiController]
 [Route("api/quota-plans")]
 [Authorize]
-[Authorize(Roles = "Admin,App")]
 public class QuotaPlanController(IQuotaPlanService quotaPlanService) : BaseController
 {
     /// <summary>Get all quota plans.</summary>
+    [Authorize(Roles = "Admin,App,VpnUser")]
     [HttpPost("get-all")]
     public async Task<ActionResult<ApiResponse<QuotaPlansResponse>>> GetAll(
         [FromBody] GetQuotaPlansRequest request,
@@ -32,6 +32,7 @@ public class QuotaPlanController(IQuotaPlanService quotaPlanService) : BaseContr
     }
 
     /// <summary>Get a quota plan by id.</summary>
+    [Authorize(Roles = "Admin,App,VpnUser")]
     [HttpGet("get/{id:int}")]
     public async Task<ActionResult<ApiResponse<QuotaPlanResponse>>> GetById(int id, CancellationToken ct)
     {
@@ -44,6 +45,7 @@ public class QuotaPlanController(IQuotaPlanService quotaPlanService) : BaseContr
     }
 
     /// <summary>Create a new quota plan.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpPost("create")]
     public async Task<ActionResult<ApiResponse<QuotaPlanResponse>>> Create(
         [FromBody] CreateOrUpdateQuotaPlanRequest request,
@@ -61,6 +63,7 @@ public class QuotaPlanController(IQuotaPlanService quotaPlanService) : BaseContr
     }
 
     /// <summary>Update an existing quota plan.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpPut("update")]
     public async Task<ActionResult<ApiResponse<string>>> Update(
         [FromBody] CreateOrUpdateQuotaPlanRequest request,
@@ -72,6 +75,7 @@ public class QuotaPlanController(IQuotaPlanService quotaPlanService) : BaseContr
     }
 
     /// <summary>Delete a quota plan by id.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpDelete("delete/{id:int}")]
     public async Task<ActionResult<ApiResponse<string>>> Delete(int id, CancellationToken ct)
     {
@@ -80,6 +84,7 @@ public class QuotaPlanController(IQuotaPlanService quotaPlanService) : BaseContr
     }
 
     /// <summary>Set quota plan as default.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpPost("set-default/{id:int}")]
     public async Task<ActionResult<ApiResponse<string>>> SetDefault(int id, CancellationToken ct)
     {

--- a/OpenVPNGateMonitor/Controllers/UserQuotaPlanController.cs
+++ b/OpenVPNGateMonitor/Controllers/UserQuotaPlanController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.Services.Api;
 using OpenVPNGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserQuotaPlans.Requests;
 using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserQuotaPlans.Responses;
@@ -10,10 +12,10 @@ namespace OpenVPNGateMonitor.Controllers;
 [ApiController]
 [Route("api/user-quota-plans")]
 [Authorize]
-[Authorize(Roles = "Admin,App")]
 public class UserQuotaPlanController(IUserQuotaPlanService userQuotaPlanService) : BaseController
 {
     /// <summary>Get paged list of user-quota-plan assignments. Optional filter by userId (query).</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpGet("get-all")]
     public async Task<ActionResult<ApiResponse<GetAllUserQuotaPlansResponse>>> GetAll(
         [FromQuery] GetAllUserQuotaPlansRequest request,
@@ -24,6 +26,7 @@ public class UserQuotaPlanController(IUserQuotaPlanService userQuotaPlanService)
     }
 
     /// <summary>Get a user-quota-plan assignment by id.</summary>
+    [Authorize(Roles = "Admin,App,VpnUser")]
     [HttpGet("get/{id:int}")]
     public async Task<ActionResult<ApiResponse<UserQuotaPlanResponse>>> GetById(int id, CancellationToken ct)
     {
@@ -31,21 +34,43 @@ public class UserQuotaPlanController(IUserQuotaPlanService userQuotaPlanService)
         if (response is null)
             return NotFound(ApiResponse<UserQuotaPlanResponse>.ErrorResponse("User quota plan not found."));
 
+        if (!HttpUserContext.IsPrivileged(User))
+        {
+            if (!HttpUserContext.TryGetUserId(User, out var currentUserId))
+                return Unauthorized(ApiResponse<UserQuotaPlanResponse>.ErrorResponse("User id missing from token."));
+            if (response.UserQuotaPlan.UserId != currentUserId)
+                return StatusCode(StatusCodes.Status403Forbidden,
+                    ApiResponse<UserQuotaPlanResponse>.ErrorResponse("Access denied."));
+        }
+
         return Ok(ApiResponse<UserQuotaPlanResponse>.SuccessResponse(response));
     }
 
     /// <summary>Get all quota-plan assignments for a user.</summary>
+    [Authorize(Roles = "Admin,App,VpnUser")]
     [HttpGet("get-by-user-id/{userId:int}")]
     public async Task<ActionResult<ApiResponse<GetUserQuotaPlansByUserIdResponse>>> GetByUserId(
         int userId,
         CancellationToken ct)
     {
+        if (!HttpUserContext.IsPrivileged(User))
+        {
+            if (!HttpUserContext.TryGetUserId(User, out var currentUserId))
+                return Unauthorized(ApiResponse<GetUserQuotaPlansByUserIdResponse>.ErrorResponse(
+                    "User id missing from token."));
+            if (currentUserId != userId)
+                return StatusCode(StatusCodes.Status403Forbidden,
+                    ApiResponse<GetUserQuotaPlansByUserIdResponse>.ErrorResponse(
+                        "You can only read your own quota plan assignments."));
+        }
+
         var items = await userQuotaPlanService.GetListByUserIdAsync(userId, ct);
         return Ok(ApiResponse<GetUserQuotaPlansByUserIdResponse>.SuccessResponse(
             new GetUserQuotaPlansByUserIdResponse { Items = items }));
     }
 
     /// <summary>Create a new user-quota-plan assignment.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpPost("create")]
     public async Task<ActionResult<ApiResponse<UserQuotaPlanResponse>>> Create(
         [FromBody] CreateOrUpdateUserQuotaPlanRequest request,
@@ -56,6 +81,7 @@ public class UserQuotaPlanController(IUserQuotaPlanService userQuotaPlanService)
     }
 
     /// <summary>Update an existing user-quota-plan assignment.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpPut("update")]
     public async Task<ActionResult<ApiResponse<string>>> Update(
         [FromBody] CreateOrUpdateUserQuotaPlanRequest request,
@@ -66,6 +92,7 @@ public class UserQuotaPlanController(IUserQuotaPlanService userQuotaPlanService)
     }
 
     /// <summary>Delete a user-quota-plan assignment by id.</summary>
+    [Authorize(Roles = "Admin,App")]
     [HttpDelete("delete/{id:int}")]
     public async Task<ActionResult<ApiResponse<string>>> Delete(int id, CancellationToken ct)
     {

--- a/OpenVPNGateMonitor/Controllers/UserRolesController.cs
+++ b/OpenVPNGateMonitor/Controllers/UserRolesController.cs
@@ -1,0 +1,79 @@
+using Mapster;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Services.UserRoles;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Dto;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Requests;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.UserRoles.Responses;
+using OpenVPNGateMonitor.SharedModels.Responses;
+
+namespace OpenVPNGateMonitor.Controllers;
+
+[ApiController]
+[Route("api/user-roles")]
+[Authorize(Roles = "Admin,App")]
+public class UserRolesController(IUserRoleManagementService userRoleManagementService) : BaseController
+{
+    /// <summary>List all roles defined in the system.</summary>
+    [HttpGet("get-all-roles")]
+    public async Task<ActionResult<ApiResponse<RolesResponse>>> GetAllRoles(CancellationToken ct)
+    {
+        var entities = await userRoleManagementService.GetAllRolesAsync(ct);
+        var response = new RolesResponse { Roles = entities.Adapt<List<RoleDto>>() };
+        return Ok(ApiResponse<RolesResponse>.SuccessResponse(response));
+    }
+
+    /// <summary>Get the current role assignment for a user.</summary>
+    [HttpGet("by-user/{userId:int}")]
+    public async Task<ActionResult<ApiResponse<UserRoleAssignmentResponse>>> GetByUserId(int userId,
+        CancellationToken ct)
+    {
+        try
+        {
+            var pair = await userRoleManagementService.GetAssignmentByUserIdAsync(userId, ct);
+            if (pair is null)
+                return Ok(ApiResponse<UserRoleAssignmentResponse>.SuccessResponse(new UserRoleAssignmentResponse()));
+
+            var (ur, role) = pair.Value;
+            var dto = ToAssignmentDto(ur, role);
+            return Ok(ApiResponse<UserRoleAssignmentResponse>.SuccessResponse(
+                new UserRoleAssignmentResponse { Assignment = dto }));
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ApiResponse<UserRoleAssignmentResponse>.ErrorResponse(ex.Message));
+        }
+    }
+
+    /// <summary>Replace the user's roles with a single role.</summary>
+    [HttpPut("set")]
+    public async Task<ActionResult<ApiResponse<UserRoleAssignmentResponse>>> SetUserRole(
+        [FromBody] SetUserRoleRequest request,
+        CancellationToken ct)
+    {
+        try
+        {
+            var (ur, role) = await userRoleManagementService.SetUserRoleAsync(request.UserId, request.RoleId, ct);
+            var dto = ToAssignmentDto(ur, role);
+            return Ok(ApiResponse<UserRoleAssignmentResponse>.SuccessResponse(
+                new UserRoleAssignmentResponse { Assignment = dto }));
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ApiResponse<string>.ErrorResponse(ex.Message));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(ApiResponse<string>.ErrorResponse(ex.Message));
+        }
+    }
+
+    private static UserRoleAssignmentDto ToAssignmentDto(UserRole ur, Role role) =>
+        new()
+        {
+            UserId = ur.UserId,
+            RoleId = ur.RoleId,
+            RoleName = role.Name
+        };
+}

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -27,7 +27,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-        <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
+        <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
         <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.94" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,18 +4,18 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.3.10</AssemblyVersion>
-        <FileVersion>1.0.3.10</FileVersion>
+        <AssemblyVersion>1.0.3.11</AssemblyVersion>
+        <FileVersion>1.0.3.11</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.3" />
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.4" />
         <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
-        <PackageReference Include="Mapster" Version="10.0.3" />
-        <PackageReference Include="Mapster.DependencyInjection" Version="10.0.0" />
+        <PackageReference Include="Mapster" Version="10.0.6" />
+        <PackageReference Include="Mapster.DependencyInjection" Version="10.0.6" />
         <PackageReference Include="MaxMind.GeoIP2" Version="5.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
@@ -24,7 +24,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.16.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
         <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
@@ -34,9 +34,9 @@
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.5" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,9 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.3.12</AssemblyVersion>
-        <FileVersion>1.0.3.12</FileVersion>
+        <Version>1.0.3.13</Version>
+        <AssemblyVersion>1.0.3.13</AssemblyVersion>
+        <FileVersion>1.0.3.13</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -4,8 +4,8 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <AssemblyVersion>1.0.3.11</AssemblyVersion>
-        <FileVersion>1.0.3.11</FileVersion>
+        <AssemblyVersion>1.0.3.12</AssemblyVersion>
+        <FileVersion>1.0.3.12</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
@@ -27,7 +27,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- OpenVPNGateMonitor.SharedModels: NuGet package only; do not use ProjectReference to the SharedModels .csproj. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.95" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.96" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/OpenVPNGateMonitor/Services/Api/Auth/Handlers/VpnServerAccessQueryService.cs
+++ b/OpenVPNGateMonitor/Services/Api/Auth/Handlers/VpnServerAccessQueryService.cs
@@ -11,7 +11,7 @@ public sealed class VpnServerAccessQueryService(
 {
     public async Task<bool> UserHasAccessAsync(int userId, int vpnServerId, CancellationToken ct)
     {
-        var userQuotaPlan = await userQuotaPlanQueryService.GetByUserId(userId, ct);
+        var userQuotaPlan = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
         if (userQuotaPlan is null)
             return false;
 

--- a/OpenVPNGateMonitor/Services/Api/HttpUserContext.cs
+++ b/OpenVPNGateMonitor/Services/Api/HttpUserContext.cs
@@ -1,0 +1,18 @@
+using System.Security.Claims;
+
+namespace OpenVPNGateMonitor.Services.Api;
+
+/// <summary>JWT / role helpers for API controllers.</summary>
+public static class HttpUserContext
+{
+    /// <summary>Admin and service accounts — full server list and no per-server quota checks.</summary>
+    public static bool IsPrivileged(ClaimsPrincipal user) =>
+        user.IsInRole("Admin") || user.IsInRole("App");
+
+    public static bool TryGetUserId(ClaimsPrincipal user, out int userId)
+    {
+        var raw = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        userId = 0;
+        return !string.IsNullOrEmpty(raw) && int.TryParse(raw, out userId);
+    }
+}

--- a/OpenVPNGateMonitor/Services/Api/VpnDataService.cs
+++ b/OpenVPNGateMonitor/Services/Api/VpnDataService.cs
@@ -1,6 +1,7 @@
 using OpenVPNGateMonitor.DataBase.Services.Command.Interfaces;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerOvpnFileConfigTable;
 using OpenVPNGateMonitor.DataBase.Services.Query.OpenVpnServerTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.QuotaPlanTable;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.Services.Api.Interfaces;
 using OpenVPNGateMonitor.Services.DataGateOpenVpnManager.Events;
@@ -13,6 +14,7 @@ namespace OpenVPNGateMonitor.Services.Api;
 public class VpnDataService(
     ILogger<IVpnDataService> logger,
     IExternalIpAddressService externalIpAddressService,
+    IQuotaPlanQueryService quotaPlanQueryService,
     IOpenVpnServerQueryService openVpnServerQueryService,
     IOpenVpnServerOvpnFileConfigQueryService openVpnServerOvpnFileConfigQueryService,
     ITransactionRunner transactionRunner,
@@ -51,7 +53,13 @@ public class VpnDataService(
             server.LastUpdate = now;
             await openVpnServerCommandService.Add(server, saveChanges: true, ct);
 
-            await SyncQuotaPlanLinksAsync(server.Id, quotaPlanIds, ct);
+            var effectiveQuotaPlanIds = quotaPlanIds.Count > 0
+                ? quotaPlanIds
+                : (await quotaPlanQueryService.GetDefault(ct)) is { } defaultPlan
+                    ? [defaultPlan.Id]
+                    : [];
+
+            await SyncQuotaPlanLinksAsync(server.Id, effectiveQuotaPlanIds, ct);
             await SyncTagLinksAsync(server.Id, tagIds, ct);
 
             // Additionally, writes that must be part of the same transaction

--- a/OpenVPNGateMonitor/Services/UserRoles/IUserRoleManagementService.cs
+++ b/OpenVPNGateMonitor/Services/UserRoles/IUserRoleManagementService.cs
@@ -1,0 +1,17 @@
+using OpenVPNGateMonitor.Models;
+
+namespace OpenVPNGateMonitor.Services.UserRoles;
+
+/// <summary>
+/// Admin API: catalog of roles and replacing a user's assigned role.
+/// </summary>
+public interface IUserRoleManagementService
+{
+    Task<List<Role>> GetAllRolesAsync(CancellationToken ct = default);
+
+    /// <summary>Returns the user's current role row, or null if none.</summary>
+    Task<(UserRole UserRole, Role Role)?> GetAssignmentByUserIdAsync(int userId, CancellationToken ct = default);
+
+    /// <summary>Replaces all role rows for the user with a single role.</summary>
+    Task<(UserRole UserRole, Role Role)> SetUserRoleAsync(int userId, int roleId, CancellationToken ct = default);
+}

--- a/OpenVPNGateMonitor/Services/UserRoles/UserRoleManagementService.cs
+++ b/OpenVPNGateMonitor/Services/UserRoles/UserRoleManagementService.cs
@@ -1,0 +1,78 @@
+using OpenVPNGateMonitor.DataBase.Services.Command.Interfaces;
+using OpenVPNGateMonitor.DataBase.Services.Query.RoleTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserRoleTable;
+using OpenVPNGateMonitor.DataBase.Services.Query.UserTable;
+using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.SharedModels.Auth;
+
+namespace OpenVPNGateMonitor.Services.UserRoles;
+
+public sealed class UserRoleManagementService(
+    ILogger<UserRoleManagementService> logger,
+    ICommandService<UserRole, int> userRoleCommandService,
+    IUserRoleQueryService userRoleQueryService,
+    IRoleQueryService roleQueryService,
+    IUserQueryService userQueryService) : IUserRoleManagementService
+{
+    public Task<List<Role>> GetAllRolesAsync(CancellationToken ct = default)
+        => roleQueryService.GetAll(ct);
+
+    public async Task<(UserRole UserRole, Role Role)?> GetAssignmentByUserIdAsync(int userId,
+        CancellationToken ct = default)
+    {
+        _ = await userQueryService.GetById(userId, ct)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        var ur = await userRoleQueryService.GetByUserId(userId, ct);
+        if (ur is null)
+            return null;
+
+        var role = await roleQueryService.GetById(ur.RoleId, ct)
+                   ?? throw new InvalidOperationException($"Role {ur.RoleId} not found.");
+
+        return (ur, role);
+    }
+
+    public async Task<(UserRole UserRole, Role Role)> SetUserRoleAsync(int userId, int roleId,
+        CancellationToken ct = default)
+    {
+        _ = await userQueryService.GetById(userId, ct)
+            ?? throw new KeyNotFoundException($"User {userId} not found.");
+
+        var role = await roleQueryService.GetById(roleId, ct)
+                   ?? throw new KeyNotFoundException($"Role {roleId} not found.");
+
+        if (roleId == SystemRoles.ServiceId)
+            throw new InvalidOperationException("The Service role cannot be assigned through this API.");
+
+        var existing = await userRoleQueryService.GetByUserId(userId, ct);
+        if (existing?.RoleId == SystemRoles.AdminId && roleId != SystemRoles.AdminId)
+        {
+            var adminIds = await userRoleQueryService.GetUserIdsByRoleIdAsync(SystemRoles.AdminId, ct);
+            if (adminIds.Count == 1 && adminIds[0] == userId)
+                throw new InvalidOperationException("Cannot remove the last administrator.");
+        }
+
+        if (existing is not null && existing.RoleId == roleId)
+        {
+            logger.LogInformation("User {UserId} already has role {RoleId}; no change.", userId, roleId);
+            return (existing, role);
+        }
+
+        await userRoleCommandService.DeleteWhere(ur => ur.UserId == userId, ct);
+
+        var now = DateTimeOffset.UtcNow;
+        var created = new UserRole
+        {
+            UserId = userId,
+            RoleId = roleId,
+            CreateDate = now,
+            LastUpdate = now
+        };
+
+        created = await userRoleCommandService.Add(created, saveChanges: true, ct);
+        logger.LogInformation("User {UserId} assigned role {RoleId} ({RoleName}).", userId, role.Id, role.Name);
+
+        return (created, role);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.201",
-    "allowPrerelease": false,
-    "rollForward": "latestFeature"
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
 }

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Do not change this file unless you know why.
+  OpenVPNGateMonitor.SharedModels must be referenced only as a NuGet package (PackageReference in .csproj),
+  never as a ProjectReference to OpenVPNGateMonitor.SharedModels.csproj.
+-->
+<configuration>
+</configuration>


### PR DESCRIPTION
Summary
This branch tightens VPN server access so it follows the user’s active quota plan and allowed server mappings, adds an admin API for user roles, extends SharedModels (new package version), and includes tests plus small CI / Docker / versioning updates.

Key changes
Quota plan & server access
Enforce allowed server per quota plan via existing QuotaPlanAllowedServer data; access checks go through IVpnServerAccessQueryService.
Use GetActiveByUserId instead of GetByUserId wherever the “current” plan matters, so closed assignments (EffectiveTo set) do not override the active plan (fixes wrong plan used for API access).
OpenVPN servers listings and OVPN file filtering align with the active plan where applicable.
User roles (Admin / App)
New UserRolesController: list roles, get assignment by user, set user role (replace assignment).
UserRoleManagementService: validates user/role, blocks assigning Service role via API, prevents removing the last admin.
DTOs under OpenVPNGateMonitor.SharedModels for user-role requests/responses.
Packaging & repo policy
OpenVPNGateMonitor.SharedModels version bump (e.g. 1.0.97); consuming projects reference the NuGet package only (PackageReference — no ProjectReference to SharedModels).
nuget.config: documents NuGet-only policy for SharedModels.
Dockerfile: restore comment clarifies SharedModels comes from NuGet; published package version must exist on nuget.org for image builds.
Tests
Unit tests for UserRolesController and UserRoleManagementService.
Mocks updated for GetActiveByUserId where quota-plan behavior is tested.
Versioning
App / SharedModels package versions bumped as in commits (e.g. app 1.0.3.13, SharedModels 1.0.97).
Ops / release notes
Publish OpenVPNGateMonitor.SharedModels to nuget.org at the version referenced in .csproj before CI/Docker builds that only restore from NuGet.
Existing DB data: ensure QuotaPlanAllowedServer and active UserQuotaPlan rows match your product rules (e.g. one server per plan tier).
How to test
dotnet restore / dotnet build / dotnet test on a clean machine (with published SharedModels version or local feed if used).
Smoke: Admin/App calls to api/user-roles/*; VpnUser flows for server list and OVPN where quota applies.