### PR TITLE
 Added a configurable auth setting to control whether email confirmation is required for password-based registration

### DIFF
--- a/DataGateMonitor.DataBase/ConfigurationModels/Seeds/SettingSeedData.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/Seeds/SettingSeedData.cs
@@ -109,5 +109,19 @@ public static class SettingSeedData
             ValueType = "string",
             StringValue = "int"
         },
+        new Setting
+        {
+            Id = 15,
+            Key = "Auth_Require_Email_Confirmation_On_Register",
+            ValueType = "bool",
+            BoolValue = true
+        },
+        new Setting
+        {
+            Id = 16,
+            Key = "Auth_Require_Email_Confirmation_On_Register_Type",
+            ValueType = "string",
+            StringValue = "bool"
+        },
     };
 }

--- a/DataGateMonitor.DataBase/ConfigurationModels/UserConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/UserConfiguration.cs
@@ -19,6 +19,9 @@ public class UserConfiguration : BaseEntityConfiguration<User, int>
         entity.Property(e => e.Email)
             .HasMaxLength(256);
 
+        entity.Property(e => e.IsEmailConfirmed)
+            .IsRequired();
+
         entity.Property(e => e.IsAdmin)
             .IsRequired();
 

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -16,13 +16,17 @@
       <PackageReference Include="Mapster" Version="10.0.7" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.7" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/DataGateMonitor.DataBase/Migrations/20260425135045_UserEmailConfirmationInit.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260425135045_UserEmailConfirmationInit.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425135045_UserEmailConfirmationInit")]
+    partial class UserEmailConfirmationInit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260425135045_UserEmailConfirmationInit.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260425135045_UserEmailConfirmationInit.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserEmailConfirmationInit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsEmailConfirmed",
+                schema: "xgb_dashopnvpn",
+                table: "Users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsEmailConfirmed",
+                schema: "xgb_dashopnvpn",
+                table: "Users");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260425135941_AuthRequireEmailConfirmationSetting.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260425135941_AuthRequireEmailConfirmationSetting.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425135941_AuthRequireEmailConfirmationSetting")]
+    partial class AuthRequireEmailConfirmationSetting
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260425135941_AuthRequireEmailConfirmationSetting.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260425135941_AuthRequireEmailConfirmationSetting.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AuthRequireEmailConfirmationSetting : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                columns: new[] { "Id", "BoolValue", "DateTimeValue", "DoubleValue", "IntValue", "Key", "StringValue", "ValueType" },
+                values: new object[,]
+                {
+                    { 15, true, null, null, null, "Auth_Require_Email_Confirmation_On_Register", null, "bool" },
+                    { 16, null, null, null, null, "Auth_Require_Email_Confirmation_On_Register_Type", "bool", "string" }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 15);
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 16);
+        }
+    }
+}

--- a/DataGateMonitor.Models/User.cs
+++ b/DataGateMonitor.Models/User.cs
@@ -8,6 +8,7 @@ public class User : BaseEntity<int>
     public string DisplayName { get; set; } = null!;
     [EmailAddress, MaxLength(256)]
     public string? Email { get; set; }
+    public bool IsEmailConfirmed { get; set; } = false;
 
     public bool IsAdmin { get; set; } = false;
     public bool IsBlocked { get; set; } = false;

--- a/DataGateMonitor.Tests/Services/Api/Auth/Login/UserLoginServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/Login/UserLoginServiceTests.cs
@@ -14,6 +14,7 @@ public class UserLoginServiceTests
         var passwordHasher = new Mock<Microsoft.AspNetCore.Identity.IPasswordHasher<DataGateMonitor.Models.User>>();
         var tokenValidator = new Mock<DataGateMonitor.Services.Api.Auth.Registers.Interfaces.IGoogleTokenValidator>();
         var userIdentityLinkCommand = new Mock<DataGateMonitor.DataBase.Services.Command.Interfaces.ICommandService<DataGateMonitor.Models.UserIdentityLink, int>>();
+        var userCommand = new Mock<DataGateMonitor.DataBase.Services.Command.Interfaces.ICommandService<DataGateMonitor.Models.User, int>>();
         var userIdentityLinkQuery = new Mock<DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable.IUserIdentityLinkQueryService>();
         var userAccountService = new Mock<DataGateMonitor.Services.Api.Auth.Users.IUserAccountService>();
         var tokenService = new Mock<ITokenService>();
@@ -25,6 +26,7 @@ public class UserLoginServiceTests
             passwordHasher.Object,
             tokenValidator.Object,
             userIdentityLinkCommand.Object,
+            userCommand.Object,
             userIdentityLinkQuery.Object,
             userAccountService.Object,
             tokenService.Object,
@@ -51,6 +53,7 @@ public class UserLoginServiceTests
         var passwordHasher = new Mock<Microsoft.AspNetCore.Identity.IPasswordHasher<DataGateMonitor.Models.User>>();
         var tokenValidator = new Mock<DataGateMonitor.Services.Api.Auth.Registers.Interfaces.IGoogleTokenValidator>();
         var userIdentityLinkCommand = new Mock<DataGateMonitor.DataBase.Services.Command.Interfaces.ICommandService<DataGateMonitor.Models.UserIdentityLink, int>>();
+        var userCommand = new Mock<DataGateMonitor.DataBase.Services.Command.Interfaces.ICommandService<DataGateMonitor.Models.User, int>>();
         var userIdentityLinkQuery = new Mock<DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable.IUserIdentityLinkQueryService>();
         var userAccountService = new Mock<DataGateMonitor.Services.Api.Auth.Users.IUserAccountService>();
         var tokenService = new Mock<ITokenService>();
