### PR TITLE
Adds GeoLite auto-update and enhances notification filtering

### DIFF
--- a/OpenVPNGateMonitor.DataBase/ConfigurationModels/Seeds/SettingSeedData.cs
+++ b/OpenVPNGateMonitor.DataBase/ConfigurationModels/Seeds/SettingSeedData.cs
@@ -1,4 +1,4 @@
-﻿using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.Models;
 
 namespace OpenVPNGateMonitor.DataBase.ConfigurationModels.Seeds;
 
@@ -93,6 +93,21 @@ public static class SettingSeedData
             Key = "GeoIp_License_Key_Type",
             ValueType = "string",
             StringValue = "string"
+        },
+        
+        new Setting
+        {
+            Id = 13,
+            Key = "GeoIp_Auto_Update_Interval_Days",
+            ValueType = "int",
+            IntValue = 0
+        },
+        new Setting
+        {
+            Id = 14,
+            Key = "GeoIp_Auto_Update_Interval_Days_Type",
+            ValueType = "string",
+            StringValue = "int"
         },
     };
 }

--- a/OpenVPNGateMonitor.DataBase/Migrations/20260406001633_GeoIp_Auto_Update_Interval_Days.Designer.cs
+++ b/OpenVPNGateMonitor.DataBase/Migrations/20260406001633_GeoIp_Auto_Update_Interval_Days.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OpenVPNGateMonitor.DataBase.Contexts;
@@ -11,9 +12,11 @@ using OpenVPNGateMonitor.DataBase.Contexts;
 namespace OpenVPNGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406001633_GeoIp_Auto_Update_Interval_Days")]
+    partial class GeoIp_Auto_Update_Interval_Days
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/OpenVPNGateMonitor.DataBase/Migrations/20260406001633_GeoIp_Auto_Update_Interval_Days.cs
+++ b/OpenVPNGateMonitor.DataBase/Migrations/20260406001633_GeoIp_Auto_Update_Interval_Days.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace OpenVPNGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class GeoIp_Auto_Update_Interval_Days : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                columns: new[] { "Id", "BoolValue", "DateTimeValue", "DoubleValue", "IntValue", "Key", "StringValue", "ValueType" },
+                values: new object[,]
+                {
+                    { 13, null, null, null, 0, "GeoIp_Auto_Update_Interval_Days", null, "int" },
+                    { 14, null, null, null, null, "GeoIp_Auto_Update_Interval_Days_Type", "int", "string" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 13);
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 14);
+        }
+    }
+}

--- a/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
+++ b/OpenVPNGateMonitor.DataBase/OpenVPNGateMonitor.DataBase.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.98" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />

--- a/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/INotificationRecipientQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/INotificationRecipientQueryService.cs
@@ -1,4 +1,5 @@
 using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.SharedModels.Notifications.Requests;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace OpenVPNGateMonitor.DataBase.Services.Query.NotificationRecipientTable;
@@ -11,9 +12,9 @@ public interface INotificationRecipientQueryService
     Task<List<NotificationListRow>> GetNotificationListByAdminUserIdAsync(int adminUserId, CancellationToken ct = default);
 
     /// <summary>
-    /// Paged list of notifications for an admin (same as above with Skip/Take).
+    /// Paged list of notifications for an admin (same as above with Skip/Take). Uses filter fields from <paramref name="request"/> (read state, severities, type).
     /// </summary>
-    Task<IPagedResult<NotificationListRow>> GetNotificationListPageByAdminUserIdAsync(int adminUserId, int page, int pageSize, CancellationToken ct = default);
+    Task<IPagedResult<NotificationListRow>> GetNotificationListPageByAdminUserIdAsync(int adminUserId, GetNotificationsRequest request, CancellationToken ct = default);
 
     Task<int> GetUnreadCountByAdminUserIdAsync(int adminUserId, CancellationToken ct = default);
 }

--- a/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/NotificationRecipientQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/NotificationRecipientTable/NotificationRecipientQueryService.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using OpenVPNGateMonitor.Models;
+using OpenVPNGateMonitor.SharedModels.Enums;
+using OpenVPNGateMonitor.SharedModels.Notifications.Requests;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
 namespace OpenVPNGateMonitor.DataBase.Services.Query.NotificationRecipientTable;
@@ -26,8 +28,10 @@ public class NotificationRecipientQueryService(
         return list;
     }
 
