### PR TITLE
fix(backend): include pre-window baseline in overview totals traffic.

### DIFF
--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQuery.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQuery.cs
@@ -55,11 +55,11 @@ public sealed class OpenVpnOverviewTotalsQuery(IUnitOfWork uow) : IOpenVpnOvervi
         if (!string.IsNullOrWhiteSpace(externalId))
             trafficQ = trafficQ.Where(s => s.ExternalId == externalId!);
 
-        trafficQ = trafficQ
+        var trafficInWindowQ = trafficQ
             .Where(s => s.MeasuredAt >= fromUtc && s.MeasuredAt < toUtc)
             .AsNoTracking();
 
-        var samples = await trafficQ
+        var samples = await trafficInWindowQ
             .Select(s => new TrafficSampleRowDto
             {
                 SessionId  = s.SessionId,
@@ -74,6 +74,33 @@ public sealed class OpenVpnOverviewTotalsQuery(IUnitOfWork uow) : IOpenVpnOvervi
         long totalIn = 0;
         long totalOut = 0;
         var lastBySession = new Dictionary<Guid, (long inTot, long outTot)>();
+
+        // Seed per-session baselines from the latest sample strictly before window start.
+        // Without this, sessions that only have one sample inside [from;to) produce zero delta.
+        var baselineRows = await trafficQ
+            .Where(s => s.MeasuredAt < fromUtc)
+            .GroupBy(s => s.SessionId)
+            .Select(g => new
+            {
+                SessionId = g.Key,
+                LastAt = g.Max(x => x.MeasuredAt)
+            })
+            .Join(
+                trafficQ,
+                k => new { k.SessionId, MeasuredAt = k.LastAt },
+                s => new { s.SessionId, s.MeasuredAt },
+                (k, s) => new TrafficSampleRowDto
+                {
+                    SessionId = s.SessionId,
+                    MeasuredAt = s.MeasuredAt,
+                    BytesIn = s.BytesReceived,
+                    BytesOut = s.BytesSent
+                })
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        foreach (var b in baselineRows)
+            lastBySession[b.SessionId] = (b.BytesIn, b.BytesOut);
 
         foreach (var s in samples)
         {

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQueryTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQueryTests.cs
@@ -105,4 +105,39 @@ public class OpenVpnOverviewTotalsQueryTests
 
         await ctx.DisposeAsync();
     }
+
+    [Fact]
+    public async Task GetOverviewTotals_Uses_PreWindow_Baseline_For_First_Sample_In_Window()
+    {
+        var (uow, ctx) = CreateUow();
+        var now = DateTimeOffset.UtcNow;
+        var from = now.AddHours(-2);
+        var to = now.AddHours(1);
+
+        ctx.Clients.Add(new VpnServerClient
+        {
+            Id = 1,
+            VpnServerId = 7,
+            ExternalId = "xr-1",
+            ConnectedSince = now.AddHours(-1),
+        });
+
+        var s = Guid.NewGuid();
+        ctx.Traffic.AddRange(new[]
+        {
+            // Baseline before range start
+            new VpnServerClientTraffic { Id = 1, VpnServerId = 7, ExternalId = "xr-1", SessionId = s, BytesReceived = 1000, BytesSent = 300, MeasuredAt = now.AddHours(-3) },
+            // Only one sample in [from;to)
+            new VpnServerClientTraffic { Id = 2, VpnServerId = 7, ExternalId = "xr-1", SessionId = s, BytesReceived = 1400, BytesSent = 500, MeasuredAt = now.AddHours(-1) },
+        });
+        await ctx.SaveChangesAsync();
+
+        var sut = new OpenVpnOverviewTotalsQuery(uow.Object);
+        var res = await sut.GetOverviewTotalsAsync(from, to, vpnServerId: 7, externalId: null, CancellationToken.None);
+
+        Assert.Equal(400, res.Totals.TrafficInBytes);
+        Assert.Equal(200, res.Totals.TrafficOutBytes);
+
+        await ctx.DisposeAsync();
+    }
 }


### PR DESCRIPTION
Compute overview summary traffic deltas using the latest sample before the requested window as per-session baseline. This prevents XRay sessions with a single sample inside the window from incorrectly reporting zero total IN/OUT bytes. Add regression test coverage for baseline behavior.

Made-with: Cursor