@@ -62,6 +65,7 @@ public class UserLoginServiceTests
             passwordHasher.Object,
             tokenValidator.Object,
             userIdentityLinkCommand.Object,
+            userCommand.Object,
             userIdentityLinkQuery.Object,
             userAccountService.Object,
             tokenService.Object,

--- a/DataGateMonitor.Tests/Services/Api/Auth/UserRegistrationServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/UserRegistrationServiceTests.cs
@@ -4,8 +4,10 @@ using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.Registers;
 using DataGateMonitor.Services.Api.Auth.Users;
+using DataGateMonitor.Services.Others;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using Xunit;
 
@@ -18,6 +20,8 @@ public class UserRegistrationServiceTests
     private readonly Mock<IUserCredentialQueryService> _credentialQuery;
     private readonly Mock<IUserQueryService> _userQuery;
     private readonly Mock<IUserAccountService> _userAccountService;
+    private readonly Mock<IEmailConfirmationService> _emailConfirmationService;
+    private readonly Mock<ISettingsService> _settingsService;
     private readonly UserRegistrationService _sut;
 
     public UserRegistrationServiceTests()
@@ -27,12 +31,16 @@ public class UserRegistrationServiceTests
         _credentialQuery = new Mock<IUserCredentialQueryService>();
         _userQuery = new Mock<IUserQueryService>();
         _userAccountService = new Mock<IUserAccountService>();
+        _emailConfirmationService = new Mock<IEmailConfirmationService>();
+        _settingsService = new Mock<ISettingsService>();
         _sut = new UserRegistrationService(
             _passwordHasher.Object,
             _credentialCommand.Object,
             _credentialQuery.Object,
             _userQuery.Object,
-            _userAccountService.Object);
+            _userAccountService.Object,
+            _emailConfirmationService.Object,
+            _settingsService.Object);
     }
 
     [Fact]