-    public async Task<IPagedResult<NotificationListRow>> GetNotificationListPageByAdminUserIdAsync(int adminUserId, int page, int pageSize, CancellationToken ct = default)
+    public async Task<IPagedResult<NotificationListRow>> GetNotificationListPageByAdminUserIdAsync(int adminUserId, GetNotificationsRequest request, CancellationToken ct = default)
     {
+        var page = request.Page;
+        var pageSize = request.PageSize;
         if (page < 1) page = 1;
         if (pageSize < 1) pageSize = 10;
 
@@ -37,13 +41,29 @@ public class NotificationRecipientQueryService(
             .GroupBy(r => r.NotificationId)
             .Select(g => new { NotificationId = g.Key, IsRead = g.Any(r => r.ReadAt != null), ReadAt = g.Min(r => r.ReadAt) });
 
-        var baseQuery = from a in agg
-                        join n in notificationQuery.Query(asNoTracking: true) on a.NotificationId equals n.Id
-                        orderby n.CreateDate descending
-                        select new NotificationListRow(n.Id, n.Type, (int)n.Severity, n.Title, n.Message, a.IsRead, n.CreateDate, a.ReadAt);
+        var joined = from a in agg
+                     join n in notificationQuery.Query(asNoTracking: true) on a.NotificationId equals n.Id
+                     select new { a, n };
 
-        var total = await baseQuery.CountAsync(ct);
-        var items = await baseQuery.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(ct);
+        var filtered = joined;
+        if (request.IsRead.HasValue)
+            filtered = filtered.Where(x => x.a.IsRead == request.IsRead.Value);
+
+        if (!string.IsNullOrWhiteSpace(request.Type))
+        {
+            var typeFilter = request.Type.Trim();
+            filtered = filtered.Where(x => x.n.Type == typeFilter);
+        }
+
+        var severities = request.Severities;
+        if (severities is { Length: > 0 })
+            filtered = filtered.Where(x => severities.Contains(x.n.Severity));
+
+        var ordered = filtered.OrderByDescending(x => x.n.CreateDate);
+        var projected = ordered.Select(x => new NotificationListRow(x.n.Id, x.n.Type, (int)x.n.Severity, x.n.Title, x.n.Message, x.a.IsRead, x.n.CreateDate, x.a.ReadAt));
+
+        var total = await projected.CountAsync(ct);
+        var items = await projected.Skip((page - 1) * pageSize).Take(pageSize).ToListAsync(ct);
 
         return new PagedResponse<NotificationListRow>
         {

--- a/OpenVPNGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
+++ b/OpenVPNGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
@@ -44,7 +44,11 @@ public class UserQueryService(
     }
 
     public Task<IPagedResult<User>> GetPage(int page, int pageSize, CancellationToken ct)
-        => q.Page(page, pageSize, ct: ct);
+        => q.Page(
+            page: page, 
+            pageSize: pageSize, 
+            orderBy: x => x.OrderByDescending(u => u.Id),
+            ct: ct);
 
     public Task<List<User>> Search(
         Expression<Func<User, bool>> predicate,

--- a/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
+++ b/OpenVPNGateMonitor.Mapping/OpenVPNGateMonitor.Mapping.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.98" />
       <PackageReference Include="Mapster" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/OpenVPNGateMonitor.Models/Helpers/NotificationTypes.cs
+++ b/OpenVPNGateMonitor.Models/Helpers/NotificationTypes.cs
@@ -7,4 +7,7 @@ public static class NotificationTypes
     public const string CertIssued      = "cert.issued";
     public const string ServerDown      = "server.down";
     public const string ServerUp        = "server.up";
+
+    public const string GeoLiteAutoUpdateSucceeded = "geolite.auto-update.succeeded";
+    public const string GeoLiteAutoUpdateFailed     = "geolite.auto-update.failed";
 }

--- a/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
+++ b/OpenVPNGateMonitor.Models/OpenVPNGateMonitor.Models.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
+      <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.98" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/OpenVPNGateMonitor.SharedModels/Notifications/Requests/GetNotificationsRequest.cs
+++ b/OpenVPNGateMonitor.SharedModels/Notifications/Requests/GetNotificationsRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using OpenVPNGateMonitor.SharedModels.Enums;
 
 namespace OpenVPNGateMonitor.SharedModels.Notifications.Requests;
 
@@ -9,4 +10,21 @@ public class GetNotificationsRequest
 
     [Range(1, int.MaxValue, ErrorMessage = "pageSize must be greater than 0.")]
     public int PageSize { get; set; } = 10;
+
+    /// <summary>
+    /// Unread only (<c>false</c>), read only (<c>true</c>), or all (<c>null</c>).
+    /// </summary>
+    public bool? IsRead { get; set; }
+
+    /// <summary>
+    /// When set and non-empty, only these <see cref="NotificationSeverity"/> values are returned.
+    /// Query: repeat the parameter, e.g. <c>?severities=Warning&amp;severities=Error</c>.
+    /// </summary>
+    public NotificationSeverity[]? Severities { get; set; }
+
+    /// <summary>
+    /// Optional exact match on notification type (e.g. <c>server.down</c>, <c>cert.issued</c>).
+    /// </summary>
+    [MaxLength(256)]
+    public string? Type { get; set; }
 }

--- a/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
+++ b/OpenVPNGateMonitor.SharedModels/OpenVPNGateMonitor.SharedModels.csproj
@@ -20,9 +20,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. After changes here: dotnet pack, publish to nuget.org, then bump package version in all referencing .csproj files. -->
-        <Version>1.0.97</Version>
-        <AssemblyVersion>1.0.97.0</AssemblyVersion>
-        <FileVersion>1.0.97.0</FileVersion>
+        <Version>1.0.98</Version>
+        <AssemblyVersion>1.0.98.0</AssemblyVersion>
+        <FileVersion>1.0.98.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/OpenVPNGateMonitor.Tests/Configurations/GeoLiteServiceConfigurationTests.cs
+++ b/OpenVPNGateMonitor.Tests/Configurations/GeoLiteServiceConfigurationTests.cs
@@ -18,6 +18,7 @@ public class GeoLiteServiceConfigurationTests
         AssertRegistered(services, typeof(IGeoLiteQueryService));
         AssertRegistered(services, typeof(IGeoLiteUpdaterService));
         AssertRegistered(services, typeof(IGeoLiteConfigProvider));
+        AssertRegistered(services, typeof(IGeoLiteScheduledUpdateRunner));
         AssertRegistered(services, typeof(GeoLiteDatabaseFactory));
     }
 

--- a/OpenVPNGateMonitor.Tests/Configurations/NotificationConfigurationTests.cs
+++ b/OpenVPNGateMonitor.Tests/Configurations/NotificationConfigurationTests.cs
@@ -7,6 +7,7 @@ using OpenVPNGateMonitor.Services.Others.Notifications.CertApiClient;
 using OpenVPNGateMonitor.Services.Others.Notifications.OvpnFileApi;
 using OpenVPNGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using OpenVPNGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
+using OpenVPNGateMonitor.Services.Others.Notifications.GeoLite;
 using Xunit;
 
 namespace OpenVPNGateMonitor.Tests.Configurations;
@@ -27,6 +28,7 @@ public class NotificationConfigurationTests
         AssertRegistered(services, typeof(ICertificateNotificationService));
         AssertRegistered(services, typeof(IServerOpenVpnNotificationService));
         AssertRegistered(services, typeof(IOpenVpnMicroserviceNotificationService));
+        AssertRegistered(services, typeof(IGeoLiteNotificationService));
         AssertRegistered(services, typeof(IAdminNotificationHub));
         AssertRegistered(services, typeof(INotifier));
     }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/NotificationRecipientTable/NotificationRecipientQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/NotificationRecipientTable/NotificationRecipientQueryServiceTests.cs
@@ -4,6 +4,7 @@ using OpenVPNGateMonitor.DataBase.Services.Query;
 using OpenVPNGateMonitor.DataBase.Services.Query.NotificationRecipientTable;
 using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.SharedModels.Enums;
+using OpenVPNGateMonitor.SharedModels.Notifications.Requests;
 using OpenVPNGateMonitor.Tests.Helpers;
 using Xunit;
 
@@ -103,7 +104,7 @@ public class NotificationRecipientQueryServiceTests
         }
         await ctx.SaveChangesAsync();
 
-        var page = await sut.GetNotificationListPageByAdminUserIdAsync(1, page: 2, pageSize: 2, CancellationToken.None);
+        var page = await sut.GetNotificationListPageByAdminUserIdAsync(1, new GetNotificationsRequest { Page = 2, PageSize = 2 }, CancellationToken.None);
 
         page.Page.Should().Be(2);
         page.PageSize.Should().Be(2);
@@ -121,7 +122,7 @@ public class NotificationRecipientQueryServiceTests
         await ctx.NotificationRecipients.AddAsync(new NotificationRecipient { Id = 1, NotificationId = 1, AdminUserId = 1, CreateDate = t, LastUpdate = t });
         await ctx.SaveChangesAsync();
 
-        var page = await sut.GetNotificationListPageByAdminUserIdAsync(1, page: 0, pageSize: 0, CancellationToken.None);
+        var page = await sut.GetNotificationListPageByAdminUserIdAsync(1, new GetNotificationsRequest { Page = 0, PageSize = 0 }, CancellationToken.None);
 
         page.Page.Should().Be(1);
         page.PageSize.Should().Be(10);
@@ -159,4 +160,88 @@ public class NotificationRecipientQueryServiceTests
 
         count.Should().Be(0);
     }
+
+    [Fact]
+    public async Task GetNotificationListPageByAdminUserIdAsync_FiltersBySeverities()
+    {
+        var (sut, ctx) = CreateSutWithContext();
+        var t = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        await ctx.Notifications.AddRangeAsync(
+            new Notification { Id = 1, Type = "a", Severity = NotificationSeverity.Info, Title = "I", Message = "M", CreateDate = t, LastUpdate = t },
+            new Notification { Id = 2, Type = "b", Severity = NotificationSeverity.Warning, Title = "W", Message = "M", CreateDate = t.AddMinutes(1), LastUpdate = t.AddMinutes(1) },
+            new Notification { Id = 3, Type = "c", Severity = NotificationSeverity.Error, Title = "E", Message = "M", CreateDate = t.AddMinutes(2), LastUpdate = t.AddMinutes(2) }
+        );
+        await ctx.NotificationRecipients.AddRangeAsync(
+            new NotificationRecipient { Id = 1, NotificationId = 1, AdminUserId = 1, CreateDate = t, LastUpdate = t },
+            new NotificationRecipient { Id = 2, NotificationId = 2, AdminUserId = 1, CreateDate = t, LastUpdate = t },
+            new NotificationRecipient { Id = 3, NotificationId = 3, AdminUserId = 1, CreateDate = t, LastUpdate = t }
+        );
+        await ctx.SaveChangesAsync();
+
+        var page = await sut.GetNotificationListPageByAdminUserIdAsync(1,
+            new GetNotificationsRequest
+            {
+                Page = 1,
+                PageSize = 10,
+                Severities =
+                [
+                    NotificationSeverity.Warning,
+                    NotificationSeverity.Error,
+                    NotificationSeverity.Critical
+                ]
+            },
+            CancellationToken.None);
+
+        page.TotalCount.Should().Be(2);
+        page.Items.Select(x => x.Id).Should().Equal(3, 2);
+    }
+
+    [Fact]
+    public async Task GetNotificationListPageByAdminUserIdAsync_FiltersByIsRead()
+    {
+        var (sut, ctx) = CreateSutWithContext();
+        var t = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        await ctx.Notifications.AddRangeAsync(
+            new Notification { Id = 1, Type = "a", Severity = NotificationSeverity.Info, Title = "A", Message = "M", CreateDate = t, LastUpdate = t },
+            new Notification { Id = 2, Type = "b", Severity = NotificationSeverity.Info, Title = "B", Message = "M", CreateDate = t.AddMinutes(1), LastUpdate = t.AddMinutes(1) }
+        );
+        await ctx.NotificationRecipients.AddRangeAsync(
+            new NotificationRecipient { Id = 1, NotificationId = 1, AdminUserId = 1, ReadAt = null, CreateDate = t, LastUpdate = t },
+            new NotificationRecipient { Id = 2, NotificationId = 2, AdminUserId = 1, ReadAt = t, CreateDate = t, LastUpdate = t }
+        );
+        await ctx.SaveChangesAsync();
+
+        var page = await sut.GetNotificationListPageByAdminUserIdAsync(1,
+            new GetNotificationsRequest { Page = 1, PageSize = 10, IsRead = false },
+            CancellationToken.None);
+
+        page.TotalCount.Should().Be(1);
+        page.Items[0].Id.Should().Be(1);
+        page.Items[0].IsRead.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetNotificationListPageByAdminUserIdAsync_FiltersByType()
+    {
+        var (sut, ctx) = CreateSutWithContext();
+        var t = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        await ctx.Notifications.AddRangeAsync(
+            new Notification { Id = 1, Type = "server.down", Severity = NotificationSeverity.Critical, Title = "Down", Message = "M", CreateDate = t.AddMinutes(2), LastUpdate = t.AddMinutes(2) },
+            new Notification { Id = 2, Type = "server.up", Severity = NotificationSeverity.Info, Title = "Up", Message = "M", CreateDate = t.AddMinutes(1), LastUpdate = t.AddMinutes(1) }
+        );
+        await ctx.NotificationRecipients.AddRangeAsync(
+            new NotificationRecipient { Id = 1, NotificationId = 1, AdminUserId = 1, CreateDate = t, LastUpdate = t },
+            new NotificationRecipient { Id = 2, NotificationId = 2, AdminUserId = 1, CreateDate = t, LastUpdate = t }
+        );
+        await ctx.SaveChangesAsync();
+
+        var page = await sut.GetNotificationListPageByAdminUserIdAsync(1,
+            new GetNotificationsRequest { Page = 1, PageSize = 10, Type = "server.up" },
+            CancellationToken.None);
+
+        page.TotalCount.Should().Be(1);
+        page.Items[0].Id.Should().Be(2);
+        page.Items[0].Type.Should().Be("server.up");
+    }
+
 }