@@ -51,6 +59,12 @@ public class UserRegistrationServiceTests
         _credentialQuery.Setup(q => q.GetByNormalizedLogin(normalizedLogin, It.IsAny<CancellationToken>()))
             .ReturnsAsync((UserCredential?)null);
         _userQuery.Setup(q => q.AnyByEmail(request.Email!, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        _settingsService
+            .Setup(s => s.GetValueAsync<string>($"{AuthEmailSettingsKeys.RequireEmailConfirmationOnRegister}_Type", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bool");
+        _settingsService
+            .Setup(s => s.GetValueAsync<bool>(AuthEmailSettingsKeys.RequireEmailConfirmationOnRegister, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         User? capturedUser = null;
         _userAccountService
@@ -69,6 +83,9 @@ public class UserRegistrationServiceTests
             .Setup(c => c.Add(It.IsAny<UserCredential>(), true, It.IsAny<CancellationToken>()))
             .Callback<UserCredential, bool, CancellationToken>((c, _, _) => capturedCredential = c)
             .ReturnsAsync((UserCredential c, bool _, CancellationToken _) => c);
+        _emailConfirmationService
+            .Setup(s => s.SendConfirmationAsync(42, "test@example.com", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
         var result = await _sut.RegisterAsync(request, CancellationToken.None);
 
@@ -89,6 +106,58 @@ public class UserRegistrationServiceTests
         Assert.Equal(normalizedLogin, capturedCredential.NormalizedLogin);
         Assert.Equal("HASHED_PASSWORD", capturedCredential.PasswordHash);
         Assert.Equal("AspNetCoreV3", capturedCredential.PasswordAlgo);
+        _emailConfirmationService.Verify(
+            s => s.SendConfirmationAsync(42, "test@example.com", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenEmailConfirmationSettingDisabled_SkipsSendingAndMarksConfirmed()
+    {
+        var request = new RegisterUserRequest
+        {
+            DisplayName = "Test User",
+            Email = "test@example.com",
+            Login = "test-login",
+            Password = "StrongPass123!",
+            ConfirmPassword = "StrongPass123!"
+        };
+
+        _credentialQuery.Setup(q => q.GetByNormalizedLogin("TEST-LOGIN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserCredential?)null);
+        _userQuery.Setup(q => q.AnyByEmail(request.Email!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _settingsService
+            .Setup(s => s.GetValueAsync<string>($"{AuthEmailSettingsKeys.RequireEmailConfirmationOnRegister}_Type", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bool");
+        _settingsService
+            .Setup(s => s.GetValueAsync<bool>(AuthEmailSettingsKeys.RequireEmailConfirmationOnRegister, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _passwordHasher.Setup(h => h.HashPassword(It.IsAny<User>(), request.Password)).Returns("HASHED_PASSWORD");
+
+        _userAccountService
+            .Setup(s => s.CreateUserWithDefaultRoleAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User u, CancellationToken _) =>
+            {
+                u.Id = 42;
+                return u;
+            });
+
+        _credentialCommand
+            .Setup(c => c.Add(It.IsAny<UserCredential>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserCredential c, bool _, CancellationToken _) => c);
+
+        var result = await _sut.RegisterAsync(request, CancellationToken.None);
+
+        Assert.Equal(42, result.UserId);
+        _userAccountService.Verify(
+            s => s.CreateUserWithDefaultRoleAsync(
+                It.Is<User>(u => u.IsEmailConfirmed),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _emailConfirmationService.Verify(
+            s => s.SendConfirmationAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Others/Notifications/AppNotificationFacadeTests.cs
+++ b/DataGateMonitor.Tests/Services/Others/Notifications/AppNotificationFacadeTests.cs
@@ -92,7 +92,7 @@ public class AppNotificationFacadeTests
         var serverId = 3;
         var serverName = "vpn-prod";
         var env = new NotificationEnvelope(
-            new NotificationRequest { Type = "server.down", Title = "Server is DOWN", Message = $"OpenVPN server \"{serverName}\" (id={serverId}) is unreachable.", Severity = NotificationSeverity.Critical, ServerId = serverId },
+            new NotificationRequest { Type = "server.down", Title = "Server is DOWN", Message = $"VPN server \"{serverName}\" (id={serverId}) is unreachable.", Severity = NotificationSeverity.Critical, ServerId = serverId },
             new[] { "web", "telegram" });
         var ct = CancellationToken.None;
 
@@ -113,7 +113,7 @@ public class AppNotificationFacadeTests
         var serverId = 4;
         var serverName = "vpn-backup";
         var env = new NotificationEnvelope(
-            new NotificationRequest { Type = "server.up", Title = "Server is UP", Message = $"OpenVPN server \"{serverName}\" (id={serverId}) is reachable again.", Severity = NotificationSeverity.Info, ServerId = serverId },
+            new NotificationRequest { Type = "server.up", Title = "Server is UP", Message = $"VPN server \"{serverName}\" (id={serverId}) is reachable again.", Severity = NotificationSeverity.Info, ServerId = serverId },
             new[] { "web", "telegram" });
         var ct = CancellationToken.None;
 

--- a/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
@@ -10,6 +10,7 @@ using DataGateMonitor.Services.Api.Auth;
 using DataGateMonitor.Services.Api.Auth.Handlers;
 using DataGateMonitor.Services.Api.Auth.Handlers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.ForgotPassword;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.TelegramLogin;
 using DataGateMonitor.Services.Api.Auth.Registers;
@@ -47,6 +48,11 @@ public static class AuthServiceConfiguration
 
         services.AddMemoryCache();
         services.AddScoped<IAdminForgotPasswordService, AdminForgotPasswordService>();
+        services.Configure<EmailSenderSettings>(configuration.GetSection("EmailSender"));
+        services.AddScoped<SmtpEmailSenderService>();
+        services.AddScoped<ResendEmailSenderService>();
+        services.AddScoped<IEmailSenderService, ConfigurableEmailSenderService>();
+        services.AddScoped<IEmailConfirmationService, EmailConfirmationService>();
         services.AddScoped<ITelegramLoginCodeService, TelegramLoginCodeService>();
 
         services.AddAuthorization(options =>

--- a/DataGateMonitor/Controllers/AuthController.cs
+++ b/DataGateMonitor/Controllers/AuthController.cs
@@ -7,8 +7,11 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using DataGateMonitor.Services.Api.Auth.ForgotPassword;
 using DataGateMonitor.Services.Api.Auth.Login;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation.Models;
 using DataGateMonitor.Services.Api.Auth.TelegramLogin;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
 using DataGateMonitor.SharedModels.Responses;
@@ -23,6 +26,8 @@ public class AuthController(
     IMicroserviceTokenService microserviceTokenService,
     IUserRegistrationService userRegistrationService,
     IUserLoginService userLoginService,
+    IUserQueryService userQueryService,
+    IEmailConfirmationService emailConfirmationService,
     IGoogleAuthCodeExchangeService exchange,
     ITokenService tokenService,
     IAdminForgotPasswordService adminForgotPasswordService,
@@ -99,6 +104,42 @@ public class AuthController(
         var result = await userRegistrationService.RegisterAsync(request, ct);
 
         return Ok(ApiResponse<RegisterUserResponse>.SuccessResponse(result));
+    }
+
+    [AllowAnonymous]
+    [HttpPost("email/request-confirmation")]
+    [ProducesResponseType(typeof(ApiResponse<string>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<string>>> RequestEmailConfirmation(
+        [FromBody] RequestEmailConfirmationRequest request,
+        CancellationToken ct)
+    {
+        if (request is null || string.IsNullOrWhiteSpace(request.Email))
+            return BadRequest(ApiResponse<string>.ErrorResponse("Email is required."));
+
+        // Prevent account enumeration: always return success message.
+        try
+        {
+            var user = await userQueryService.GetByEmail(request.Email.Trim(), ct);
+            if (user is { IsEmailConfirmed: false } && !string.IsNullOrWhiteSpace(user.Email))
+                await emailConfirmationService.SendConfirmationAsync(user.Id, user.Email, ct);
+        }
+        catch
+        {
+            // Intentionally ignored to avoid leaking account existence.
+        }
+
+        return Ok(ApiResponse<string>.SuccessResponse("If this email exists, confirmation code has been sent."));
+    }
+
+    [AllowAnonymous]
+    [HttpPost("email/confirm")]
+    [ProducesResponseType(typeof(ApiResponse<ConfirmEmailResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<ConfirmEmailResponse>>> ConfirmEmail(
+        [FromBody] ConfirmEmailRequest request,
+        CancellationToken ct)
+    {
+        var result = await emailConfirmationService.ConfirmAsync(request.Email, request.Code, ct);
+        return Ok(ApiResponse<ConfirmEmailResponse>.SuccessResponse(result));
     }
 
     [AllowAnonymous]

--- a/DataGateMonitor/Controllers/VpnServersController.cs
+++ b/DataGateMonitor/Controllers/VpnServersController.cs
@@ -1,6 +1,7 @@
 using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTagTable;
 using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
@@ -52,8 +53,13 @@ public class VpnServersController(IVpnDataService vpnDataService,
                     includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId: uqp.QuotaPlanId, ct);
         }
 
-        var response = result.Adapt<VpnServerWithStatusesResponse>();
+        VpnServerWithStatusesResponse response = result.Adapt<VpnServerWithStatusesResponse>();
+        response = new LegacyVpnServerWithStatusesResponse
+        {
+            VpnServerWithStatuses = response.VpnServerWithStatuses
+        };
         await FillTagsForOverviewResponse(response, ct);
+        ApplyLegacyOpenVpnAliases(response);
         return Ok(ApiResponse<VpnServerWithStatusesResponse>.SuccessResponse(response));
     }
 
@@ -221,5 +227,43 @@ public class VpnServersController(IVpnDataService vpnDataService,
             var id = item.VpnServerResponses.VpnServer.Id;
             item.VpnServerResponses.VpnServer.Tags = tagNamesByServer.GetValueOrDefault(id, []);
         }
+    }
+
+    // Keep old Windows clients working after DTO renames (OpenVpn* -> Vpn*).
+    private static void ApplyLegacyOpenVpnAliases(VpnServerWithStatusesResponse response)
+    {
+        response.VpnServerWithStatuses = response.VpnServerWithStatuses
+            .Select(item => new LegacyVpnServerWithStatusDto
+            {
+                VpnServerResponses = new LegacyVpnServerResponse
+                {
+                    VpnServer = item.VpnServerResponses.VpnServer
+                },
+                VpnServerStatusLogResponse = item.VpnServerStatusLogResponse,
+                CountConnectedClients = item.CountConnectedClients,
+                CountSessions = item.CountSessions,
+                TotalBytesIn = item.TotalBytesIn,
+                TotalBytesOut = item.TotalBytesOut
+            })
+            .Cast<VpnServerWithStatusDto>()
+            .ToList();
+    }
+
+    private sealed class LegacyVpnServerWithStatusDto : VpnServerWithStatusDto
+    {
+        [JsonProperty("OpenVpnServerResponses")]
+        public VpnServerResponse OpenVpnServerResponses => VpnServerResponses;
+    }
+
+    private sealed class LegacyVpnServerWithStatusesResponse : VpnServerWithStatusesResponse
+    {
+        [JsonProperty("OpenVpnServerWithStatuses")]
+        public List<VpnServerWithStatusDto> OpenVpnServerWithStatuses => VpnServerWithStatuses;
+    }
+
+    private sealed class LegacyVpnServerResponse : VpnServerResponse
+    {
+        [JsonProperty("OpenVpnServer")]
+        public VpnServerDto OpenVpnServer => VpnServer;
     }
 }

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -23,6 +23,10 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -37,6 +41,7 @@
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="10.0.0" />
+        <PackageReference Include="Resend" Version="0.5.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/AuthEmailSettingsKeys.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/AuthEmailSettingsKeys.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public static class AuthEmailSettingsKeys
+{
+    public const string RequireEmailConfirmationOnRegister = "Auth_Require_Email_Confirmation_On_Register";
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/ConfigurableEmailSenderService.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/ConfigurableEmailSenderService.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Options;
+
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public sealed class ConfigurableEmailSenderService(
+    IOptions<EmailSenderSettings> options,
+    SmtpEmailSenderService smtpEmailSenderService,
+    ResendEmailSenderService resendEmailSenderService) : IEmailSenderService
+{
+    private readonly EmailSenderSettings _settings = options.Value;
+
+    public Task SendAsync(string toEmail, string subject, string body, CancellationToken ct)
+    {
+        var provider = (_settings.Provider ?? "smtp").Trim().ToLowerInvariant();
+        return provider switch
+        {
+            "smtp" => smtpEmailSenderService.SendAsync(toEmail, subject, body, ct),
+            "resend" => resendEmailSenderService.SendAsync(toEmail, subject, body, ct),
+            _ => throw new InvalidOperationException(
+                $"Unsupported email provider '{_settings.Provider}'. Allowed values: smtp, resend.")
+        };
+    }
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/EmailConfirmationService.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/EmailConfirmationService.cs
@@ -1,0 +1,131 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Caching.Memory;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation.Models;
+
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public sealed class EmailConfirmationService(
+    IMemoryCache cache,
+    IUserQueryService userQueryService,
+    ICommandService<User, int> userCommandService,
+    IEmailSenderService emailSenderService) : IEmailConfirmationService
+{
+    private const int CodeLength = 6;
+    private const int CodeTtlMinutes = 30;
+    private const int RateLimitWindowMinutes = 10;
+    private const int RateLimitMaxRequests = 3;
+    private static readonly ConcurrentDictionary<string, object> RateLimitLocks = new();
+
+    public async Task SendConfirmationAsync(int userId, string email, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Email is required.", nameof(email));
+
+        var normalizedEmail = email.Trim().ToUpperInvariant();
+        var rateLimitKey = $"email-confirm:rate:{normalizedEmail}";
+        if (IsRateLimited(rateLimitKey))
+            throw new InvalidOperationException("Too many confirmation requests. Try again later.");
+
+        RecordRateLimit(rateLimitKey);
+
+        var code = GenerateCode();
+        cache.Set(
+            key: GetCodeCacheKey(normalizedEmail),
+            value: new EmailConfirmationCodePayload(userId, code),
+            options: new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(CodeTtlMinutes)
+            });
+
+        var subject = "Confirm your email";
+        var body = $"Your confirmation code is: {code}\nCode is valid for {CodeTtlMinutes} minutes.";
+        await emailSenderService.SendAsync(email, subject, body, ct);
+    }
+
+    public async Task<ConfirmEmailResponse> ConfirmAsync(string email, string code, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(code))
+            return new ConfirmEmailResponse { Success = false, Message = "Email and code are required." };
+
+        var normalizedEmail = email.Trim().ToUpperInvariant();
+        var cacheKey = GetCodeCacheKey(normalizedEmail);
+
+        if (!cache.TryGetValue(cacheKey, out EmailConfirmationCodePayload? payload) || payload is null)
+            return new ConfirmEmailResponse { Success = false, Message = "Invalid or expired confirmation code." };
+
+        if (!string.Equals(payload.Code, code.Trim(), StringComparison.Ordinal))
+            return new ConfirmEmailResponse { Success = false, Message = "Invalid or expired confirmation code." };
+
+        var user = await userQueryService.GetById(payload.UserId, ct);
+        if (user is null)
+            return new ConfirmEmailResponse { Success = false, Message = "User not found." };
+
+        if (!string.Equals(user.Email?.Trim(), email.Trim(), StringComparison.OrdinalIgnoreCase))
+            return new ConfirmEmailResponse { Success = false, Message = "Email mismatch." };
+
+        user.IsEmailConfirmed = true;
+        await userCommandService.Update(user, saveChanges: true, ct);
+        cache.Remove(cacheKey);
+
+        return new ConfirmEmailResponse { Success = true, Message = "Email confirmed successfully." };
+    }
+
+    private static string GetCodeCacheKey(string normalizedEmail) => $"email-confirm:code:{normalizedEmail}";
+
+    private static string GenerateCode()
+    {
+        const string chars = "0123456789";
+        var bytes = new byte[CodeLength];
+        RandomNumberGenerator.Fill(bytes);
+        var result = new char[CodeLength];
+        for (var i = 0; i < CodeLength; i++)
+            result[i] = chars[bytes[i] % chars.Length];
+        return new string(result);
+    }
+
+    private bool IsRateLimited(string cacheKey)
+    {
+        var lockObj = RateLimitLocks.GetOrAdd(cacheKey, _ => new object());
+        lock (lockObj)
+        {
+            if (!cache.TryGetValue(cacheKey, out RateLimitEntry? entry) || entry is null)
+                return false;
+
+            var now = DateTimeOffset.UtcNow;
+            if (now - entry.FirstRequestUtc > TimeSpan.FromMinutes(RateLimitWindowMinutes))
+                return false;
+
+            return entry.Count >= RateLimitMaxRequests;
+        }
+    }
+
+    private void RecordRateLimit(string cacheKey)
+    {
+        var lockObj = RateLimitLocks.GetOrAdd(cacheKey, _ => new object());
+        lock (lockObj)
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (!cache.TryGetValue(cacheKey, out RateLimitEntry? entry) || entry is null)
+            {
+                cache.Set(cacheKey, new RateLimitEntry(now, 1), TimeSpan.FromMinutes(RateLimitWindowMinutes + 1));
+                return;
+            }
+
+            if (now - entry.FirstRequestUtc > TimeSpan.FromMinutes(RateLimitWindowMinutes))
+            {
+                cache.Set(cacheKey, new RateLimitEntry(now, 1), TimeSpan.FromMinutes(RateLimitWindowMinutes + 1));
+                return;
+            }
+
+            cache.Set(cacheKey, new RateLimitEntry(entry.FirstRequestUtc, entry.Count + 1),
+                TimeSpan.FromMinutes(RateLimitWindowMinutes + 1));
+        }
+    }
+
+    private sealed record EmailConfirmationCodePayload(int UserId, string Code);
+    private sealed record RateLimitEntry(DateTimeOffset FirstRequestUtc, int Count);
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/EmailSenderSettings.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/EmailSenderSettings.cs
@@ -1,0 +1,16 @@
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public sealed class EmailSenderSettings
+{
+    public string Provider { get; set; } = "smtp";
+
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; } = 587;
+    public bool UseSsl { get; set; } = true;
+    public string FromEmail { get; set; } = string.Empty;
+    public string? FromName { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+
+    public string ResendApiKey { get; set; } = string.Empty;
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/IEmailConfirmationService.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/IEmailConfirmationService.cs
@@ -1,0 +1,9 @@
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation.Models;
+
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public interface IEmailConfirmationService
+{
+    Task SendConfirmationAsync(int userId, string email, CancellationToken ct);
+    Task<ConfirmEmailResponse> ConfirmAsync(string email, string code, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/IEmailSenderService.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/IEmailSenderService.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public interface IEmailSenderService
+{
+    Task SendAsync(string toEmail, string subject, string body, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/Models/ConfirmEmailRequest.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/Models/ConfirmEmailRequest.cs
@@ -1,0 +1,7 @@
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation.Models;
+
+public sealed class ConfirmEmailRequest
+{
+    public string Email { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/Models/ConfirmEmailResponse.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/Models/ConfirmEmailResponse.cs
@@ -1,0 +1,7 @@
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation.Models;
+
+public sealed class ConfirmEmailResponse
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = string.Empty;
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/Models/RequestEmailConfirmationRequest.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/Models/RequestEmailConfirmationRequest.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation.Models;
+
+public sealed class RequestEmailConfirmationRequest
+{
+    public string Email { get; set; } = string.Empty;
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/ResendEmailSenderService.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/ResendEmailSenderService.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Options;
+using Resend;
+
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public sealed class ResendEmailSenderService(
+    IOptions<EmailSenderSettings> options,
+    ILogger<ResendEmailSenderService> logger) : IEmailSenderService
+{
+    private readonly EmailSenderSettings _settings = options.Value;
+
+    public async Task SendAsync(string toEmail, string subject, string body, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(toEmail))
+            throw new ArgumentException("Recipient email is required.", nameof(toEmail));
+
+        ValidateSettings();
+
+        var resend = ResendClient.Create(_settings.ResendApiKey);
+        var response = await resend.EmailSendAsync(new EmailMessage
+        {
+            From = _settings.FromEmail,
+            To = toEmail,
+            Subject = subject,
+            HtmlBody = body
+        }, ct);
+
+        if (!response.Success)
+        {
+            logger.LogError("Resend failed to send email to {Email}.", toEmail);
+            throw new InvalidOperationException("Resend email delivery failed.");
+        }
+    }
+
+    private void ValidateSettings()
+    {
+        if (string.IsNullOrWhiteSpace(_settings.ResendApiKey)
+            || string.IsNullOrWhiteSpace(_settings.FromEmail))
+        {
+            throw new InvalidOperationException(
+                "Resend settings are not configured. Set EmailSender:ResendApiKey and EmailSender:FromEmail.");
+        }
+    }
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/SmtpEmailSenderService.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/SmtpEmailSenderService.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Net.Mail;
+using Microsoft.Extensions.Options;
+
+namespace DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+
+public sealed class SmtpEmailSenderService(
+    IOptions<EmailSenderSettings> options,
+    ILogger<SmtpEmailSenderService> logger) : IEmailSenderService
+{
+    private readonly EmailSenderSettings _settings = options.Value;
+
+    public async Task SendAsync(string toEmail, string subject, string body, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(toEmail))
+            throw new ArgumentException("Recipient email is required.", nameof(toEmail));
+
+        ValidateSettings();
+
+        using var message = new MailMessage
+        {
+            From = string.IsNullOrWhiteSpace(_settings.FromName)
+                ? new MailAddress(_settings.FromEmail)
+                : new MailAddress(_settings.FromEmail, _settings.FromName),
+            Subject = subject,
+            Body = body,
+            IsBodyHtml = false
+        };
+        message.To.Add(toEmail);
+
+        using var client = new SmtpClient(_settings.Host, _settings.Port)
+        {
+            EnableSsl = _settings.UseSsl,
+            Credentials = new NetworkCredential(_settings.Username, _settings.Password)
+        };
+
+        using var registration = ct.Register(client.SendAsyncCancel);
+        try
+        {
+            await client.SendMailAsync(message, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send email confirmation message to {Email}", toEmail);
+            throw;
+        }
+    }
+
+    private void ValidateSettings()
+    {
+        if (string.IsNullOrWhiteSpace(_settings.Host)
+            || string.IsNullOrWhiteSpace(_settings.FromEmail)
+            || string.IsNullOrWhiteSpace(_settings.Username)
+            || string.IsNullOrWhiteSpace(_settings.Password))
+        {
+            throw new InvalidOperationException(
+                "Email sender settings are not configured. Configure EmailSender section in configuration.");
+        }
+    }
+}

--- a/DataGateMonitor/Services/Api/Auth/Login/UserLoginService.cs
+++ b/DataGateMonitor/Services/Api/Auth/Login/UserLoginService.cs
@@ -18,6 +18,7 @@ public sealed class UserLoginService(
     IPasswordHasher<User> passwordHasher,
     IGoogleTokenValidator tokenValidator,
     ICommandService<UserIdentityLink, int> userIdentityLinkCommandService,
+    ICommandService<User, int> userCommandService,
     IUserIdentityLinkQueryService userIdentityLinkQueryService,
     IUserAccountService userAccountService,
     ITokenService tokenService,
@@ -46,6 +47,9 @@ public sealed class UserLoginService(
 
         if (user.IsBlocked)
             throw new UnauthorizedAccessException("User account is blocked.");
+
+        if (!string.IsNullOrWhiteSpace(user.Email) && !user.IsEmailConfirmed)
+            throw new UnauthorizedAccessException("Email is not confirmed.");
 
         var result = passwordHasher.VerifyHashedPassword(user, credential.PasswordHash, password);
         if (result == PasswordVerificationResult.Failed)
@@ -104,7 +108,7 @@ public sealed class UserLoginService(
             if (user is null)
             {
                 var displayName = googleUser.Name ?? googleUser.Email ?? "Google User";
-                var newUser = UserFactory.CreateNew(displayName, googleUser.Email);
+                var newUser = UserFactory.CreateNew(displayName, googleUser.Email, isEmailConfirmed: true);
                 user = await userAccountService.CreateUserWithDefaultRoleAsync(newUser, ct);
                 isNew = true;
             }
@@ -121,6 +125,14 @@ public sealed class UserLoginService(
 
         if (user.IsBlocked)
             throw new UnauthorizedAccessException("User account is blocked.");
+
+        if (!string.IsNullOrWhiteSpace(googleUser.Email)
+            && string.Equals(user.Email, googleUser.Email, StringComparison.OrdinalIgnoreCase)
+            && !user.IsEmailConfirmed)
+        {
+            user.IsEmailConfirmed = true;
+            await userCommandService.Update(user, saveChanges: true, ct);
+        }
 
         var (deviceId, userAgent) = GetClientInfo();
 

--- a/DataGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
+++ b/DataGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
@@ -3,6 +3,7 @@ using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Users;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
@@ -15,7 +16,8 @@ public sealed class UserRegistrationService(
     ICommandService<UserCredential, int> userCredentialCommandService,
     IUserCredentialQueryService userCredentialQueryService,
     IUserQueryService userQueryService,
-    IUserAccountService userAccountService
+    IUserAccountService userAccountService,
+    IEmailConfirmationService emailConfirmationService
 ) : IUserRegistrationService
 {
     public async Task<RegisterUserResponse> RegisterAsync(RegisterUserRequest request, CancellationToken ct)
@@ -74,6 +76,9 @@ public sealed class UserRegistrationService(
         };
 
         await userCredentialCommandService.Add(credential, saveChanges: true, ct);
+
+        if (!string.IsNullOrWhiteSpace(user.Email))
+            await emailConfirmationService.SendConfirmationAsync(user.Id, user.Email, ct);
 
         return new RegisterUserResponse
         {

--- a/DataGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
+++ b/DataGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
@@ -6,6 +6,7 @@ using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Users;
+using DataGateMonitor.Services.Others;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
 
@@ -17,7 +18,8 @@ public sealed class UserRegistrationService(
     IUserCredentialQueryService userCredentialQueryService,
     IUserQueryService userQueryService,
     IUserAccountService userAccountService,
-    IEmailConfirmationService emailConfirmationService
+    IEmailConfirmationService emailConfirmationService,
+    ISettingsService settingsService
 ) : IUserRegistrationService
 {
     public async Task<RegisterUserResponse> RegisterAsync(RegisterUserRequest request, CancellationToken ct)
@@ -57,7 +59,11 @@ public sealed class UserRegistrationService(
                 throw new InvalidOperationException("Email is already in use.");
         }
 
-        var user = UserFactory.CreateNew(displayName!, email);
+        var requireEmailConfirmation = await IsEmailConfirmationRequiredAsync(ct);
+        var user = UserFactory.CreateNew(
+            displayName!,
+            email,
+            isEmailConfirmed: string.IsNullOrWhiteSpace(email) || !requireEmailConfirmation);
 
         user = await userAccountService.CreateUserWithDefaultRoleAsync(user, ct);
 
@@ -77,7 +83,7 @@ public sealed class UserRegistrationService(
 
         await userCredentialCommandService.Add(credential, saveChanges: true, ct);
 
-        if (!string.IsNullOrWhiteSpace(user.Email))
+        if (requireEmailConfirmation && !string.IsNullOrWhiteSpace(user.Email))
             await emailConfirmationService.SendConfirmationAsync(user.Id, user.Email, ct);
 
         return new RegisterUserResponse
@@ -87,5 +93,16 @@ public sealed class UserRegistrationService(
             Email = user.Email,
             HasDashboardAccess = user.HasDashboardAccess
         };
+    }
+
+    private async Task<bool> IsEmailConfirmationRequiredAsync(CancellationToken ct)
+    {
+        var typeKey = $"{AuthEmailSettingsKeys.RequireEmailConfirmationOnRegister}_Type";
+        var type = await settingsService.GetValueAsync<string>(typeKey, ct);
+        if (!string.Equals(type, "bool", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        var value = await settingsService.GetValueAsync<bool>(AuthEmailSettingsKeys.RequireEmailConfirmationOnRegister, ct);
+        return value;
     }
 }

--- a/DataGateMonitor/Services/Api/Auth/Users/UserFactory.cs
+++ b/DataGateMonitor/Services/Api/Auth/Users/UserFactory.cs
@@ -5,12 +5,13 @@ namespace DataGateMonitor.Services.Api.Auth.Users;
 
 public static class UserFactory
 {
-    public static User CreateNew(string displayName, string? email)
+    public static User CreateNew(string displayName, string? email, bool isEmailConfirmed = false)
     {
         return new User
         {
             DisplayName = displayName,
             Email = email,
+            IsEmailConfirmed = string.IsNullOrWhiteSpace(email) || isEmailConfirmed,
             IsAdmin = false,
             IsBlocked = false,
             HasDashboardAccess = true

--- a/DataGateMonitor/Services/Others/Notifications/NotificationCatalog.cs
+++ b/DataGateMonitor/Services/Others/Notifications/NotificationCatalog.cs
@@ -60,7 +60,7 @@ public class NotificationCatalog : INotificationCatalog
         {
             Type = NotificationTypes.ServerDown,
             Title = "Server is DOWN",
-            Message = $"OpenVPN server \"{serverName}\" (id={serverId}) is unreachable.",
+            Message = $"VPN server \"{serverName}\" (id={serverId}) is unreachable.",
             Severity = NotificationSeverity.Critical,
             Source = "monitor",
             ServerId = serverId,
@@ -75,7 +75,7 @@ public class NotificationCatalog : INotificationCatalog
         {
             Type = NotificationTypes.ServerUp,
             Title = "Server is UP",
-            Message = $"OpenVPN server \"{serverName}\" (id={serverId}) is reachable again.",
+            Message = $"VPN server \"{serverName}\" (id={serverId}) is reachable again.",
             Severity = NotificationSeverity.Info,
             Source = "monitor",
             ServerId = serverId,

--- a/DataGateMonitor/Services/Others/Notifications/ServerOpenVpnApiClient/ServerOpenVpnNotificationService.cs
+++ b/DataGateMonitor/Services/Others/Notifications/ServerOpenVpnApiClient/ServerOpenVpnNotificationService.cs
@@ -10,33 +10,33 @@ public class ServerOpenVpnNotificationService(INotificationService notifications
     private const string Source = "server-openvpn-api";
 
     public Task NotifyBecameAvailable(int serverId, string? serverName, CancellationToken ct)
-        => Notify(ApplicationNotificationKind.OpenVpnServerBecameAvailable, "server.became-available", "OpenVPN server became available",
+        => Notify(ApplicationNotificationKind.OpenVpnServerBecameAvailable, "server.became-available", "VPN server became available",
             Detail(serverId, serverName), serverId, NotificationSeverity.Info, InfoChannels, ct);
 
     public Task NotifyAdded(int serverId, string? serverName, CancellationToken ct)
-        => Notify(ApplicationNotificationKind.OpenVpnServerAdded, "server.added", "OpenVPN server added",
+        => Notify(ApplicationNotificationKind.OpenVpnServerAdded, "server.added", "VPN server added",
             Detail(serverId, serverName), serverId, NotificationSeverity.Info, InfoChannels, ct);
 
     public Task NotifyUpdated(int serverId, string? serverName, CancellationToken ct)
-        => Notify(ApplicationNotificationKind.OpenVpnServerUpdated, "server.updated", "OpenVPN server updated",
+        => Notify(ApplicationNotificationKind.OpenVpnServerUpdated, "server.updated", "VPN server updated",
             Detail(serverId, serverName), serverId, NotificationSeverity.Info, InfoChannels, ct);
 
     public Task NotifyDeleted(int serverId, string? serverName, CancellationToken ct)
-        => Notify(ApplicationNotificationKind.OpenVpnServerDeleted, "server.deleted", "OpenVPN server deleted",
+        => Notify(ApplicationNotificationKind.OpenVpnServerDeleted, "server.deleted", "VPN server deleted",
             Detail(serverId, serverName), serverId, NotificationSeverity.Warning, InfoChannels, ct);
 
     public Task NotifyBecameUnavailableDueToError(int serverId, string? serverName, string? errorMessage, CancellationToken ct)
-        => Notify(ApplicationNotificationKind.OpenVpnServerBecameUnavailable, "server.became-unavailable", "OpenVPN server became unavailable due to error",
+        => Notify(ApplicationNotificationKind.OpenVpnServerBecameUnavailable, "server.became-unavailable", "VPN server became unavailable due to error",
             Detail(serverId, serverName) + (string.IsNullOrEmpty(errorMessage) ? "" : $"; Error={errorMessage}"),
             serverId, NotificationSeverity.Error, ErrorChannels, ct);
 
     public Task NotifySyncError(int serverId, string? serverName, string? errorMessage, CancellationToken ct)
-        => Notify(ApplicationNotificationKind.OpenVpnServerSyncError, "server.sync-error", "Synchronization error with OpenVPN server",
+        => Notify(ApplicationNotificationKind.OpenVpnServerSyncError, "server.sync-error", "Synchronization error with VPN server",
             Detail(serverId, serverName) + (string.IsNullOrEmpty(errorMessage) ? "" : $"; Error={errorMessage}"),
             serverId, NotificationSeverity.Error, ErrorChannels, ct);
 
     public Task NotifyNoResponseFromServer(int serverId, string? serverName, CancellationToken ct)
-        => Notify(ApplicationNotificationKind.OpenVpnServerNoResponse, "server.no-response", "No response from OpenVPN server",
+        => Notify(ApplicationNotificationKind.OpenVpnServerNoResponse, "server.no-response", "No response from VPN server",
             Detail(serverId, serverName), serverId, NotificationSeverity.Warning, ErrorChannels, ct);
 
     private static string Detail(int serverId, string? serverName)

--- a/DataGateMonitor/example.appsettings.json
+++ b/DataGateMonitor/example.appsettings.json
@@ -16,6 +16,17 @@
     "Secret": "super-secret-key-should-be-at-least-16-characters",
     "RefreshPepper": "your-refresh-pepper"
   },
+  "EmailSender": {
+    "Provider": "smtp",
+    "FromEmail": "noreply@datagateapp.com",
+    "FromName": "DataGate",
+    "ResendApiKey": "",
+    "Host": "smtp.example.com",
+    "Port": 587,
+    "UseSsl": true,
+    "Username": "smtp_user",
+    "Password": "smtp_password"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- Added a configurable auth setting to control whether email confirmation is required for password-based registration:
  - `Auth_Require_Email_Confirmation_On_Register` (`bool`)
  - Seeded with default value `true`
- Updated registration flow to respect this setting:
  - if enabled, confirmation email is sent
  - if disabled, email is marked as confirmed immediately for classic registration
- Added SMTP/Resend provider routing for email sending via `EmailSender:Provider` (`smtp` or `resend`)
- Restored backward compatibility for legacy Windows clients by adding `OpenVpn*` JSON aliases in `GET /api/open-vpn-servers/get-all-with-status` response while preserving current `Vpn*` fields
- Added and updated tests for auth registration/login constructor changes and compatibility behavior
- Added EF migrations for:
  - `IsEmailConfirmed` user field
  - new auth settings seed entries

## Why
Recent DTO/model renames and email-confirmation changes caused regressions for older Windows clients and made rollout riskier. This PR keeps newer clients working while preserving legacy compatibility and gives operators a runtime switch to disable confirmation requirement when needed.

## Test Plan
- [x] `dotnet build DataGateMonitor/DataGateMonitor.csproj`
- [x] `dotnet test DataGateMonitor.Tests/DataGateMonitor.Tests.csproj`
- [x] Verified VPN servers controller tests pass
- [x] Verified legacy `OpenVpn*` aliases are returned along with current `Vpn*` fields
- [x] Verified registration behavior changes based on `Auth_Require_Email_Confirmation_On_Register`