--- a/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserTable/UserQueryServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/DataBase/Services/Query/UserTable/UserQueryServiceTests.cs
@@ -60,7 +60,7 @@ public class UserQueryServiceTests
     }
 
     [Fact]
-    public async Task Paging_Works()
+    public async Task Paging_Works_With_Desc_Sort()
     {
         var (sut, ctx) = CreateSutWithContext();
         await ctx.Users.AddRangeAsync(Enumerable.Range(1, 15).Select(i => new User { Id = i, DisplayName = $"u{i}" }));
@@ -71,7 +71,9 @@ public class UserQueryServiceTests
         Assert.Equal(10, page.PageSize);
         Assert.Equal(15, page.TotalCount);
         Assert.Equal(5, page.Items.Count);
-        Assert.Equal(11, page.Items.First().Id);
+        // При сортировке DESC: 15, 14, 13, 12, 11, 10, 9, 8, 7, 6 (страница 1)
+        // 5, 4, 3, 2, 1 (страница 2)
+        Assert.Equal(5, page.Items.First().Id);
     }
 
     private sealed class TestDbContext : DbContext

--- a/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
+++ b/OpenVPNGateMonitor.Tests/OpenVPNGateMonitor.Tests.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.98" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/OpenVPNGateMonitor.Tests/Services/GeoLite/GeoLiteScheduledUpdateRunnerTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/GeoLite/GeoLiteScheduledUpdateRunnerTests.cs
@@ -1,0 +1,196 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OpenVPNGateMonitor.Services.GeoLite;
+using OpenVPNGateMonitor.Services.GeoLite.Interfaces;
+using OpenVPNGateMonitor.Services.Others;
+using OpenVPNGateMonitor.Services.Others.Notifications.GeoLite;
+using OpenVPNGateMonitor.SharedModels.DataGateMonitorBackend.GeoLite.Responses;
+using Xunit;
+
+namespace OpenVPNGateMonitor.Tests.Services.GeoLite;
+
+public class GeoLiteScheduledUpdateRunnerTests
+{
+    private static IServiceScopeFactory CreateScopeFactory(
+        ISettingsService settings,
+        IGeoLiteNotificationService notifier)
+    {
+        var sc = new ServiceCollection();
+        sc.AddScoped(_ => settings);
+        sc.AddScoped(_ => notifier);
+        var sp = sc.BuildServiceProvider();
+        return sp.GetRequiredService<IServiceScopeFactory>();
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenIntervalIsZero_DoesNotTouchUpdater()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetValueAsync<int>(GeoLiteScheduledUpdateRunner.GeoIpAutoUpdateIntervalDays, It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        var notifier = new Mock<IGeoLiteNotificationService>(MockBehavior.Strict);
+        var config = new Mock<IGeoLiteConfigProvider>(MockBehavior.Strict);
+        var updater = new Mock<IGeoLiteUpdaterService>(MockBehavior.Strict);
+
+        var sut = new GeoLiteScheduledUpdateRunner(
+            NullLogger<GeoLiteScheduledUpdateRunner>.Instance,
+            CreateScopeFactory(settings.Object, notifier.Object),
+            config.Object,
+            updater.Object);
+
+        await sut.RunAsync(CancellationToken.None);
+
+        updater.Verify(u => u.CheckNewVersionAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenLocalFileStillFresh_SkipsVersionCheck()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GeoLiteTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Combine(tempDir, "db.mmdb");
+        await File.WriteAllTextAsync(dbPath, "x");
+        File.SetLastWriteTimeUtc(dbPath, DateTime.UtcNow.AddDays(-1));
+
+        try
+        {
+            var settings = new Mock<ISettingsService>();
+            settings.Setup(s => s.GetValueAsync<int>(GeoLiteScheduledUpdateRunner.GeoIpAutoUpdateIntervalDays, It.IsAny<CancellationToken>())).ReturnsAsync(7);
+            var notifier = new Mock<IGeoLiteNotificationService>(MockBehavior.Strict);
+            var config = new Mock<IGeoLiteConfigProvider>();
+            config.Setup(c => c.GetDatabasePathAsync(It.IsAny<CancellationToken>())).ReturnsAsync(dbPath);
+            var updater = new Mock<IGeoLiteUpdaterService>(MockBehavior.Strict);
+
+            var sut = new GeoLiteScheduledUpdateRunner(
+                NullLogger<GeoLiteScheduledUpdateRunner>.Instance,
+                CreateScopeFactory(settings.Object, notifier.Object),
+                config.Object,
+                updater.Object);
+
+            await sut.RunAsync(CancellationToken.None);
+
+            updater.Verify(u => u.CheckNewVersionAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, true);
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenUpdateAvailable_DownloadsAndNotifiesSuccess()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GeoLiteTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Combine(tempDir, "db.mmdb");
+        await File.WriteAllTextAsync(dbPath, "x");
+        File.SetLastWriteTimeUtc(dbPath, DateTime.UtcNow.AddDays(-10));
+
+        try
+        {
+            var settings = new Mock<ISettingsService>();
+            settings.Setup(s => s.GetValueAsync<int>(GeoLiteScheduledUpdateRunner.GeoIpAutoUpdateIntervalDays, It.IsAny<CancellationToken>())).ReturnsAsync(7);
+            var notifier = new Mock<IGeoLiteNotificationService>();
+            notifier.Setup(n => n.NotifyAutoUpdateSucceededAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            var config = new Mock<IGeoLiteConfigProvider>();
+            config.Setup(c => c.GetDatabasePathAsync(It.IsAny<CancellationToken>())).ReturnsAsync(dbPath);
+            var updater = new Mock<IGeoLiteUpdaterService>();
+            updater.Setup(u => u.CheckNewVersionAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new GeoLiteVersionCheckResponse { IsUpdateAvailable = true });
+            updater.Setup(u => u.DownloadAndUpdateDatabaseAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new GeoLiteUpdateResponse { Success = true, DatabasePath = dbPath });
+
+            var sut = new GeoLiteScheduledUpdateRunner(
+                NullLogger<GeoLiteScheduledUpdateRunner>.Instance,
+                CreateScopeFactory(settings.Object, notifier.Object),
+                config.Object,
+                updater.Object);
+
+            await sut.RunAsync(CancellationToken.None);
+
+            notifier.Verify(n => n.NotifyAutoUpdateSucceededAsync(dbPath, It.IsAny<CancellationToken>()), Times.Once);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, true);
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCheckSaysNoUpdate_DoesNotDownloadOrNotifySuccess()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "GeoLiteTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var dbPath = Path.Combine(tempDir, "db.mmdb");
+        await File.WriteAllTextAsync(dbPath, "x");
+        File.SetLastWriteTimeUtc(dbPath, DateTime.UtcNow.AddDays(-10));
+
+        try
+        {
+            var settings = new Mock<ISettingsService>();
+            settings.Setup(s => s.GetValueAsync<int>(GeoLiteScheduledUpdateRunner.GeoIpAutoUpdateIntervalDays, It.IsAny<CancellationToken>())).ReturnsAsync(7);
+            var notifier = new Mock<IGeoLiteNotificationService>(MockBehavior.Strict);
+            var config = new Mock<IGeoLiteConfigProvider>();
+            config.Setup(c => c.GetDatabasePathAsync(It.IsAny<CancellationToken>())).ReturnsAsync(dbPath);
+            var updater = new Mock<IGeoLiteUpdaterService>();
+            updater.Setup(u => u.CheckNewVersionAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new GeoLiteVersionCheckResponse { IsUpdateAvailable = false });
+
+            var sut = new GeoLiteScheduledUpdateRunner(
+                NullLogger<GeoLiteScheduledUpdateRunner>.Instance,
+                CreateScopeFactory(settings.Object, notifier.Object),
+                config.Object,
+                updater.Object);
+
+            await sut.RunAsync(CancellationToken.None);
+
+            updater.Verify(u => u.DownloadAndUpdateDatabaseAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, true);
+            }
+            catch
+            {
+                // best-effort cleanup
+            }
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenDatabasePathThrows_NotifiesConfigurationFailure()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetValueAsync<int>(GeoLiteScheduledUpdateRunner.GeoIpAutoUpdateIntervalDays, It.IsAny<CancellationToken>())).ReturnsAsync(7);
+        var notifier = new Mock<IGeoLiteNotificationService>();
+        notifier.Setup(n => n.NotifyAutoUpdateFailedAsync("configuration", It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var config = new Mock<IGeoLiteConfigProvider>();
+        config.Setup(c => c.GetDatabasePathAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("bad path"));
+        var updater = new Mock<IGeoLiteUpdaterService>(MockBehavior.Strict);
+
+        var sut = new GeoLiteScheduledUpdateRunner(
+            NullLogger<GeoLiteScheduledUpdateRunner>.Instance,
+            CreateScopeFactory(settings.Object, notifier.Object),
+            config.Object,
+            updater.Object);
+
+        await sut.RunAsync(CancellationToken.None);
+
+        notifier.Verify(
+            n => n.NotifyAutoUpdateFailedAsync("configuration", It.Is<string>(m => m.Contains("InvalidOperationException", StringComparison.Ordinal)), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/OpenVPNGateMonitor.Tests/Services/Others/Notifications/GeoLite/GeoLiteNotificationServiceTests.cs
+++ b/OpenVPNGateMonitor.Tests/Services/Others/Notifications/GeoLite/GeoLiteNotificationServiceTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using Moq;
+using OpenVPNGateMonitor.Models.Helpers;
+using OpenVPNGateMonitor.Services.Others;
+using OpenVPNGateMonitor.Services.Others.Models;
+using OpenVPNGateMonitor.Services.Others.Notifications.GeoLite;
+using OpenVPNGateMonitor.SharedModels.Enums;
+using Xunit;
+
+namespace OpenVPNGateMonitor.Tests.Services.Others.Notifications.GeoLite;
+
+public class GeoLiteNotificationServiceTests
+{
+    private readonly Mock<INotificationService> _notificationService;
+    private readonly GeoLiteNotificationService _sut;
+
+    public GeoLiteNotificationServiceTests()
+    {
+        _notificationService = new Mock<INotificationService>(MockBehavior.Strict);
+        _sut = new GeoLiteNotificationService(_notificationService.Object);
+    }
+
+    [Fact]
+    public async Task NotifyAutoUpdateSucceededAsync_CallsNotifyAdmins_WithCorrectRequestAndChannels()
+    {
+        var path = "/data/geo-lite2-city.mmdb";
+        var ct = CancellationToken.None;
+
+        NotificationRequest? captured = null;
+        IEnumerable<string>? capturedChannels = null;
+        _notificationService
+            .Setup(s => s.NotifyAdmins(It.IsAny<NotificationRequest>(), It.IsAny<IEnumerable<string>?>(), ct))
+            .Callback<NotificationRequest, IEnumerable<string>?, CancellationToken>((req, ch, _) =>
+            {
+                captured = req;
+                capturedChannels = ch;
+            })
+            .ReturnsAsync(1);
+
+        await _sut.NotifyAutoUpdateSucceededAsync(path, ct);
+
+        captured.Should().NotBeNull();
+        captured!.Type.Should().Be(NotificationTypes.GeoLiteAutoUpdateSucceeded);
+        captured.Title.Should().Be("GeoLite database updated");
+        captured.Message.Should().Contain(path);
+        captured.Severity.Should().Be(NotificationSeverity.Info);
+        captured.Source.Should().Be("geolite-auto-update");
+        capturedChannels.Should().BeEquivalentTo("web", "telegram");
+    }
+
+    [Fact]
+    public async Task NotifyAutoUpdateFailedAsync_CallsNotifyAdmins_WithCorrectRequestAndChannels()
+    {
+        var ct = CancellationToken.None;
+
+        NotificationRequest? captured = null;
+        IEnumerable<string>? capturedChannels = null;
+        _notificationService
+            .Setup(s => s.NotifyAdmins(It.IsAny<NotificationRequest>(), It.IsAny<IEnumerable<string>?>(), ct))
+            .Callback<NotificationRequest, IEnumerable<string>?, CancellationToken>((req, ch, _) =>
+            {
+                captured = req;
+                capturedChannels = ch;
+            })
+            .ReturnsAsync(1);
+
+        await _sut.NotifyAutoUpdateFailedAsync("download", "HttpRequestException: 503", ct);
+
+        captured.Should().NotBeNull();
+        captured!.Type.Should().Be(NotificationTypes.GeoLiteAutoUpdateFailed);
+        captured.Title.Should().Be("GeoLite automatic update failed");
+        captured.Message.Should().Contain("download").And.Contain("503");
+        captured.Severity.Should().Be(NotificationSeverity.Error);
+        captured.Source.Should().Be("geolite-auto-update");
+        capturedChannels.Should().BeEquivalentTo("web", "telegram");
+    }
+}

--- a/OpenVPNGateMonitor/Configurations/GeoLiteServiceConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/GeoLiteServiceConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using OpenVPNGateMonitor.Services.GeoLite;
+using Microsoft.Extensions.DependencyInjection;
+using OpenVPNGateMonitor.Services.GeoLite;
 using OpenVPNGateMonitor.Services.GeoLite.Interfaces;
 
 namespace OpenVPNGateMonitor.Configurations;
@@ -26,5 +27,8 @@ public static class GeoLiteServiceConfiguration
         services.AddSingleton<IGeoLiteProgressNotifier, GeoLiteProgressNotifier>();
         services.AddSingleton<IHttpErrorMapper, HttpErrorMapper>();
         services.AddSingleton<IStreamCopier, StreamCopier>();
+
+        services.AddSingleton<IGeoLiteScheduledUpdateRunner, GeoLiteScheduledUpdateRunner>();
+        services.AddHostedService<GeoLiteAutoUpdateBackgroundService>();
     }
 }

--- a/OpenVPNGateMonitor/Configurations/NotificationConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/NotificationConfiguration.cs
@@ -4,6 +4,7 @@ using OpenVPNGateMonitor.Services.Others.Notifications.CertApiClient;
 using OpenVPNGateMonitor.Services.Others.Notifications.OvpnFileApi;
 using OpenVPNGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using OpenVPNGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
+using OpenVPNGateMonitor.Services.Others.Notifications.GeoLite;
 using OpenVPNGateMonitor.Hubs;
 
 namespace OpenVPNGateMonitor.Configurations;
@@ -24,6 +25,7 @@ public static class NotificationConfiguration
         services.AddScoped<ICertificateNotificationService, CertificateNotificationService>();
         services.AddScoped<IServerOpenVpnNotificationService, ServerOpenVpnNotificationService>();
         services.AddScoped<IOpenVpnMicroserviceNotificationService, OpenVpnMicroserviceNotificationService>();
+        services.AddScoped<IGeoLiteNotificationService, GeoLiteNotificationService>();
 
         // Admin hub adapter for WebNotifier
         services.AddSingleton<IAdminNotificationHub, AdminNotificationHubService>(); // <— ADD THIS

--- a/OpenVPNGateMonitor/Configurations/PipelineConfiguration.cs
+++ b/OpenVPNGateMonitor/Configurations/PipelineConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -105,7 +105,12 @@ public static class PipelineConfiguration
         app.MapHub<AdminNotificationHub>("/api/hubs/admin-notify");
         app.MapHub<OpenVpnStatusHub>("/api/hubs/status-stream", options =>
         {
-            options.Transports = HttpTransportType.WebSockets;
+            // Default: WebSockets only — publisher sends ~every 700ms; long polling is heavy at scale.
+            // Set SignalR:StatusStreamAllowLongPolling=true where WS is blocked (e.g. some dev proxies) — env SignalR__StatusStreamAllowLongPolling.
+            var allowLongPolling = app.Configuration.GetValue("SignalR:StatusStreamAllowLongPolling", false);
+            options.Transports = allowLongPolling
+                ? HttpTransportType.WebSockets | HttpTransportType.LongPolling
+                : HttpTransportType.WebSockets;
         });
 
         var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "Unknown version";

--- a/OpenVPNGateMonitor/Controllers/NotificationController.cs
+++ b/OpenVPNGateMonitor/Controllers/NotificationController.cs
@@ -68,7 +68,7 @@ public class NotificationController(INotificationService notificationService) : 
         if (!TryGetAdminUserId(out var adminUserId))
             return Unauthorized(ApiResponse<GetNotificationsResponse>.ErrorResponse("User not identified."));
 
-        var result = await notificationService.GetPageForUserAsync(adminUserId, request.Page, request.PageSize, cancellationToken);
+        var result = await notificationService.GetPageForUserAsync(adminUserId, request, cancellationToken);
         return Ok(ApiResponse<GetNotificationsResponse>.SuccessResponse(result));
     }
 

--- a/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
+++ b/OpenVPNGateMonitor/OpenVPNGateMonitor.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.97" />
+        <PackageReference Include="OpenVPNGateMonitor.SharedModels" Version="1.0.98" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/OpenVPNGateMonitor/Services/GeoLite/GeoLiteAutoUpdateBackgroundService.cs
+++ b/OpenVPNGateMonitor/Services/GeoLite/GeoLiteAutoUpdateBackgroundService.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Hosting;
+
+namespace OpenVPNGateMonitor.Services.GeoLite;
+
+/// <summary>
+/// Periodically runs <see cref="IGeoLiteScheduledUpdateRunner"/> using
+/// <see cref="GeoLiteScheduledUpdateRunner.GeoIpAutoUpdateIntervalDays"/> from settings (days since local DB file write time; 0 = disabled).
+/// </summary>
+public sealed class GeoLiteAutoUpdateBackgroundService(
+    ILogger<GeoLiteAutoUpdateBackgroundService> logger,
+    IGeoLiteScheduledUpdateRunner scheduledUpdateRunner)
+    : BackgroundService
+{
+    private static readonly TimeSpan LoopDelay = TimeSpan.FromHours(1);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("{Service} started", nameof(GeoLiteAutoUpdateBackgroundService));
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await scheduledUpdateRunner.RunAsync(stoppingToken).ConfigureAwait(false);
+                await Task.Delay(LoopDelay, stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // shutdown
+        }
+
+        logger.LogInformation("{Service} stopped", nameof(GeoLiteAutoUpdateBackgroundService));
+    }
+}

--- a/OpenVPNGateMonitor/Services/GeoLite/GeoLiteScheduledUpdateRunner.cs
+++ b/OpenVPNGateMonitor/Services/GeoLite/GeoLiteScheduledUpdateRunner.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenVPNGateMonitor.Services.GeoLite.Interfaces;
+using OpenVPNGateMonitor.Services.Others;
+using OpenVPNGateMonitor.Services.Others.Notifications.GeoLite;
+
+namespace OpenVPNGateMonitor.Services.GeoLite;
+
+public sealed class GeoLiteScheduledUpdateRunner(
+    ILogger<GeoLiteScheduledUpdateRunner> logger,
+    IServiceScopeFactory scopeFactory,
+    IGeoLiteConfigProvider geoLiteConfig,
+    IGeoLiteUpdaterService geoLiteUpdater)
+    : IGeoLiteScheduledUpdateRunner
+{
+    public const string GeoIpAutoUpdateIntervalDays = "GeoIp_Auto_Update_Interval_Days";
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            await RunCoreAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "GeoLite auto-update check failed");
+            await NotifyFailedAsync("scheduled update", ex, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task RunCoreAsync(CancellationToken ct)
+    {
+        int intervalDays;
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var settings = scope.ServiceProvider.GetRequiredService<ISettingsService>();
+            intervalDays = await settings.GetValueAsync<int>(GeoIpAutoUpdateIntervalDays, ct).ConfigureAwait(false);
+        }
+
+        if (intervalDays <= 0)
+            return;
+
+        string dbPath;
+        try
+        {
+            dbPath = await geoLiteConfig.GetDatabasePathAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "GeoLite auto-update: failed to resolve database path");
+            await NotifyFailedAsync("configuration", ex, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(dbPath))
+        {
+            await NotifyFailedAsync("configuration",
+                "GeoIp_Db_Path is empty or invalid.", ct).ConfigureAwait(false);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        if (File.Exists(dbPath))
+        {
+            var lastWrite = File.GetLastWriteTimeUtc(dbPath);
+            if (lastWrite.AddDays(intervalDays) > now)
+                return;
+        }
+
+        logger.LogInformation("GeoLite auto-update: interval elapsed ({IntervalDays} day(s)), checking remote version", intervalDays);
+
+        try
+        {
+            var versionInfo = await geoLiteUpdater.CheckNewVersionAsync(ct).ConfigureAwait(false);
+            if (!versionInfo.IsUpdateAvailable)
+            {
+                logger.LogInformation("GeoLite auto-update: local database is up to date");
+                return;
+            }
+
+            logger.LogInformation("GeoLite auto-update: downloading new database");
+            var updateResult = await geoLiteUpdater.DownloadAndUpdateDatabaseAsync(ct).ConfigureAwait(false);
+            var path = updateResult.DatabasePath ?? dbPath;
+            await NotifySucceededAsync(path, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "GeoLite auto-update: version check or download failed");
+            await NotifyFailedAsync("version check or download", ex, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task NotifySucceededAsync(string databasePath, CancellationToken ct)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var notifier = scope.ServiceProvider.GetRequiredService<IGeoLiteNotificationService>();
+            await notifier.NotifyAutoUpdateSucceededAsync(databasePath, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to send GeoLite auto-update success notification");
+        }
+    }
+
+    private async Task NotifyFailedAsync(string phase, Exception ex, CancellationToken ct)
+    {
+        await NotifyFailedAsync(phase, $"{ex.GetType().Name}: {ex.Message}", ct).ConfigureAwait(false);
+    }
+
+    private async Task NotifyFailedAsync(string phase, string detail, CancellationToken ct)
+    {
+        try
+        {
+            using var scope = scopeFactory.CreateScope();
+            var notifier = scope.ServiceProvider.GetRequiredService<IGeoLiteNotificationService>();
+            await notifier.NotifyAutoUpdateFailedAsync(phase, detail, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to send GeoLite auto-update failure notification");
+        }
+    }
+}

--- a/OpenVPNGateMonitor/Services/GeoLite/IGeoLiteScheduledUpdateRunner.cs
+++ b/OpenVPNGateMonitor/Services/GeoLite/IGeoLiteScheduledUpdateRunner.cs
@@ -1,0 +1,9 @@
+namespace OpenVPNGateMonitor.Services.GeoLite;
+
+/// <summary>
+/// One iteration of GeoLite auto-update: read interval, optionally check remote and download, notify admins.
+/// </summary>
+public interface IGeoLiteScheduledUpdateRunner
+{
+    Task RunAsync(CancellationToken ct);
+}

--- a/OpenVPNGateMonitor/Services/Others/INotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/INotificationService.cs
@@ -1,4 +1,5 @@
 using OpenVPNGateMonitor.Services.Others.Models;
+using OpenVPNGateMonitor.SharedModels.Notifications.Requests;
 using OpenVPNGateMonitor.SharedModels.Notifications.Responses;
 
 namespace OpenVPNGateMonitor.Services.Others;
@@ -43,7 +44,7 @@ public interface INotificationService
     /// <summary>
     /// Returns a paged list of notifications for the given admin user.
     /// </summary>
-    Task<GetNotificationsResponse> GetPageForUserAsync(int adminUserId, int page, int pageSize, CancellationToken ct = default);
+    Task<GetNotificationsResponse> GetPageForUserAsync(int adminUserId, GetNotificationsRequest request, CancellationToken ct = default);
 
     /// <summary>
     /// Returns the count of notifications not yet read by the given admin user.

--- a/OpenVPNGateMonitor/Services/Others/NotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/NotificationService.cs
@@ -5,6 +5,7 @@ using OpenVPNGateMonitor.Models;
 using OpenVPNGateMonitor.Services.Others.Models;
 using OpenVPNGateMonitor.SharedModels.Auth;
 using OpenVPNGateMonitor.SharedModels.Enums;
+using OpenVPNGateMonitor.SharedModels.Notifications.Requests;
 using OpenVPNGateMonitor.SharedModels.Notifications.Responses;
 using OpenVPNGateMonitor.SharedModels.Responses;
 
@@ -152,9 +153,9 @@ public class NotificationService(
         return new GetAllNotificationsResponse { Notifications = items };
     }
 
-    public async Task<GetNotificationsResponse> GetPageForUserAsync(int adminUserId, int page, int pageSize, CancellationToken ct = default)
+    public async Task<GetNotificationsResponse> GetPageForUserAsync(int adminUserId, GetNotificationsRequest request, CancellationToken ct = default)
     {
-        var paged = await notificationRecipientQueryService.GetNotificationListPageByAdminUserIdAsync(adminUserId, page, pageSize, ct);
+        var paged = await notificationRecipientQueryService.GetNotificationListPageByAdminUserIdAsync(adminUserId, request, ct);
         var items = paged.Items.Select(r => new NotificationItemDto
         {
             Id = r.Id,

--- a/OpenVPNGateMonitor/Services/Others/Notifications/GeoLite/GeoLiteNotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/Notifications/GeoLite/GeoLiteNotificationService.cs
@@ -1,0 +1,31 @@
+using OpenVPNGateMonitor.Models.Helpers;
+using OpenVPNGateMonitor.Services.Others.Models;
+using OpenVPNGateMonitor.SharedModels.Enums;
+
+namespace OpenVPNGateMonitor.Services.Others.Notifications.GeoLite;
+
+public sealed class GeoLiteNotificationService(INotificationService notifications) : IGeoLiteNotificationService
+{
+    private static readonly string[] Channels = ["web", "telegram"];
+    private const string Source = "geolite-auto-update";
+
+    public Task NotifyAutoUpdateSucceededAsync(string databasePath, CancellationToken ct)
+        => notifications.NotifyAdmins(new NotificationRequest
+        {
+            Type = NotificationTypes.GeoLiteAutoUpdateSucceeded,
+            Title = "GeoLite database updated",
+            Message = $"Automatic GeoLite2 update completed. Database path: {databasePath}",
+            Severity = NotificationSeverity.Info,
+            Source = Source
+        }, Channels, ct);
+
+    public Task NotifyAutoUpdateFailedAsync(string phase, string detail, CancellationToken ct)
+        => notifications.NotifyAdmins(new NotificationRequest
+        {
+            Type = NotificationTypes.GeoLiteAutoUpdateFailed,
+            Title = "GeoLite automatic update failed",
+            Message = $"Phase: {phase}. {detail}",
+            Severity = NotificationSeverity.Error,
+            Source = Source
+        }, Channels, ct);
+}

--- a/OpenVPNGateMonitor/Services/Others/Notifications/GeoLite/IGeoLiteNotificationService.cs
+++ b/OpenVPNGateMonitor/Services/Others/Notifications/GeoLite/IGeoLiteNotificationService.cs
@@ -1,0 +1,8 @@
+namespace OpenVPNGateMonitor.Services.Others.Notifications.GeoLite;
+
+public interface IGeoLiteNotificationService
+{
+    Task NotifyAutoUpdateSucceededAsync(string databasePath, CancellationToken ct);
+
+    Task NotifyAutoUpdateFailedAsync(string phase, string detail, CancellationToken ct);
+}


### PR DESCRIPTION
Implements an automated GeoLite2 database update mechanism and improves notification management for administrators.

**Key Changes:**
*   **GeoLite Database Auto-Update**:
    *   Introduces a new background service to periodically check for and download updates to the GeoLite2 City database.
    *   A new configuration setting, `GeoIp_Auto_Update_Interval_Days`, controls the frequency of these automatic updates.
    *   Sends notifications to administrators (via web and Telegram channels) upon successful updates or in the event of failures during the update process.
*   **Enhanced Notification Filtering**:
    *   The `/notifications` API endpoint for administrators now supports advanced filtering options, including by read status, notification severity levels, and specific notification types.
*   **Consistent User Paging**:
    *   Ensures a consistent descending sort order by ID for user list paging, leading to more predictable results.
*   **SignalR Transport Options**:
    *   Adds a new configuration option (`SignalR:StatusStreamAllowLongPolling`) to allow fallback to long polling for the OpenVPN status stream SignalR hub. This improves compatibility for clients in network environments where WebSockets might be blocked.
*   **Dependency Update**:
    *   Updates the `OpenVPNGateMonitor.SharedModels` NuGet package to version `1.0.98`.