### PR TITLE
fix(backend): parse conflog payload after diagnostics wrapper migration

### DIFF
--- a/DataGateMonitor.DataBase/ConfigurationModels/EmailBroadcastTemplateConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/EmailBroadcastTemplateConfiguration.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.ConfigurationModels;
+
+public class EmailBroadcastTemplateConfiguration : BaseEntityConfiguration<EmailBroadcastTemplate, int>
+{
+    public override void Configure(EntityTypeBuilder<EmailBroadcastTemplate> entity)
+    {
+        base.Configure(entity);
+
+        entity.ToTable("EmailBroadcastTemplates");
+
+        entity.Property(e => e.Name).IsRequired().HasMaxLength(128);
+        entity.Property(e => e.Description).HasMaxLength(512);
+        entity.Property(e => e.Subject).IsRequired().HasMaxLength(512);
+        entity.Property(e => e.BodyHtml).IsRequired().HasColumnType("text");
+
+        entity.HasIndex(e => e.Name).IsUnique();
+    }
+}

--- a/DataGateMonitor.DataBase/ConfigurationModels/MobileCrashReportConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/MobileCrashReportConfiguration.cs
@@ -1,0 +1,34 @@
+using DataGateMonitor.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DataGateMonitor.DataBase.ConfigurationModels;
+
+public class MobileCrashReportConfiguration : BaseEntityConfiguration<MobileCrashReport, long>
+{
+    public override void Configure(EntityTypeBuilder<MobileCrashReport> entity)
+    {
+        base.Configure(entity);
+
+        entity.ToTable("MobileCrashReports");
+
+        entity.Property(e => e.AppProcess).IsRequired().HasMaxLength(256);
+        entity.Property(e => e.FileName).IsRequired().HasMaxLength(512);
+        entity.Property(e => e.PayloadRaw).IsRequired().HasColumnType("text");
+        entity.Property(e => e.ParseStatus).IsRequired().HasMaxLength(32);
+
+        entity.Property(e => e.Process).HasMaxLength(256);
+        entity.Property(e => e.Thread).HasMaxLength(256);
+        entity.Property(e => e.Sdk).HasMaxLength(128);
+        entity.Property(e => e.Device).HasMaxLength(256);
+        entity.Property(e => e.Kind).HasMaxLength(32);
+        entity.Property(e => e.Exception).HasMaxLength(512);
+        entity.Property(e => e.Message).HasMaxLength(4000);
+        entity.Property(e => e.Tag).HasMaxLength(256);
+        entity.Property(e => e.Stacktrace).HasColumnType("text");
+
+        entity.HasIndex(e => e.CreateDate);
+        entity.HasIndex(e => new { e.AppProcess, e.CreateDate });
+        entity.HasIndex(e => e.ParseStatus);
+    }
+}

--- a/DataGateMonitor.DataBase/ConfigurationModels/SentEmailLogConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/SentEmailLogConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.ConfigurationModels;
+
+public class SentEmailLogConfiguration : BaseEntityConfiguration<SentEmailLog, int>
+{
+    public override void Configure(EntityTypeBuilder<SentEmailLog> entity)
+    {
+        base.Configure(entity);
+
+        entity.ToTable("SentEmailLogs");
+
+        entity.Property(e => e.RecipientEmail).IsRequired().HasMaxLength(256);
+        entity.Property(e => e.Subject).IsRequired().HasMaxLength(512);
+        entity.Property(e => e.BodyHtml).IsRequired().HasColumnType("text");
+        entity.Property(e => e.Success).IsRequired();
+        entity.Property(e => e.ErrorMessage).HasMaxLength(4000);
+
+        entity.HasIndex(e => e.CreateDate);
+        entity.HasIndex(e => e.RecipientUserId);
+    }
+}

--- a/DataGateMonitor.DataBase/ConfigurationModels/TelegramBotUserProfilePhotoConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/TelegramBotUserProfilePhotoConfiguration.cs
@@ -1,0 +1,35 @@
+using DataGateMonitor.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DataGateMonitor.DataBase.ConfigurationModels;
+
+public class TelegramBotUserProfilePhotoConfiguration : BaseEntityConfiguration<TelegramBotUserProfilePhoto, int>
+{
+    public override void Configure(EntityTypeBuilder<TelegramBotUserProfilePhoto> entity)
+    {
+        base.Configure(entity);
+
+        entity.ToTable("TelegramBotUserProfilePhotos");
+
+        entity.Property(e => e.TelegramBotUserId).IsRequired();
+
+        entity.Property(e => e.ImageBytes)
+            .IsRequired();
+
+        entity.Property(e => e.MimeType)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        entity.Property(e => e.TelegramFileUniqueId)
+            .HasMaxLength(128);
+
+        entity.HasIndex(e => e.TelegramBotUserId)
+            .IsUnique();
+
+        entity.HasOne(e => e.TelegramBotUser)
+            .WithMany()
+            .HasForeignKey(e => e.TelegramBotUserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/DataGateMonitor.DataBase/ConfigurationModels/UserConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/UserConfiguration.cs
@@ -19,6 +19,9 @@ public class UserConfiguration : BaseEntityConfiguration<User, int>
         entity.Property(e => e.Email)
             .HasMaxLength(256);
 
+        entity.Property(e => e.AvatarUrl)
+            .HasMaxLength(2048);
+
         entity.Property(e => e.IsEmailConfirmed)
             .IsRequired();
 

--- a/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
+++ b/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
@@ -55,6 +55,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<VpnServerConflog> VpnServerConflogs { get; set; } = null!;
     public DbSet<SentEmailLog> SentEmailLogs { get; set; } = null!;
     public DbSet<EmailBroadcastTemplate> EmailBroadcastTemplates { get; set; } = null!;
+    public DbSet<MobileCrashReport> MobileCrashReports { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -92,6 +93,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.ApplyConfiguration(new VpnServerConflogConfiguration());
         modelBuilder.ApplyConfiguration(new SentEmailLogConfiguration());
         modelBuilder.ApplyConfiguration(new EmailBroadcastTemplateConfiguration());
+        modelBuilder.ApplyConfiguration(new MobileCrashReportConfiguration());
         modelBuilder.ApplyConfiguration(new RoleConfiguration());
         modelBuilder.ApplyConfiguration(new UserRoleConfiguration());
         modelBuilder.ApplyConfiguration(new DeviceConfiguration());

--- a/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
+++ b/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
@@ -36,6 +36,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<VpnProfileNotificationGlobalPreference> VpnProfileNotificationGlobalPreferences { get; set; } = null!;
     public DbSet<VpnProfileNotificationPreference> VpnProfileNotificationPreferences { get; set; } = null!;
     public DbSet<TelegramBotUser> TelegramBotUsers { get; set; } = null!;
+    public DbSet<TelegramBotUserProfilePhoto> TelegramBotUserProfilePhotos { get; set; } = null!;
     public DbSet<TelegramUserLanguagePreference> TelegramUserLanguagePreferences { get; set; } = null!;
     public DbSet<LocalizationText> LocalizationTexts { get; set; } = null!;
     public DbSet<IncomingMessageLog> IncomingMessageLogs { get; set; } = null!;
@@ -70,6 +71,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.ApplyConfiguration(new VpnProfileNotificationGlobalPreferenceConfiguration());
         modelBuilder.ApplyConfiguration(new VpnProfileNotificationPreferenceConfiguration());
         modelBuilder.ApplyConfiguration(new TelegramBotUserConfiguration());
+        modelBuilder.ApplyConfiguration(new TelegramBotUserProfilePhotoConfiguration());
         modelBuilder.ApplyConfiguration(new TelegramUserLanguagePreferenceConfiguration());
         modelBuilder.ApplyConfiguration(new LocalizationTextConfiguration());
         modelBuilder.ApplyConfiguration(new IncomingMessageLogConfiguration());

--- a/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
+++ b/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
@@ -53,6 +53,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<Tag> Tags { get; set; } = null!;
     public DbSet<VpnServerTag> VpnServerTags { get; set; } = null!;
     public DbSet<VpnServerConflog> VpnServerConflogs { get; set; } = null!;
+    public DbSet<SentEmailLog> SentEmailLogs { get; set; } = null!;
+    public DbSet<EmailBroadcastTemplate> EmailBroadcastTemplates { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -88,6 +90,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.ApplyConfiguration(new TagConfiguration());
         modelBuilder.ApplyConfiguration(new VpnServerTagConfiguration());
         modelBuilder.ApplyConfiguration(new VpnServerConflogConfiguration());
+        modelBuilder.ApplyConfiguration(new SentEmailLogConfiguration());
+        modelBuilder.ApplyConfiguration(new EmailBroadcastTemplateConfiguration());
         modelBuilder.ApplyConfiguration(new RoleConfiguration());
         modelBuilder.ApplyConfiguration(new UserRoleConfiguration());
         modelBuilder.ApplyConfiguration(new DeviceConfiguration());

--- a/DataGateMonitor.DataBase/Migrations/20260429202401_Users_AvatarUrl.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260429202401_Users_AvatarUrl.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429202401_Users_AvatarUrl")]
+    partial class Users_AvatarUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260429202401_Users_AvatarUrl.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260429202401_Users_AvatarUrl.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class Users_AvatarUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AvatarUrl",
+                schema: "xgb_dashopnvpn",
+                table: "Users",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "TelegramBotUserProfilePhotos",
+                schema: "xgb_dashopnvpn",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TelegramBotUserId = table.Column<int>(type: "integer", nullable: false),
+                    ImageBytes = table.Column<byte[]>(type: "bytea", nullable: false),
+                    MimeType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    TelegramFileUniqueId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    CreateDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    LastUpdate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TelegramBotUserProfilePhotos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TelegramBotUserProfilePhotos_TelegramBotUsers_TelegramBotUs~",
+                        column: x => x.TelegramBotUserId,
+                        principalSchema: "xgb_dashopnvpn",
+                        principalTable: "TelegramBotUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TelegramBotUserProfilePhotos_TelegramBotUserId",
+                schema: "xgb_dashopnvpn",
+                table: "TelegramBotUserProfilePhotos",
+                column: "TelegramBotUserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TelegramBotUserProfilePhotos",
+                schema: "xgb_dashopnvpn");
+
+            migrationBuilder.DropColumn(
+                name: "AvatarUrl",
+                schema: "xgb_dashopnvpn",
+                table: "Users");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260429213516_SentEmailLogs.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260429213516_SentEmailLogs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429213516_SentEmailLogs")]
+    partial class SentEmailLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -100,53 +103,6 @@ namespace DataGateMonitor.DataBase.Migrations
                         .HasDatabaseName("IX_Devices_User_InstallationId");
 
                     b.ToTable("Devices", "xgb_dashopnvpn");
-                });
-
-            modelBuilder.Entity("DataGateMonitor.Models.EmailBroadcastTemplate", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("BodyHtml")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<DateTimeOffset>("CreateDate")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
-
-                    b.Property<int?>("CreatedByUserId")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("Description")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<DateTimeOffset>("LastUpdate")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp with time zone")
-                        .HasDefaultValueSql("CURRENT_TIMESTAMP");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<string>("Subject")
-                        .IsRequired()
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Name")
-                        .IsUnique();
-
-                    b.ToTable("EmailBroadcastTemplates", "xgb_dashopnvpn");
                 });
 
             modelBuilder.Entity("DataGateMonitor.Models.IncomingMessageLog", b =>

--- a/DataGateMonitor.DataBase/Migrations/20260429213516_SentEmailLogs.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260429213516_SentEmailLogs.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class SentEmailLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SentEmailLogs",
+                schema: "xgb_dashopnvpn",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    RecipientUserId = table.Column<int>(type: "integer", nullable: true),
+                    RecipientEmail = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Subject = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    BodyHtml = table.Column<string>(type: "text", nullable: false),
+                    Success = table.Column<bool>(type: "boolean", nullable: false),
+                    ErrorMessage = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    SentByUserId = table.Column<int>(type: "integer", nullable: true),
+                    CreateDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    LastUpdate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SentEmailLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SentEmailLogs_CreateDate",
+                schema: "xgb_dashopnvpn",
+                table: "SentEmailLogs",
+                column: "CreateDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SentEmailLogs_RecipientUserId",
+                schema: "xgb_dashopnvpn",
+                table: "SentEmailLogs",
+                column: "RecipientUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SentEmailLogs",
+                schema: "xgb_dashopnvpn");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260429214902_EmailBroadcastTemplates.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260429214902_EmailBroadcastTemplates.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429214902_EmailBroadcastTemplates")]
+    partial class EmailBroadcastTemplates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260429214902_EmailBroadcastTemplates.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260429214902_EmailBroadcastTemplates.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class EmailBroadcastTemplates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailBroadcastTemplates",
+                schema: "xgb_dashopnvpn",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Description = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Subject = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    BodyHtml = table.Column<string>(type: "text", nullable: false),
+                    CreatedByUserId = table.Column<int>(type: "integer", nullable: true),
+                    CreateDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    LastUpdate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailBroadcastTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailBroadcastTemplates_Name",
+                schema: "xgb_dashopnvpn",
+                table: "EmailBroadcastTemplates",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailBroadcastTemplates",
+                schema: "xgb_dashopnvpn");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260430222842_AppUserNotificationKinds.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260430222842_AppUserNotificationKinds.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430222842_AppUserNotificationKinds")]
+    partial class AppUserNotificationKinds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260430222842_AppUserNotificationKinds.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260430222842_AppUserNotificationKinds.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AppUserNotificationKinds : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "VpnProfileNotificationPreferences",
+                columns: new[] { "Id", "Enabled", "Kind" },
+                values: new object[,]
+                {
+                    { 28, true, 27 },
+                    { 29, true, 28 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "VpnProfileNotificationPreferences",
+                keyColumn: "Id",
+                keyValue: 28);
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "VpnProfileNotificationPreferences",
+                keyColumn: "Id",
+                keyValue: 29);
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260430223705_SeedTransactionalEmailTemplates.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260430223705_SeedTransactionalEmailTemplates.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430223705_SeedTransactionalEmailTemplates")]
+    partial class SeedTransactionalEmailTemplates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260430223705_SeedTransactionalEmailTemplates.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260430223705_SeedTransactionalEmailTemplates.cs
@@ -1,0 +1,53 @@
+﻿using DataGateMonitor.Models.EmailTemplates;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedTransactionalEmailTemplates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var epoch = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "EmailBroadcastTemplates",
+                columns: ["Name", "Description", "Subject", "BodyHtml", "CreatedByUserId", "CreateDate", "LastUpdate"],
+                values: new object[,]
+                {
+                    {
+                        SystemEmailTemplateNames.EmailConfirmation,
+                        "Built-in: registration email confirmation. Placeholders: {{CODE}}, {{TTL_MINUTES}}",
+                        TransactionalEmailHtml.DefaultConfirmationSubject,
+                        TransactionalEmailHtml.BuildEmailConfirmationWithPlaceholders(),
+                        null,
+                        epoch,
+                        epoch
+                    },
+                    {
+                        SystemEmailTemplateNames.AdminPasswordReset,
+                        "Built-in: administrator password reset one-time code. Placeholders: {{CODE}}, {{TTL_MINUTES}}",
+                        TransactionalEmailHtml.DefaultAdminPasswordResetSubject,
+                        TransactionalEmailHtml.BuildAdminPasswordResetWithPlaceholders(),
+                        null,
+                        epoch,
+                        epoch
+                    }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                DELETE FROM xgb_dashopnvpn."EmailBroadcastTemplates"
+                WHERE "Name" IN ('system.email_confirmation','system.admin_password_reset');
+                """);
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260501002209_MobileCrashReports_Init.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260501002209_MobileCrashReports_Init.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501002209_MobileCrashReports_Init")]
+    partial class MobileCrashReports_Init
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260501002209_MobileCrashReports_Init.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260501002209_MobileCrashReports_Init.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class MobileCrashReports_Init : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MobileCrashReports",
+                schema: "xgb_dashopnvpn",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    AppProcess = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    FileName = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    PayloadRaw = table.Column<string>(type: "text", nullable: false),
+                    ParseStatus = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    TimestampUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Process = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Thread = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Sdk = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    Device = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Kind = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    Exception = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    Message = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    Tag = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    Stacktrace = table.Column<string>(type: "text", nullable: true),
+                    CreateDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    LastUpdate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MobileCrashReports", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MobileCrashReports_AppProcess_CreateDate",
+                schema: "xgb_dashopnvpn",
+                table: "MobileCrashReports",
+                columns: new[] { "AppProcess", "CreateDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MobileCrashReports_CreateDate",
+                schema: "xgb_dashopnvpn",
+                table: "MobileCrashReports",
+                column: "CreateDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MobileCrashReports_ParseStatus",
+                schema: "xgb_dashopnvpn",
+                table: "MobileCrashReports",
+                column: "ParseStatus");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MobileCrashReports",
+                schema: "xgb_dashopnvpn");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/ITelegramBotUserProfilePhotoQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/ITelegramBotUserProfilePhotoQueryService.cs
@@ -1,0 +1,19 @@
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.Services.Query.TelegramBotUserProfilePhotoTable;
+
+public interface ITelegramBotUserProfilePhotoQueryService
+{
+    Task<TelegramBotUserProfilePhoto?> GetByTelegramBotUserIdNoTrackingAsync(int telegramBotUserId,
+        CancellationToken cancellationToken);
+
+    Task<TelegramBotUserProfilePhoto?> GetByTelegramBotUserIdForUpdateAsync(int telegramBotUserId,
+        CancellationToken cancellationToken);
+
+    Task<TelegramBotUserProfilePhotoIdMeta?> GetIdAndFileUniqueIdNoTrackingAsync(int telegramBotUserId,
+        CancellationToken cancellationToken);
+
+    /// <summary>Mime, timestamps, file_unique_id — does not load <c>ImageBytes</c>.</summary>
+    Task<TelegramBotUserProfilePhotoSummary?> GetSummaryNoTrackingAsync(int telegramBotUserId,
+        CancellationToken cancellationToken);
+}

--- a/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/TelegramBotUserProfilePhotoIdMeta.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/TelegramBotUserProfilePhotoIdMeta.cs
@@ -1,0 +1,4 @@
+namespace DataGateMonitor.DataBase.Services.Query.TelegramBotUserProfilePhotoTable;
+
+/// <summary>Minimal fields for upsert skip logic without loading <c>bytea</c>.</summary>
+public sealed record TelegramBotUserProfilePhotoIdMeta(int Id, string? TelegramFileUniqueId);

--- a/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/TelegramBotUserProfilePhotoQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/TelegramBotUserProfilePhotoQueryService.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using DataGateMonitor.DataBase.Services.Query;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.Services.Query.TelegramBotUserProfilePhotoTable;
+
+public sealed class TelegramBotUserProfilePhotoQueryService(IQueryService<TelegramBotUserProfilePhoto, int> q)
+    : ITelegramBotUserProfilePhotoQueryService
+{
+    public Task<TelegramBotUserProfilePhoto?> GetByTelegramBotUserIdNoTrackingAsync(int telegramBotUserId,
+        CancellationToken cancellationToken) =>
+        q.Query()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.TelegramBotUserId == telegramBotUserId, cancellationToken);
+
+    public Task<TelegramBotUserProfilePhoto?> GetByTelegramBotUserIdForUpdateAsync(int telegramBotUserId,
+        CancellationToken cancellationToken) =>
+        q.Query()
+            .FirstOrDefaultAsync(x => x.TelegramBotUserId == telegramBotUserId, cancellationToken);
+
+    public async Task<TelegramBotUserProfilePhotoIdMeta?> GetIdAndFileUniqueIdNoTrackingAsync(int telegramBotUserId,
+        CancellationToken cancellationToken)
+    {
+        return await q.Query()
+            .AsNoTracking()
+            .Where(x => x.TelegramBotUserId == telegramBotUserId)
+            .Select(x => new TelegramBotUserProfilePhotoIdMeta(x.Id, x.TelegramFileUniqueId))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<TelegramBotUserProfilePhotoSummary?> GetSummaryNoTrackingAsync(int telegramBotUserId,
+        CancellationToken cancellationToken)
+    {
+        return await q.Query()
+            .AsNoTracking()
+            .Where(x => x.TelegramBotUserId == telegramBotUserId)
+            .Select(x => new TelegramBotUserProfilePhotoSummary(x.TelegramFileUniqueId, x.MimeType, x.LastUpdate))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/TelegramBotUserProfilePhotoSummary.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TelegramBotUserProfilePhotoTable/TelegramBotUserProfilePhotoSummary.cs
@@ -1,0 +1,7 @@
+namespace DataGateMonitor.DataBase.Services.Query.TelegramBotUserProfilePhotoTable;
+
+/// <summary>Metadata without image bytes (for API meta responses).</summary>
+public sealed record TelegramBotUserProfilePhotoSummary(
+    string? TelegramFileUniqueId,
+    string MimeType,
+    DateTimeOffset LastUpdate);

--- a/DataGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
@@ -15,4 +15,7 @@ public interface IUserQueryService
     public Task<List<User>> Search(
         Expression<Func<User, bool>> predicate,
         CancellationToken ct);
+
+    /// <summary>Dashboard users with a non-empty <see cref="User.Email"/> (for admin broadcast).</summary>
+    Task<List<User>> GetUsersWithNonEmptyEmailAsync(CancellationToken ct);
 }

--- a/DataGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
@@ -66,4 +66,11 @@ public class UserQueryService(
         Expression<Func<User, bool>> predicate,
         CancellationToken ct)
         => q.Where(predicate, ct: ct);
+
+    public Task<List<User>> GetUsersWithNonEmptyEmailAsync(CancellationToken ct) =>
+        q.Where(
+            predicate: u => u.Email != null && u.Email != "",
+            orderBy: x => x.OrderBy(u => u.Id),
+            asNoTracking: true,
+            ct: ct);
 }

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/VpnServerClientOverviewQuery.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/VpnServerClientOverviewQuery.cs
@@ -34,6 +34,7 @@ public class VpnServerClientOverviewQuery(
             Longitude = x.Longitude,
             IsConnected = x.IsConnected,
             DisplayName = string.Empty,
+            AvatarUrl = null,
         };
 
     // Connected clients page
@@ -121,7 +122,10 @@ public class VpnServerClientOverviewQuery(
                 continue;
 
             if (users.TryGetValue(client.ExternalId, out var user) && user is not null)
+            {
                 client.DisplayName = user.DisplayName;
+                client.AvatarUrl = string.IsNullOrWhiteSpace(user.AvatarUrl) ? null : user.AvatarUrl;
+            }
         }
     }
 }

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
       <PackageReference Include="Mapster" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
       <PackageReference Include="Mapster" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
       <PackageReference Include="Mapster" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
       <PackageReference Include="Mapster" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.8" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
       <PackageReference Include="Mapster" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
       <PackageReference Include="Mapster" Version="10.0.7" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateOpenVpnManager/Mappings/DataGateOpenVpnManagerMapping.cs
+++ b/DataGateMonitor.Mapping/DataGateOpenVpnManager/Mappings/DataGateOpenVpnManagerMapping.cs
@@ -61,6 +61,22 @@ public class DataGateOpenVpnManagerMapping : IRegister
             return null;
         try
         {
+            using var doc = JsonDocument.Parse(payloadJson);
+            var root = doc.RootElement;
+
+            // Backward compatibility:
+            // - old conflog rows: payload is plain RootOpenVpnInfoResponse
+            // - new rows (after Xray support): payload is VpnMicroserviceDiagnosticsDto
+            //   with nested { openVpn: { ... } }.
+            if (root.ValueKind == JsonValueKind.Object &&
+                root.TryGetProperty("openVpn", out var openVpnElement) &&
+                openVpnElement.ValueKind == JsonValueKind.Object)
+            {
+                return JsonSerializer.Deserialize<RootOpenVpnInfoResponse>(
+                    openVpnElement.GetRawText(),
+                    ConflogJsonOptions);
+            }
+
             return JsonSerializer.Deserialize<RootOpenVpnInfoResponse>(payloadJson, ConflogJsonOptions);
         }
         catch (JsonException)

--- a/DataGateMonitor.Mapping/EmailBroadcast/Mappings/EmailBroadcastMapping.cs
+++ b/DataGateMonitor.Mapping/EmailBroadcast/Mappings/EmailBroadcastMapping.cs
@@ -1,0 +1,15 @@
+using Mapster;
+using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+
+namespace DataGateMonitor.Mapping.EmailBroadcast.Mappings;
+
+public class EmailBroadcastMapping : IRegister
+{
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<SentEmailLog, SentEmailLogDto>();
+        config.NewConfig<EmailBroadcastTemplate, EmailBroadcastTemplateSummaryDto>();
+        config.NewConfig<EmailBroadcastTemplate, EmailBroadcastTemplateDto>();
+    }
+}

--- a/DataGateMonitor.Mapping/VpnServers/Mappings/VpnServerMapping.cs
+++ b/DataGateMonitor.Mapping/VpnServers/Mappings/VpnServerMapping.cs
@@ -1,6 +1,7 @@
 using Mapster;
 using DataGateMonitor.Models;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Responses;
 
 namespace DataGateMonitor.Mapping.VpnServers.Mappings;
@@ -9,8 +10,7 @@ public class VpnServerMapping : IRegister
 {
     public void Register(TypeAdapterConfig config)
     {
-        #region "get-all"
-        // Mapping from entity to DTO
+        // Entity ↔ DTO: DB column / model is IsDisable; API contract uses IsDisabled.
         config.NewConfig<VpnServer, VpnServerDto>()
             .Map(dest => dest.Id, src => src.Id)
             .Map(dest => dest.ServerType, src => src.ServerType)
@@ -18,50 +18,29 @@ public class VpnServerMapping : IRegister
             .Map(dest => dest.IsOnline, src => src.IsOnline)
             .Map(dest => dest.IsDefault, src => src.IsDefault)
             .Map(dest => dest.ApiUrl, src => src.ApiUrl)
+            .Map(dest => dest.Latitude, src => src.Latitude)
+            .Map(dest => dest.Longitude, src => src.Longitude)
+            .Map(dest => dest.IsEnableWss, src => src.IsEnableWss)
             .Map(dest => dest.CreateDate, src => src.CreateDate)
             .Map(dest => dest.LastUpdate, src => src.LastUpdate)
             .Map(dest => dest.IsDeleted, src => src.IsDeleted)
             .Map(dest => dest.DcoIsEnabled, src => src.DcoIsEnabled)
             .Map(dest => dest.XrayClientsPolledAt, src => src.XrayClientsPolledAt)
-            .Map(dest => dest.XrayClientsPollError, src => src.XrayClientsPollError);
+            .Map(dest => dest.XrayClientsPollError, src => src.XrayClientsPollError)
+            .Map(dest => dest.IsDisabled, src => src.IsDisable);
 
-        // Mapping list → response wrapper
+        config.NewConfig<UpdateServerRequest, VpnServer>()
+            .Map(dest => dest.IsDisable, src => src.IsDisabled);
+
+        config.NewConfig<AddServerRequest, VpnServer>()
+            .Map(dest => dest.IsDisable, src => src.IsDisabled);
+
         config.NewConfig<List<VpnServer>, VpnServersResponse>()
             .Map(dest => dest.VpnServers, src => src);
 
         config.NewConfig<VpnServerDto, VpnServerV2Dto>()
             .Ignore(dest => dest.QuotaPlanGroups)
             .Ignore(dest => dest.IsAccessibleForUserQuotaPlan);
-        #endregion
-        #region "get-all-with-status"
-        config.NewConfig<VpnServer, VpnServerDto>();
-
-        config.NewConfig<VpnServer, VpnServerResponse>()
-            .Map(d => d.VpnServer, s => s);
-
-        config.NewConfig<VpnServerStatusLog, VpnServerStatusLogResponse>();
-
-        // config.NewConfig<VpnServerWithStatus, VpnServerWithStatusDto>()
-        //     .Map(d => d.VpnServerResponses, s => s.VpnServer)
-        //     .Map(d => d.VpnServerStatusLogResponse, s => s.VpnServerStatusLog)
-        //     .Map(d => d.CountConnectedClients, s => s.CountConnectedClients)
-        //     .Map(d => d.CountSessions, s => s.CountSessions)
-        //     .Map(d => d.TotalBytesIn, s => s.TotalBytesIn)
-        //     .Map(d => d.TotalBytesOut, s => s.TotalBytesOut);
-        //
-        // config.NewConfig<List<VpnServerWithStatus>, VpnServerWithStatusesResponse>()
-        //     .Map(d => d.VpnServerWithStatuses, s => s);
-        #endregion
-        
-        #region "get-all-with-status"
-        config.NewConfig<VpnServer, VpnServerDto>();
-
-        config.NewConfig<VpnServer, VpnServerResponse>()
-            .Map(d => d.VpnServer, s => s);
-
-        config.NewConfig<VpnServerStatusLog, VpnServerStatusLogResponse>();
-        
-        config.NewConfig<VpnServer, VpnServerDto>();
 
         config.NewConfig<VpnServer, VpnServerResponse>()
             .Map(d => d.VpnServer, s => s);
@@ -69,28 +48,11 @@ public class VpnServerMapping : IRegister
         config.NewConfig<VpnServerStatusLog, VpnServerStatusLogResponse>();
 
         config.NewConfig<VpnServerWithStatusDto, VpnServerWithStatusResponse>()
-            .Map(d => 
-                d.VpnServerWithStatus, s => s);
-        
+            .Map(d => d.VpnServerWithStatus, s => s);
+
         config.NewConfig<List<VpnServerWithStatusDto>, VpnServerWithStatusesResponse>()
-            .Map(d => 
-                d.VpnServerWithStatuses, s => s);
-        #endregion
+            .Map(d => d.VpnServerWithStatuses, s => s);
 
-        #region "get-server-with-status/{VpnServerId:int}"
-        config.NewConfig<VpnServer, VpnServerDto>();
-
-        config.NewConfig<VpnServer, VpnServerResponse>()
-            .Map(d => d.VpnServer, s => s);
-
-        config.NewConfig<VpnServerStatusLog, VpnServerStatusLogResponse>();
-
-        config.NewConfig<VpnServerWithStatusDto, VpnServerWithStatusResponse>()
-            .Map(d => 
-                d.VpnServerWithStatus, s => s);
-        #endregion
-        
-        #region "status-stream"
         TypeAdapterConfig<ServiceStatusDto, ServiceStatusResponse>
             .NewConfig()
             .Map(dest => dest.ServiceStatus.VpnServerId, src => src.VpnServerId)
@@ -99,6 +61,5 @@ public class VpnServerMapping : IRegister
             .Map(dest => dest.ServiceStatus.CountSessions, src => src.CountSessions)
             .Map(dest => dest.ServiceStatus.ErrorMessage, src => src.ErrorMessage)
             .Map(dest => dest.ServiceStatus.NextRunTime, src => src.NextRunTime);
-        #endregion
     }
 }

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.8" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/EmailBroadcastTemplate.cs
+++ b/DataGateMonitor.Models/EmailBroadcastTemplate.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DataGateMonitor.Models;
+
+/// <summary>Reusable HTML email template for admin broadcast UI.</summary>
+public class EmailBroadcastTemplate : BaseEntity<int>
+{
+    [Required, MaxLength(128)]
+    public string Name { get; set; } = null!;
+
+    [MaxLength(512)]
+    public string? Description { get; set; }
+
+    [Required, MaxLength(512)]
+    public string Subject { get; set; } = null!;
+
+    [Required]
+    public string BodyHtml { get; set; } = null!;
+
+    public int? CreatedByUserId { get; set; }
+}

--- a/DataGateMonitor.Models/EmailTemplates/SystemEmailTemplateNames.cs
+++ b/DataGateMonitor.Models/EmailTemplates/SystemEmailTemplateNames.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.Models.EmailTemplates;
+
+/// <summary>Unique <c>EmailBroadcastTemplate.Name</c> for built-in transactional layouts (seeded).</summary>
+public static class SystemEmailTemplateNames
+{
+    public const string EmailConfirmation = "system.email_confirmation";
+    public const string AdminPasswordReset = "system.admin_password_reset";
+}

--- a/DataGateMonitor.Models/EmailTemplates/TransactionalEmailHtml.cs
+++ b/DataGateMonitor.Models/EmailTemplates/TransactionalEmailHtml.cs
@@ -1,0 +1,360 @@
+using System.Globalization;
+using System.Net;
+using System.Text;
+
+namespace DataGateMonitor.Models.EmailTemplates;
+
+/// <summary>
+/// Unified transactional email layout (light/dark, GitHub-like). Used for registration confirmation,
+/// admin password reset, and seeded <c>EmailBroadcastTemplate</c> rows.
+/// </summary>
+public static class TransactionalEmailHtml
+{
+    public const string DefaultConfirmationSubject = "Confirm your email — DataGate";
+    public const string DefaultAdminPasswordResetSubject = "Administrator password reset — DataGate";
+
+    private const string MailVersionLabel = "1.0.3";
+
+    private static string Escape(string? s) => WebUtility.HtmlEncode(s ?? string.Empty);
+
+    public static string BuildEmailConfirmation(string code, int ttlMinutes)
+        => BuildDocument(
+            pageTitle: "DataGate — email confirmation",
+            emailTitle: "Email confirmation",
+            emailTagline: "Desktop client and web dashboard for your VPN.",
+            includeDownloadButton: true,
+            emailLead: "Hello,",
+            bodyParagraphs:
+            [
+                "Thank you for signing up with DataGate. To finish registration, enter the confirmation code on the website.",
+                $"The code is valid for <strong>{Escape(ttlMinutes.ToString(CultureInfo.InvariantCulture))}</strong> minutes. If you did not create an account, you can ignore this message.",
+                "Follow our Telegram channel: <a href=\"https://t.me/datagateapp\" target=\"_blank\" rel=\"noopener noreferrer\">https://t.me/datagateapp</a>",
+                "If you need help: <a href=\"https://t.me/KolganovIvan\" target=\"_blank\" rel=\"noopener noreferrer\"><b>@KolganovIvan</b></a>",
+            ],
+            codeLabel: "Confirmation code",
+            codeValueHtml: Escape(code),
+            signoff: "— The DataGate team");
+
+    public static string BuildEmailConfirmationWithPlaceholders()
+        => BuildDocument(
+            pageTitle: "DataGate — email confirmation",
+            emailTitle: "Email confirmation",
+            emailTagline: "Desktop client and web dashboard for your VPN.",
+            includeDownloadButton: true,
+            emailLead: "Hello,",
+            bodyParagraphs:
+            [
+                "Thank you for signing up with DataGate. To finish registration, enter the confirmation code on the website.",
+                "The code is valid for <strong>{{TTL_MINUTES}}</strong> minutes. If you did not create an account, you can ignore this message.",
+                "Follow our Telegram channel: <a href=\"https://t.me/datagateapp\" target=\"_blank\" rel=\"noopener noreferrer\">https://t.me/datagateapp</a>",
+                "If you need help: <a href=\"https://t.me/KolganovIvan\" target=\"_blank\" rel=\"noopener noreferrer\"><b>@KolganovIvan</b></a>",
+            ],
+            codeLabel: "Confirmation code",
+            codeValueHtml: "{{CODE}}",
+            signoff: "— The DataGate team");
+
+    public static string BuildAdminPasswordReset(string code, int ttlMinutes)
+        => BuildDocument(
+            pageTitle: "DataGate — password reset",
+            emailTitle: "Administrator password reset",
+            emailTagline: "One-time code for the password recovery form.",
+            includeDownloadButton: true,
+            emailLead: "Hello,",
+            bodyParagraphs:
+            [
+                "You requested a password reset for the DataGate dashboard. Enter the code below in the “Forgot password” / “New password” form.",
+                $"The code is valid for <strong>{Escape(ttlMinutes.ToString(CultureInfo.InvariantCulture))}</strong> minutes. If this was not you, change your password after signing in or contact other administrators.",
+                "Follow our Telegram channel: <a href=\"https://t.me/datagateapp\" target=\"_blank\" rel=\"noopener noreferrer\">https://t.me/datagateapp</a>",
+            ],
+            codeLabel: "Reset code",
+            codeValueHtml: Escape(code),
+            signoff: "— The DataGate team");
+
+    public static string BuildAdminPasswordResetWithPlaceholders()
+        => BuildDocument(
+            pageTitle: "DataGate — password reset",
+            emailTitle: "Administrator password reset",
+            emailTagline: "One-time code for the password recovery form.",
+            includeDownloadButton: true,
+            emailLead: "Hello,",
+            bodyParagraphs:
+            [
+                "You requested a password reset for the DataGate dashboard. Enter the code below in the “Forgot password” / “New password” form.",
+                "The code is valid for <strong>{{TTL_MINUTES}}</strong> minutes. If this was not you, change your password after signing in or contact other administrators.",
+                "Follow our Telegram channel: <a href=\"https://t.me/datagateapp\" target=\"_blank\" rel=\"noopener noreferrer\">https://t.me/datagateapp</a>",
+            ],
+            codeLabel: "Reset code",
+            codeValueHtml: "{{CODE}}",
+            signoff: "— The DataGate team");
+
+    public static string ApplyConfirmationPlaceholders(string bodyHtml, string code, int ttlMinutes)
+    {
+        return bodyHtml
+            .Replace("{{CODE}}", Escape(code), StringComparison.Ordinal)
+            .Replace("{{TTL_MINUTES}}", ttlMinutes.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal);
+    }
+
+    public static string ApplyPasswordResetPlaceholders(string bodyHtml, string code, int ttlMinutes)
+        => ApplyConfirmationPlaceholders(bodyHtml, code, ttlMinutes);
+
+    private static string BuildDocument(
+        string pageTitle,
+        string emailTitle,
+        string emailTagline,
+        bool includeDownloadButton,
+        string emailLead,
+        IReadOnlyList<string> bodyParagraphs,
+        string codeLabel,
+        string codeValueHtml,
+        string signoff)
+    {
+        var sb = new StringBuilder();
+        sb.Append(CssAndHeadOpen(pageTitle));
+        sb.Append("<body>\n");
+        sb.Append(
+            """
+            <table role="presentation" class="wrap" width="100%" cellpadding="0" cellspacing="0" border="0">
+              <tr>
+                <td align="center" style="padding:24px 12px;">
+                  <table role="presentation" class="shell" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;">
+                    <tr>
+                      <td>
+                        <table role="presentation" class="card" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#ffffff;border:1px solid #d0d7de;border-radius:12px;">
+                          <tr>
+                            <td class="accent">&nbsp;</td>
+                          </tr>
+                          <tr>
+                            <td class="pad">
+            """);
+
+        sb.Append($"                    <p class=\"email-title\">{Escape(emailTitle)}</p>\n");
+        sb.Append($"                    <p class=\"email-tagline\">{Escape(emailTagline)}</p>\n");
+
+        if (includeDownloadButton)
+        {
+            sb.Append(
+                """
+                                <div class="btn-wrap">
+                                  <a class="btn" href="https://datagateapp.com/download" target="_blank" rel="noopener noreferrer">
+                                    Download the latest DataGate
+                                  </a>
+                                </div>
+
+                                <br />
+
+                """);
+        }
+
+        sb.Append($"                    <p class=\"email-lead\">{Escape(emailLead)}</p>\n");
+
+        foreach (var p in bodyParagraphs)
+            sb.Append($"                    <p class=\"email-body\">{p}</p>\n");
+
+        sb.Append(
+            $"""
+                            <div class="code-panel" style="margin:18px 0 12px;padding:14px 16px;border:1px solid #d0d7de;border-radius:10px;text-align:center;background:#f6f8fa;">
+                              <div style="font-size:12px;color:#656d76;text-transform:uppercase;letter-spacing:0.06em;margin-bottom:8px;">{Escape(codeLabel)}</div>
+                              <div style="font-size:26px;font-weight:700;letter-spacing:0.18em;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;color:#24292f;">{codeValueHtml}</div>
+                            </div>
+
+            """);
+
+        sb.Append($"                    <p class=\"email-signoff\">{Escape(signoff)}</p>\n");
+
+        sb.Append(
+            """
+                            </td>
+                          </tr>
+                          <tr>
+                            <td class="footer">
+                              <div class="footer-muted">
+                                Open clients and server-side tools for full control of your VPN
+                              </div>
+                              <div class="footer-muted">
+                                <a href="https://datagateapp.com/" target="_blank" rel="noopener noreferrer">datagateapp.com</a>
+                              </div>
+                              <div>© 2026 DataGate v.
+            """);
+
+        sb.Append(MailVersionLabel);
+        sb.Append(
+            """
+            </div>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            </body>
+            </html>
+            """);
+
+        return sb.ToString();
+    }
+
+    private static string CssAndHeadOpen(string pageTitle)
+    {
+        var t = Escape(pageTitle);
+        return """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <meta name="color-scheme" content="light dark" />
+              <meta name="supported-color-schemes" content="light dark" />
+              <title>__TITLE__</title>
+              <style type="text/css">
+                html, body {
+                  margin: 0 !important;
+                  padding: 0 !important;
+                  width: 100% !important;
+                  -webkit-text-size-adjust: 100%;
+                  -ms-text-size-adjust: 100%;
+                }
+
+                body {
+                  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+                  font-size: 16px;
+                  line-height: 1.55;
+                  color: #1f2328;
+                  background-color: #f6f8fa;
+                }
+
+                .wrap { width: 100%; background-color: #f6f8fa; }
+                .shell { max-width: 600px; margin: 0 auto; }
+
+                .card {
+                  background-color: #ffffff;
+                  border: 1px solid #d0d7de;
+                  border-radius: 12px;
+                  overflow: hidden;
+                }
+
+                .accent {
+                  height: 4px;
+                  line-height: 0;
+                  font-size: 0;
+                  background: linear-gradient(90deg, #238636, #2ea043);
+                }
+
+                .pad { padding: 28px 24px 24px; }
+
+                .email-title {
+                  margin: 0 0 4px;
+                  font-size: 22px;
+                  font-weight: 600;
+                  color: #1f2328;
+                  letter-spacing: -0.02em;
+                }
+
+                .email-tagline {
+                  margin: 0 0 24px;
+                  font-size: 13px;
+                  color: #656d76;
+                }
+
+                .email-lead {
+                  margin: 0 0 16px;
+                  font-size: 16px;
+                  font-weight: 500;
+                  color: #24292f;
+                }
+
+                .email-body {
+                  margin: 0 0 16px;
+                  font-size: 15px;
+                  color: #424a53;
+                  line-height: 1.55;
+                }
+
+                .email-body:last-of-type { margin-bottom: 0; }
+
+                .email-body a {
+                  color: #0969da;
+                  text-decoration: none;
+                  font-weight: 500;
+                }
+
+                .email-body a:hover { text-decoration: underline; }
+
+                .email-signoff {
+                  margin: 0;
+                  font-size: 15px;
+                  color: #424a53;
+                  line-height: 1.55;
+                }
+
+                .btn-wrap { margin-top: 16px; margin-bottom: 8px; }
+
+                .btn {
+                  display: inline-block;
+                  padding: 10px 18px;
+                  font-size: 14px;
+                  font-weight: 600;
+                  text-decoration: none;
+                  border-radius: 8px;
+                  background-color: #238636;
+                  color: #ffffff !important;
+                  border: 1px solid #2ea043;
+                }
+
+                .footer {
+                  padding: 20px 24px 28px;
+                  font-size: 12px;
+                  line-height: 1.5;
+                  color: #656d76;
+                  text-align: center;
+                  border-top: 1px solid #d0d7de;
+                  background-color: #f6f8fa;
+                }
+
+                .footer a { color: #0969da; text-decoration: none; font-weight: 500; }
+
+                .footer-muted { margin-bottom: 8px; }
+
+                @media (prefers-color-scheme: dark) {
+                  body {
+                    color: #e6edf3 !important;
+                    background-color: #0d1117 !important;
+                  }
+                  .wrap { background-color: #0d1117 !important; }
+                  .card {
+                    background-color: #161b22 !important;
+                    border-color: #30363d !important;
+                  }
+                  .email-title { color: #f0f6fc !important; }
+                  .email-tagline { color: #9da7b3 !important; }
+                  .email-lead { color: #e6edf3 !important; }
+                  .email-body,
+                  .email-signoff {
+                    color: #c9d1d9 !important;
+                  }
+                  .email-body a { color: #79c0ff !important; }
+                  .code-panel {
+                    background-color: #21262d !important;
+                    border-color: #30363d !important;
+                  }
+                  .code-panel div:last-child { color: #f0f6fc !important; }
+                  .footer {
+                    color: #9da7b3 !important;
+                    border-top-color: #30363d !important;
+                    background-color: #0d1117 !important;
+                  }
+                  .footer a { color: #79c0ff !important; }
+                }
+
+                @media only screen and (max-width: 620px) {
+                  .pad { padding: 22px 18px 18px !important; }
+                  .email-title { font-size: 20px !important; }
+                  .btn { display: block !important; text-align: center !important; }
+                }
+              </style>
+            </head>
+            """.Replace("__TITLE__", t, StringComparison.Ordinal);
+    }
+}

--- a/DataGateMonitor.Models/Helpers/NotificationTypes.cs
+++ b/DataGateMonitor.Models/Helpers/NotificationTypes.cs
@@ -10,4 +10,7 @@ public static class NotificationTypes
 
     public const string GeoLiteAutoUpdateSucceeded = "geolite.auto-update.succeeded";
     public const string GeoLiteAutoUpdateFailed     = "geolite.auto-update.failed";
+
+    public const string UserRegistered       = "user.registered";
+    public const string UserPasswordChanged  = "user.password_changed";
 }

--- a/DataGateMonitor.Models/MobileCrashReport.cs
+++ b/DataGateMonitor.Models/MobileCrashReport.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DataGateMonitor.Models;
+
+public class MobileCrashReport : BaseEntity<long>
+{
+    [Required, MaxLength(256)]
+    public string AppProcess { get; set; } = null!;
+
+    [Required, MaxLength(512)]
+    public string FileName { get; set; } = null!;
+
+    [Required]
+    public string PayloadRaw { get; set; } = null!;
+
+    [Required, MaxLength(32)]
+    public string ParseStatus { get; set; } = null!;
+
+    public DateTimeOffset? TimestampUtc { get; set; }
+
+    [MaxLength(256)]
+    public string? Process { get; set; }
+
+    [MaxLength(256)]
+    public string? Thread { get; set; }
+
+    [MaxLength(128)]
+    public string? Sdk { get; set; }
+
+    [MaxLength(256)]
+    public string? Device { get; set; }
+
+    [MaxLength(32)]
+    public string? Kind { get; set; }
+
+    [MaxLength(512)]
+    public string? Exception { get; set; }
+
+    [MaxLength(4000)]
+    public string? Message { get; set; }
+
+    [MaxLength(256)]
+    public string? Tag { get; set; }
+
+    public string? Stacktrace { get; set; }
+}

--- a/DataGateMonitor.Models/SentEmailLog.cs
+++ b/DataGateMonitor.Models/SentEmailLog.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DataGateMonitor.Models;
+
+/// <summary>Audit row for each outbound admin email (broadcast or single recipient).</summary>
+public class SentEmailLog : BaseEntity<int>
+{
+    public int? RecipientUserId { get; set; }
+
+    [Required, MaxLength(256)]
+    public string RecipientEmail { get; set; } = null!;
+
+    [Required, MaxLength(512)]
+    public string Subject { get; set; } = null!;
+
+    [Required]
+    public string BodyHtml { get; set; } = null!;
+
+    public bool Success { get; set; }
+
+    [MaxLength(4000)]
+    public string? ErrorMessage { get; set; }
+
+    public int? SentByUserId { get; set; }
+}

--- a/DataGateMonitor.Models/TelegramBotUserProfilePhoto.cs
+++ b/DataGateMonitor.Models/TelegramBotUserProfilePhoto.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DataGateMonitor.Models;
+
+/// <summary>Latest Telegram profile picture for a <see cref="TelegramBotUser"/> (binary stored in DB).</summary>
+public sealed class TelegramBotUserProfilePhoto : BaseEntity<int>
+{
+    [Required]
+    public int TelegramBotUserId { get; set; }
+
+    public TelegramBotUser TelegramBotUser { get; set; } = null!;
+
+    [Required]
+    public byte[] ImageBytes { get; set; } = Array.Empty<byte>();
+
+    [Required, MaxLength(64)]
+    public string MimeType { get; set; } = "image/jpeg";
+
+    /// <summary>Telegram PhotoSize file_unique_id for change detection.</summary>
+    [MaxLength(128)]
+    public string? TelegramFileUniqueId { get; set; }
+}

--- a/DataGateMonitor.Models/User.cs
+++ b/DataGateMonitor.Models/User.cs
@@ -8,6 +8,11 @@ public class User : BaseEntity<int>
     public string DisplayName { get; set; } = null!;
     [EmailAddress, MaxLength(256)]
     public string? Email { get; set; }
+
+    /// <summary>Profile image URL from OAuth (e.g. Google ID token <c>picture</c> claim).</summary>
+    [MaxLength(2048)]
+    public string? AvatarUrl { get; set; }
+
     public bool IsEmailConfirmed { get; set; } = false;
 
     public bool IsAdmin { get; set; } = false;

--- a/DataGateMonitor.SharedModels/Auth/Google/GoogleUserInfo.cs
+++ b/DataGateMonitor.SharedModels/Auth/Google/GoogleUserInfo.cs
@@ -6,4 +6,6 @@ public sealed class GoogleUserInfo
     public string? Email { get; set; }
     public bool EmailVerified { get; set; }
     public string? Name { get; set; }
+    /// <summary>HTTPS URL from Google ID token <c>picture</c> claim.</summary>
+    public string? Picture { get; set; }
 }

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.11</Version>
-        <AssemblyVersion>1.0.11.0</AssemblyVersion>
-        <FileVersion>1.0.11.0</FileVersion>
+        <Version>1.0.12</Version>
+        <AssemblyVersion>1.0.12.0</AssemblyVersion>
+        <FileVersion>1.0.12.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.10</Version>
-        <AssemblyVersion>1.0.10.0</AssemblyVersion>
-        <FileVersion>1.0.10.0</FileVersion>
+        <Version>1.0.11</Version>
+        <AssemblyVersion>1.0.11.0</AssemblyVersion>
+        <FileVersion>1.0.11.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.12</Version>
-        <AssemblyVersion>1.0.12.0</AssemblyVersion>
-        <FileVersion>1.0.12.0</FileVersion>
+        <Version>1.0.13</Version>
+        <AssemblyVersion>1.0.13.0</AssemblyVersion>
+        <FileVersion>1.0.13.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.9</Version>
-        <AssemblyVersion>1.0.9.0</AssemblyVersion>
-        <FileVersion>1.0.9.0</FileVersion>
+        <Version>1.0.10</Version>
+        <AssemblyVersion>1.0.10.0</AssemblyVersion>
+        <FileVersion>1.0.10.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.13</Version>
-        <AssemblyVersion>1.0.13.0</AssemblyVersion>
-        <FileVersion>1.0.13.0</FileVersion>
+        <Version>1.0.14</Version>
+        <AssemblyVersion>1.0.14.0</AssemblyVersion>
+        <FileVersion>1.0.14.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.8</Version>
-        <AssemblyVersion>1.0.8.0</AssemblyVersion>
-        <FileVersion>1.0.8.0</FileVersion>
+        <Version>1.0.9</Version>
+        <AssemblyVersion>1.0.9.0</AssemblyVersion>
+        <FileVersion>1.0.9.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/GoogleLoginResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/GoogleLoginResponse.cs
@@ -6,4 +6,6 @@ public sealed class GoogleLoginResponse : AuthTokensResponse
     public string DisplayName { get; set; } = string.Empty;
     public string? Email { get; set; }
     public bool IsNewUser { get; set; }
+    /// <summary>Same URL persisted on the user record from Google <c>picture</c> (HTTPS).</summary>
+    public string? AvatarUrl { get; set; }
 }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/CreateEmailTemplateRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/CreateEmailTemplateRequest.cs
@@ -1,0 +1,9 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+
+public class CreateEmailTemplateRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public string HtmlBody { get; set; } = string.Empty;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/GetSentEmailHistoryRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/GetSentEmailHistoryRequest.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+
+public class GetSentEmailHistoryRequest
+{
+    public int Page { get; set; } = 1;
+
+    public int PageSize { get; set; } = 20;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/SendAdminEmailRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/SendAdminEmailRequest.cs
@@ -1,0 +1,12 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+
+public class SendAdminEmailRequest
+{
+    public string Subject { get; set; } = string.Empty;
+
+    /// <summary>Full HTML body (sent as MIME HTML).</summary>
+    public string HtmlBody { get; set; } = string.Empty;
+
+    /// <summary>When set, send only to this dashboard user. When null, send to every user with a non-empty email.</summary>
+    public int? TargetUserId { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/UpdateEmailTemplateRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Requests/UpdateEmailTemplateRequest.cs
@@ -1,0 +1,9 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+
+public class UpdateEmailTemplateRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public string HtmlBody { get; set; } = string.Empty;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/Dto/EmailBroadcastTemplateDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/Dto/EmailBroadcastTemplateDto.cs
@@ -1,0 +1,13 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+
+public class EmailBroadcastTemplateDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public string BodyHtml { get; set; } = string.Empty;
+    public DateTimeOffset CreateDate { get; set; }
+    public DateTimeOffset LastUpdate { get; set; }
+    public int? CreatedByUserId { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/Dto/EmailBroadcastTemplateSummaryDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/Dto/EmailBroadcastTemplateSummaryDto.cs
@@ -1,0 +1,12 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+
+/// <summary>List row without full HTML body.</summary>
+public class EmailBroadcastTemplateSummaryDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string Subject { get; set; } = string.Empty;
+    public DateTimeOffset CreateDate { get; set; }
+    public DateTimeOffset LastUpdate { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/Dto/SentEmailLogDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/Dto/SentEmailLogDto.cs
@@ -1,0 +1,14 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+
+public class SentEmailLogDto
+{
+    public int Id { get; set; }
+    public DateTimeOffset CreateDate { get; set; }
+    public int? RecipientUserId { get; set; }
+    public string RecipientEmail { get; set; } = string.Empty;
+    public string Subject { get; set; } = string.Empty;
+    public string BodyHtml { get; set; } = string.Empty;
+    public bool Success { get; set; }
+    public string? ErrorMessage { get; set; }
+    public int? SentByUserId { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/GetEmailTemplatesResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/GetEmailTemplatesResponse.cs
@@ -1,0 +1,8 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+
+public class GetEmailTemplatesResponse
+{
+    public List<EmailBroadcastTemplateSummaryDto> Items { get; set; } = new();
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/GetSentEmailHistoryResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/GetSentEmailHistoryResponse.cs
@@ -1,0 +1,11 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+
+public class GetSentEmailHistoryResponse
+{
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+    public int TotalCount { get; set; }
+    public List<SentEmailLogDto> Items { get; set; } = new();
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/SendAdminEmailResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/EmailBroadcast/Responses/SendAdminEmailResponse.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+
+public class SendAdminEmailResponse
+{
+    public int Attempted { get; set; }
+    public int Succeeded { get; set; }
+    public int Failed { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/TelegramBotUser/Requests/UpsertTelegramBotUserProfilePhotoRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/TelegramBotUser/Requests/UpsertTelegramBotUserProfilePhotoRequest.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Requests;
+
+/// <summary>Store or replace a Telegram user's profile photo (dashboard DB).</summary>
+public sealed class UpsertTelegramBotUserProfilePhotoRequest
+{
+    [Required]
+    public long TelegramId { get; set; }
+
+    /// <summary>Raw image bytes, base64-encoded (typically JPEG from Telegram).</summary>
+    [Required]
+    public string ProfilePhotoBase64 { get; set; } = string.Empty;
+
+    [MaxLength(64)]
+    public string? ProfilePhotoMimeType { get; set; }
+
+    [MaxLength(128)]
+    public string? ProfilePhotoFileUniqueId { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/TelegramBotUser/Responses/TelegramBotUserProfilePhotoMetaResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/TelegramBotUser/Responses/TelegramBotUserProfilePhotoMetaResponse.cs
@@ -1,0 +1,11 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses;
+
+/// <summary>Whether a profile photo is stored and its Telegram file_unique_id (for change detection).</summary>
+public sealed class TelegramBotUserProfilePhotoMetaResponse
+{
+    public long TelegramId { get; set; }
+    public bool HasPhoto { get; set; }
+    public string? TelegramFileUniqueId { get; set; }
+    public string? MimeType { get; set; }
+    public DateTimeOffset? LastUpdate { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/TelegramBotUser/Responses/UpsertTelegramBotUserProfilePhotoResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/TelegramBotUser/Responses/UpsertTelegramBotUserProfilePhotoResponse.cs
@@ -1,0 +1,7 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses;
+
+public sealed class UpsertTelegramBotUserProfilePhotoResponse
+{
+    /// <summary>True if a row was inserted or image bytes / mime were updated.</summary>
+    public bool Updated { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/User/Requests/ConfirmUserEmailRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/User/Requests/ConfirmUserEmailRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
+
+public class ConfirmUserEmailRequest
+{
+    [Required(ErrorMessage = "id is required.")]
+    [FromRoute(Name = "id")]
+    public int Id { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/User/Requests/GetUserEmailConfirmationStatusRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/User/Requests/GetUserEmailConfirmationStatusRequest.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
+
+public class GetUserEmailConfirmationStatusRequest
+{
+    [Required(ErrorMessage = "id is required.")]
+    [FromRoute(Name = "id")]
+    public int Id { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/User/Responses/ConfirmUserEmailResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/User/Responses/ConfirmUserEmailResponse.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.User.Responses;
+
+public class ConfirmUserEmailResponse
+{
+    public bool IsEmailConfirmed { get; set; } = true;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/User/Responses/Dto/UserDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/User/Responses/Dto/UserDto.cs
@@ -4,6 +4,8 @@ public class UserDto
 {
     public int Id { get; set; }
     public string DisplayName { get; set; } = null!;
+    /// <summary>Profile image URL when known (e.g. Google OAuth <c>picture</c> stored on the user row).</summary>
+    public string? AvatarUrl { get; set; }
     public string? Email { get; set; }
     public bool IsAdmin { get; set; } = false;
     public bool IsBlocked { get; set; } = false;

--- a/DataGateMonitor.SharedModels/DataGateMonitor/User/Responses/GetUserEmailConfirmationStatusResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/User/Responses/GetUserEmailConfirmationStatusResponse.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.User.Responses;
+
+public class GetUserEmailConfirmationStatusResponse
+{
+    public bool IsEmailConfirmed { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/QuotaPlanGroupDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/QuotaPlanGroupDto.cs
@@ -1,8 +1,8 @@
 namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
 
-/// <summary>Quota plan a VPN server belongs to (for UI grouping).</summary>
 public class QuotaPlanGroupDto
 {
     public int Id { get; set; }
+
     public string Name { get; set; } = string.Empty;
 }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/VpnClientInfoDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/VpnClientInfoDto.cs
@@ -6,6 +6,9 @@ public class VpnClientInfoDto
     public int VpnServerId { get; set; }
     public string ExternalId { get; set; } = string.Empty;
     public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Dashboard user profile image URL when the session is linked to a user that stores an avatar URL.</summary>
+    public string? AvatarUrl { get; set; }
     public Guid SessionId { get; set; }
     public string CommonName { get; set; } = string.Empty;
     public string RemoteIp { get; set; } = string.Empty;

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/VpnServerDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/VpnServerDto.cs
@@ -5,23 +5,37 @@ namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
 public class VpnServerDto
 {
     public int Id { get; set; }
-    public VpnServerType ServerType { get; set; } = VpnServerType.OpenVpn;
-    public string ServerName { get; set; } = string.Empty;
-    public bool IsOnline { get; set; } = false;
-    public bool IsDefault { get; set; } = false;
-    public string ApiUrl { get; set; } = string.Empty;
-    public double? Latitude { get; set; }
-    public double? Longitude { get; set; }
-    public bool IsEnableWss { get; set; } = false;
-    public DateTimeOffset CreateDate { get; set; }
-    public DateTimeOffset LastUpdate { get; set; }
-    public bool IsDeleted { get; set; }
-    /// <summary>DCO (Data Channel Offload) enabled; optional, not required in DB.</summary>
-    public bool? DcoIsEnabled { get; set; }
-    public List<string> Tags { get; set; } = [];
 
-    /// <summary>Last Xray node clients poll (dashboard UX).</summary>
+    public VpnServerType ServerType { get; set; }
+
+    public string ServerName { get; set; } = string.Empty;
+
+    public bool IsOnline { get; set; }
+
+    public bool IsDefault { get; set; }
+
+    public string ApiUrl { get; set; } = string.Empty;
+
+    public double? Latitude { get; set; }
+
+    public double? Longitude { get; set; }
+
+    public bool IsEnableWss { get; set; }
+
+    public DateTimeOffset CreateDate { get; set; }
+
+    public DateTimeOffset LastUpdate { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public bool? DcoIsEnabled { get; set; }
+
+    public List<string> Tags { get; set; } = new();
+
     public DateTimeOffset? XrayClientsPolledAt { get; set; }
 
     public string? XrayClientsPollError { get; set; }
+
+    /// <summary>When true, background polling / status collection is turned off for this server (dashboard).</summary>
+    public bool IsDisabled { get; set; }
 }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/VpnServerV2Dto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Dto/VpnServerV2Dto.cs
@@ -2,34 +2,44 @@ using DataGateMonitor.SharedModels.Enums;
 
 namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
 
-/// <summary>
-/// OpenVPN server payload for API v2: same fields as <see cref="VpnServerDto"/> plus quota-plan groups.
-/// </summary>
 public class VpnServerV2Dto
 {
     public int Id { get; set; }
-    public VpnServerType ServerType { get; set; } = VpnServerType.OpenVpn;
-    public string ServerName { get; set; } = string.Empty;
-    public bool IsOnline { get; set; }
-    public bool IsDefault { get; set; }
-    public string ApiUrl { get; set; } = string.Empty;
-    public double? Latitude { get; set; }
-    public double? Longitude { get; set; }
-    public bool IsEnableWss { get; set; }
-    public DateTimeOffset CreateDate { get; set; }
-    public DateTimeOffset LastUpdate { get; set; }
-    public bool IsDeleted { get; set; }
-    public bool? DcoIsEnabled { get; set; }
-    public List<string> Tags { get; set; } = [];
-    public List<QuotaPlanGroupDto> QuotaPlanGroups { get; set; } = [];
 
-    /// <summary>
-    /// Whether the current user may connect to this server (their quota plan includes it).
-    /// Always true for Admin/App. For users without a quota plan, false for all servers.
-    /// </summary>
+    public VpnServerType ServerType { get; set; }
+
+    public string ServerName { get; set; } = string.Empty;
+
+    public bool IsOnline { get; set; }
+
+    public bool IsDefault { get; set; }
+
+    public string ApiUrl { get; set; } = string.Empty;
+
+    public double? Latitude { get; set; }
+
+    public double? Longitude { get; set; }
+
+    public bool IsEnableWss { get; set; }
+
+    public DateTimeOffset CreateDate { get; set; }
+
+    public DateTimeOffset LastUpdate { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public bool? DcoIsEnabled { get; set; }
+
+    public List<string> Tags { get; set; } = new();
+
+    public List<QuotaPlanGroupDto> QuotaPlanGroups { get; set; } = new();
+
     public bool IsAccessibleForUserQuotaPlan { get; set; }
 
     public DateTimeOffset? XrayClientsPolledAt { get; set; }
 
     public string? XrayClientsPollError { get; set; }
+
+    /// <summary>When true, background polling / status collection is turned off for this server (dashboard).</summary>
+    public bool IsDisabled { get; set; }
 }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Requests/AddServerRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Requests/AddServerRequest.cs
@@ -5,16 +5,27 @@ namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Requests;
 
 public class AddServerRequest
 {
-    public VpnServerType ServerType { get; set; } = VpnServerType.OpenVpn;
+    public VpnServerType ServerType { get; set; }
 
     [Required(ErrorMessage = "Server name is required.")]
     public string ServerName { get; set; } = string.Empty;
-    public bool IsOnline { get; set; } = false;
-    public bool IsDefault { get; set; } = false;
+
+    public bool IsOnline { get; set; }
+
+    public bool IsDefault { get; set; }
+
     public string ApiUrl { get; set; } = string.Empty;
+
     public double? Latitude { get; set; }
+
     public double? Longitude { get; set; }
-    public bool IsEnableWss { get; set; } = false;
-    public List<int> QuotaPlanIds { get; set; } = [];
-    public List<int> TagIds { get; set; } = [];
+
+    public bool IsEnableWss { get; set; }
+
+    public List<int> QuotaPlanIds { get; set; } = new();
+
+    public List<int> TagIds { get; set; } = new();
+
+    /// <summary>When true, background polling is disabled for this server after creation.</summary>
+    public bool IsDisabled { get; set; }
 }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Requests/UpdateServerRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Requests/UpdateServerRequest.cs
@@ -5,20 +5,31 @@ namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Requests;
 
 public class UpdateServerRequest
 {
-    public VpnServerType ServerType { get; set; } = VpnServerType.OpenVpn;
+    public VpnServerType ServerType { get; set; }
 
-    [Required(ErrorMessage = "Id is required.")]
-    [Range(1, int.MaxValue, ErrorMessage = "ServerId must be greater than 0.")]
+    [Required]
+    [Range(1, int.MaxValue)]
     public int Id { get; set; }
 
     [Required(ErrorMessage = "Server name is required.")]
     public string ServerName { get; set; } = string.Empty;
-    public bool IsOnline { get; set; } = false;
-    public bool IsDefault { get; set; } = false;
+
+    public bool IsOnline { get; set; }
+
+    public bool IsDefault { get; set; }
+
     public string ApiUrl { get; set; } = string.Empty;
+
     public double? Latitude { get; set; }
+
     public double? Longitude { get; set; }
-    public bool IsEnableWss { get; set; } = false;
-    public List<int> QuotaPlanIds { get; set; } = [];
-    public List<int> TagIds { get; set; } = [];
+
+    public bool IsEnableWss { get; set; }
+
+    public List<int> QuotaPlanIds { get; set; } = new();
+
+    public List<int> TagIds { get; set; } = new();
+
+    /// <summary>When true, background polling is disabled for this server.</summary>
+    public bool IsDisabled { get; set; }
 }

--- a/DataGateMonitor.SharedModels/Enums/ApplicationNotificationKind.cs
+++ b/DataGateMonitor.SharedModels/Enums/ApplicationNotificationKind.cs
@@ -45,4 +45,10 @@ public enum ApplicationNotificationKind
     AppCertificateIssued = 24,
     AppServerMonitorDown = 25,
     AppServerMonitorUp = 26,
+
+    /// <summary>New dashboard user registered (self-service).</summary>
+    AppUserRegistered = 27,
+
+    /// <summary>Password hash changed (forgot/reset flow or future profile password change). Not used for successful login.</summary>
+    AppUserPasswordChanged = 28,
 }

--- a/DataGateMonitor.SharedModels/Enums/VpnServerType.cs
+++ b/DataGateMonitor.SharedModels/Enums/VpnServerType.cs
@@ -1,6 +1,5 @@
 namespace DataGateMonitor.SharedModels.Enums;
 
-/// <summary>Technology stack of a VPN/proxy server row in <c>VpnServers</c>.</summary>
 public enum VpnServerType
 {
     OpenVpn = 0,

--- a/DataGateMonitor.Tests/Configurations/QueryCommandConfigurationTests.cs
+++ b/DataGateMonitor.Tests/Configurations/QueryCommandConfigurationTests.cs
@@ -5,6 +5,7 @@ using DataGateMonitor.DataBase.Services.Query.TagTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerConflogTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTagTable;
 using DataGateMonitor.DataBase.Services.Query.QuotaPlanTable;
+using DataGateMonitor.DataBase.Services.Query.TelegramBotUserProfilePhotoTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using Xunit;
@@ -44,6 +45,7 @@ public class QueryCommandConfigurationTests
         AssertRegistered(services, typeof(IVpnServerTagQueryService));
         AssertRegistered(services, typeof(IVpnServerConflogQueryService));
         AssertRegistered(services, typeof(IQuotaPlanQueryService));
+        AssertRegistered(services, typeof(ITelegramBotUserProfilePhotoQueryService));
     }
 
     private static void AssertRegistered(IServiceCollection services, Type serviceType)

--- a/DataGateMonitor.Tests/Controllers/MobileCrashIngestControllerIntegrationTests.cs
+++ b/DataGateMonitor.Tests/Controllers/MobileCrashIngestControllerIntegrationTests.cs
@@ -1,0 +1,142 @@
+using DataGateMonitor.DataBase.Contexts;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class MobileCrashIngestControllerIntegrationTests
+{
+    private static HttpRequestMessage CreateRequest(string body, string process = "com.imkolganov.datagate.dev")
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/v1/mobile/crash-ingest");
+        req.Content = new StringContent(body);
+        req.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/plain")
+        {
+            CharSet = "utf-8"
+        };
+        req.Headers.TryAddWithoutValidation("X-Crash-Filename", "fatal_2026-05-01T00-00-00.000Z.txt");
+        req.Headers.TryAddWithoutValidation("X-Crash-Process", process);
+        return req;
+    }
+
+    [Fact]
+    public async Task Ingest_WithValidPayload_ReturnsNoContentAndPersists()
+    {
+        await using var factory = new CrashIngestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var payload = """
+                      process=com.imkolganov.datagate.dev
+                      kind=fatal
+
+                      java.lang.RuntimeException: boom
+                      """;
+        using var request = CreateRequest(payload);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, response.StatusCode);
+
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        Assert.Equal(1, await db.MobileCrashReports.CountAsync());
+    }
+
+    [Fact]
+    public async Task Ingest_WithEmptyBody_ReturnsBadRequest()
+    {
+        await using var factory = new CrashIngestWebApplicationFactory();
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        using var request = CreateRequest(string.Empty);
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Ingest_WhenPayloadTooLarge_ReturnsPayloadTooLarge()
+    {
+        await using var factory = new CrashIngestWebApplicationFactory(maxPayloadBytes: 32);
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var payload = new string('A', 64);
+        using var request = CreateRequest(payload);
+        var response = await client.SendAsync(request);
+
+        Assert.Equal((System.Net.HttpStatusCode)413, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Ingest_WhenRateLimitExceeded_ReturnsTooManyRequests()
+    {
+        await using var factory = new CrashIngestWebApplicationFactory(rateLimitMaxRequests: 1, rateLimitWindowSeconds: 300);
+        using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+
+        var payload = """
+                      process=com.imkolganov.datagate.dev
+
+                      stacktrace
+                      """;
+
+        using var request1 = CreateRequest(payload, process: "com.imkolganov.datagate.dev");
+        using var response1 = await client.SendAsync(request1);
+        Assert.Equal(System.Net.HttpStatusCode.NoContent, response1.StatusCode);
+
+        using var request2 = CreateRequest(payload, process: "com.imkolganov.datagate.dev");
+        using var response2 = await client.SendAsync(request2);
+        Assert.Equal((System.Net.HttpStatusCode)429, response2.StatusCode);
+    }
+}
+
+file sealed class CrashIngestWebApplicationFactory(
+    int maxPayloadBytes = 1024 * 1024,
+    int rateLimitMaxRequests = 10,
+    int rateLimitWindowSeconds = 60)
+    : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(Microsoft.AspNetCore.Hosting.IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((_, configBuilder) =>
+        {
+            var overrides = new Dictionary<string, string?>
+            {
+                ["CrashIngest:MaxPayloadBytes"] = maxPayloadBytes.ToString(),
+                ["CrashIngest:RateLimitMaxRequests"] = rateLimitMaxRequests.ToString(),
+                ["CrashIngest:RateLimitWindowSeconds"] = rateLimitWindowSeconds.ToString(),
+                ["CrashIngest:RequireHttps"] = "true",
+                ["CrashIngest:RecentMaxLimit"] = "100"
+            };
+            configBuilder.AddInMemoryCollection(overrides);
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll(typeof(ApplicationDbContext));
+            services.RemoveAll(typeof(DbContextOptions<ApplicationDbContext>));
+            services.RemoveAll(typeof(IDbContextFactory<ApplicationDbContext>));
+
+            var databaseName = $"mobile-crash-tests-{Guid.NewGuid()}";
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseInMemoryDatabase(databaseName));
+
+            services.AddDbContextFactory<ApplicationDbContext>(options =>
+                options.UseInMemoryDatabase(databaseName));
+        });
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
@@ -251,7 +251,7 @@ public class OpenVpnFilesControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<OvpnFilesResponse>>(ok.Value);
         Assert.True(response.Success);
-        Assert.Single(response.Data!.IssuedOvpnFiles);
+        _service.Verify(s => s.GetAllByExternalId("legacy-user", It.IsAny<CancellationToken>()), Times.Once);
         _quotaAllowed.Verify(q => q.GetVpnServerIdsByQuotaPlanId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/DataGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/OpenVpnFilesControllerTests.cs
@@ -14,6 +14,10 @@ using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateMonitor.Tests.Controllers;
 
+/// <summary>
+/// Legacy Android compatibility regression tests for profile/file APIs.
+/// These expectations must stay compatible with old Android app installs.
+/// </summary>
 public class OpenVpnFilesControllerTests
 {
     private readonly Mock<IOvpnFileApiService> _service = new();
@@ -222,6 +226,33 @@ public class OpenVpnFilesControllerTests
         var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<string>>(bad.Value);
         Assert.False(response.Success);
+    }
+
+    [Fact]
+    [Trait("Compatibility", "LegacyAndroid")]
+    public async Task GetFiles_WhenVpnUserAndNoQuotaPlan_DoesNotFilterOutFiles_ForLegacyAndroidCompatibility()
+    {
+        SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "777")
+            ],
+            "mock")));
+
+        _userQuotaPlan.Setup(u => u.GetActiveByUserId(777, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DataGateMonitor.Models.UserQuotaPlan?)null);
+        _service.Setup(s => s.GetAllByExternalId("legacy-user", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new DataGateMonitor.Models.IssuedOvpnFile { VpnServerId = 10, CommonName = "legacy-cn" }
+            ]);
+
+        var result = await _controller.GetFiles(new ByExternalIdRequest { ExternalId = "legacy-user" }, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<OvpnFilesResponse>>(ok.Value);
+        Assert.True(response.Success);
+        Assert.Single(response.Data!.IssuedOvpnFiles);
+        _quotaAllowed.Verify(q => q.GetVpnServerIdsByQuotaPlanId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Controllers/TelegramBotUserControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/TelegramBotUserControllerTests.cs
@@ -15,13 +15,17 @@ namespace DataGateMonitor.Tests.Controllers;
 public class TelegramBotUserControllerTests
 {
     private readonly Mock<ITelegramUserService> _telegramUserServiceMock;
+    private readonly Mock<ITelegramBotUserProfilePhotoService> _profilePhotoServiceMock;
     private readonly TelegramBotUserController _controller;
 
     public TelegramBotUserControllerTests()
     {
         TypeAdapterConfig.GlobalSettings.Scan(typeof(TelegramBotUserMapping).Assembly);
         _telegramUserServiceMock = new Mock<ITelegramUserService>();
-        _controller = new TelegramBotUserController(_telegramUserServiceMock.Object);
+        _profilePhotoServiceMock = new Mock<ITelegramBotUserProfilePhotoService>();
+        _controller = new TelegramBotUserController(
+            _telegramUserServiceMock.Object,
+            _profilePhotoServiceMock.Object);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Controllers/VpnServersControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServersControllerTests.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Security.Claims;
+using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using Newtonsoft.Json.Linq;
 using DataGateMonitor.Controllers;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTagTable;
@@ -64,6 +67,14 @@ public class VpnServersControllerTests
         };
     }
 
+    private static JObject ParseLegacyJsonResponse(ActionResult actionResult)
+    {
+        var content = Assert.IsType<ContentResult>(actionResult);
+        Assert.Equal("application/json", content.ContentType);
+        Assert.False(string.IsNullOrWhiteSpace(content.Content));
+        return JObject.Parse(content.Content!);
+    }
+
     [Fact]
     public async Task GetAllServersWithStatus_Returns_Ok()
     {
@@ -75,9 +86,9 @@ public class VpnServersControllerTests
 
         var result = await _controller.GetAllServersWithStatus(includeDeleted: false, CancellationToken.None);
 
-        var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var response = Assert.IsType<ApiResponse<VpnServerWithStatusesResponse>>(ok.Value);
-        Assert.True(response.Success);
+        var json = ParseLegacyJsonResponse(result);
+        Assert.True(json.Value<bool>("success"));
+        Assert.NotNull(json["data"]?["openVpnServerWithStatuses"]);
         _overviewQuery.Verify(q => q.GetAllVpnServersWithStatusAsync(false, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -93,6 +104,72 @@ public class VpnServersControllerTests
         await _controller.GetAllServersWithStatus(includeDeleted: true, CancellationToken.None);
 
         _overviewQuery.Verify(q => q.GetAllVpnServersWithStatusAsync(true, false, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Compatibility", "LegacyAndroid")]
+    public void GetAllServersWithStatus_UsesLegacyAndroidRequestRouteTemplate()
+    {
+        var method = typeof(VpnServersController).GetMethod(nameof(VpnServersController.GetAllServersWithStatus));
+        Assert.NotNull(method);
+        var route = method!
+            .GetCustomAttributes<HttpGetAttribute>(inherit: true)
+            .Single();
+
+        Assert.Equal("get-all-with-status", route.Template);
+    }
+
+    [Fact]
+    [Trait("Compatibility", "LegacyAndroid")]
+    public async Task GetAllServersWithStatus_ReturnsLegacyAndroidResponseShape()
+    {
+        var withStatus = new VpnServerWithStatusDto
+        {
+            VpnServerResponses = new VpnServerResponse
+            {
+                VpnServer = new VpnServerDto
+                {
+                    Id = 7,
+                    ServerName = "legacy-ru-1",
+                    IsOnline = true,
+                    IsDefault = false,
+                    ApiUrl = "https://legacy.example"
+                }
+            },
+            VpnServerStatusLogResponse = new VpnServerStatusLogResponse
+            {
+                VpnServerId = 7,
+                SessionId = Guid.NewGuid(),
+                BytesIn = 12,
+                BytesOut = 34
+            },
+            CountConnectedClients = 1,
+            CountSessions = 2,
+            TotalBytesIn = 100,
+            TotalBytesOut = 200
+        };
+
+        _overviewQuery.Setup(q => q.GetAllVpnServersWithStatusAsync(
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<int?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([withStatus]);
+        _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<string>> { [7] = ["legacy"] });
+
+        var result = await _controller.GetAllServersWithStatus(false, CancellationToken.None);
+
+        var json = ParseLegacyJsonResponse(result);
+        Assert.True(json.Value<bool>("success"));
+        Assert.NotNull(json["message"]);
+
+        var item = json["data"]?["openVpnServerWithStatuses"]?.First;
+        Assert.True(item is not null, $"Unexpected legacy payload: {json}");
+        Assert.Equal("legacy-ru-1", item!["openVpnServerResponses"]?["openVpnServer"]?["serverName"]?.Value<string>());
+        Assert.Equal(7, item["openVpnServerResponses"]?["openVpnServer"]?["id"]?.Value<int>());
+        Assert.Equal(7, item["openVpnServerStatusLogResponse"]?["vpnServerId"]?.Value<int>());
+        _overviewQuery.Verify(q => q.GetAllVpnServersWithStatusAsync(false, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -312,7 +389,7 @@ public class VpnServersControllerTests
 
         var result = await _controller.GetAllServersWithStatus(false, CancellationToken.None);
 
-        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result.Result);
+        var unauthorized = Assert.IsType<UnauthorizedObjectResult>(result);
         var response = Assert.IsType<ApiResponse<VpnServerWithStatusesResponse>>(unauthorized.Value);
         Assert.False(response.Success);
         _overviewQuery.Verify(
@@ -342,7 +419,6 @@ public class VpnServersControllerTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<VpnServersResponse>>(ok.Value);
         Assert.True(response.Success);
-        Assert.Single(response.Data!.VpnServers);
         _serverQuery.Verify(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/DataGateMonitor.Tests/Controllers/VpnServersControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServersControllerTests.cs
@@ -20,6 +20,10 @@ using Xunit;
 
 namespace DataGateMonitor.Tests.Controllers;
 
+/// <summary>
+/// Legacy Android compatibility regression tests.
+/// These checks protect behavior required by already-installed old Android app versions.
+/// </summary>
 public class VpnServersControllerTests
 {
     private readonly Mock<IVpnDataService> _vpnDataService = new();
@@ -317,7 +321,8 @@ public class VpnServersControllerTests
     }
 
     [Fact]
-    public async Task GetAllServers_WhenVpnUserAndNoQuotaPlan_Returns_EmptyList()
+    [Trait("Compatibility", "LegacyAndroid")]
+    public async Task GetAllServers_WhenVpnUserAndNoQuotaPlan_Returns_AllServers_ForLegacyAndroidCompatibility()
     {
         SetUser(_controller, new ClaimsPrincipal(new ClaimsIdentity(
             [
@@ -327,14 +332,18 @@ public class VpnServersControllerTests
             "mock")));
         _userQuotaPlan.Setup(u => u.GetActiveByUserId(50, It.IsAny<CancellationToken>()))
             .ReturnsAsync((UserQuotaPlan?)null);
+        _serverQuery.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new VpnServer { Id = 1, ServerName = "legacy-visible" }]);
+        _tagQuery.Setup(q => q.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<string>>());
 
         var result = await _controller.GetAllServers(false, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         var response = Assert.IsType<ApiResponse<VpnServersResponse>>(ok.Value);
         Assert.True(response.Success);
-        Assert.Empty(response.Data!.VpnServers);
-        _serverQuery.Verify(s => s.GetAll(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Single(response.Data!.VpnServers);
+        _serverQuery.Verify(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Controllers/VpnServersV2ControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServersV2ControllerTests.cs
@@ -14,6 +14,10 @@ using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateMonitor.Tests.Controllers;
 
+/// <summary>
+/// Legacy Android compatibility regression tests for VPN server listing.
+/// Keep these expectations aligned with old Android client behavior.
+/// </summary>
 public class VpnServersV2ControllerTests
 {
     private readonly Mock<IVpnServerOverviewQuery> _overviewQuery = new();
@@ -100,6 +104,41 @@ public class VpnServersV2ControllerTests
         var s2 = api.Data.VpnServers.Single(x => x.Id == 2);
         Assert.True(s1.IsAccessibleForUserQuotaPlan);
         Assert.False(s2.IsAccessibleForUserQuotaPlan);
+    }
+
+    [Fact]
+    [Trait("Compatibility", "LegacyAndroid")]
+    public async Task GetAllServers_WithVpnUserAndNoQuotaPlan_StillMarksServersAccessible_ForLegacyAndroidCompatibility()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [
+                new Claim(ClaimTypes.Role, "VpnUser"),
+                new Claim(ClaimTypes.NameIdentifier, "101")
+            ],
+            "mock"));
+        var controller = CreateController(user);
+
+        _userQuotaPlan.Setup(u => u.GetActiveByUserId(101, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserQuotaPlan?)null);
+
+        _serverQuery.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new VpnServer { Id = 1, ServerName = "legacy-a" },
+                new VpnServer { Id = 2, ServerName = "legacy-b" }
+            ]);
+        _quotaGroups.Setup(g => g.GetGroupsByVpnServerIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<QuotaPlanGroupDto>>());
+        _tagQuery.Setup(t => t.GetTagNamesByVpnServerIds(It.IsAny<List<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<string>>());
+
+        var result = await controller.GetAllServers(false, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var api = Assert.IsType<ApiResponse<VpnServersV2Response>>(ok.Value);
+        Assert.True(api.Success);
+        Assert.NotNull(api.Data);
+        Assert.Equal(2, api.Data!.VpnServers.Count);
+        Assert.All(api.Data.VpnServers, s => Assert.True(s.IsAccessibleForUserQuotaPlan));
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -20,6 +20,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="8.9.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -20,11 +20,11 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="8.9.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.8" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>

--- a/DataGateMonitor.Tests/Services/Api/Auth/ForgotPassword/AdminForgotPasswordServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/ForgotPassword/AdminForgotPasswordServiceTests.cs
@@ -4,10 +4,13 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
-using DataGateMonitor.DataBase.Services.Query.UserRoleTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.ForgotPassword;
+using DataGateMonitor.Services.EmailTemplates;
+using DataGateMonitor.Services.Others.Notifications;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using Xunit;
 
@@ -20,19 +23,25 @@ public class AdminForgotPasswordServiceTests
     {
         var credentialQuery = new Mock<IUserCredentialQueryService>();
         var userQuery = new Mock<IUserQueryService>();
-        var userRoleQuery = new Mock<IUserRoleQueryService>();
         var credentialCommand = new Mock<ICommandService<UserCredential, int>>();
         var passwordHasher = new Mock<IPasswordHasher<User>>();
         var cache = new MemoryCache(new MemoryCacheOptions());
+        var emailSender = new Mock<IEmailSenderService>();
+        var sentEmailLog = new Mock<ISentEmailLogService>();
+        var systemTransactionalEmail = new Mock<ISystemTransactionalEmailService>();
+        var appNotifications = new Mock<IAppNotificationFacade>();
         var logger = new Mock<ILogger<AdminForgotPasswordService>>();
 
         var sut = new AdminForgotPasswordService(
             credentialQuery.Object,
             userQuery.Object,
-            userRoleQuery.Object,
             credentialCommand.Object,
             passwordHasher.Object,
             cache,
+            emailSender.Object,
+            sentEmailLog.Object,
+            systemTransactionalEmail.Object,
+            appNotifications.Object,
             logger.Object);
 
         var request = new AdminForgotPasswordRequest { LoginOrEmail = "   " };

--- a/DataGateMonitor.Tests/Services/Api/Auth/Handlers/VpnServerAccessQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/Handlers/VpnServerAccessQueryServiceTests.cs
@@ -7,6 +7,9 @@ using Xunit;
 
 namespace DataGateMonitor.Tests.Services.Api.Auth.Handlers;
 
+/// <summary>
+/// Legacy Android compatibility regression tests for quota/access fallback behavior.
+/// </summary>
 public class VpnServerAccessQueryServiceTests
 {
     [Fact]
@@ -28,7 +31,8 @@ public class VpnServerAccessQueryServiceTests
     }
 
     [Fact]
-    public async Task UserHasAccessAsync_When_UserHasNoQuotaPlan_Returns_False()
+    [Trait("Compatibility", "LegacyAndroid")]
+    public async Task UserHasAccessAsync_When_UserHasNoQuotaPlan_Returns_True()
     {
         var quotaQuery = new Mock<IUserQuotaPlanQueryService>();
         quotaQuery.Setup(q => q.GetActiveByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync((UserQuotaPlan?)null);
@@ -38,7 +42,7 @@ public class VpnServerAccessQueryServiceTests
 
         var result = await sut.UserHasAccessAsync(1, 10, CancellationToken.None);
 
-        Assert.False(result);
+        Assert.True(result);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Api/Auth/UserRegistrationServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/UserRegistrationServiceTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
@@ -8,6 +9,7 @@ using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.Registers;
 using DataGateMonitor.Services.Api.Auth.Users;
 using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.Others.Notifications;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using Xunit;
 
@@ -22,6 +24,8 @@ public class UserRegistrationServiceTests
     private readonly Mock<IUserAccountService> _userAccountService;
     private readonly Mock<IEmailConfirmationService> _emailConfirmationService;
     private readonly Mock<ISettingsService> _settingsService;
+    private readonly Mock<IAppNotificationFacade> _appNotificationFacade;
+    private readonly Mock<ILogger<UserRegistrationService>> _logger;
     private readonly UserRegistrationService _sut;
 
     public UserRegistrationServiceTests()
@@ -33,6 +37,8 @@ public class UserRegistrationServiceTests
         _userAccountService = new Mock<IUserAccountService>();
         _emailConfirmationService = new Mock<IEmailConfirmationService>();
         _settingsService = new Mock<ISettingsService>();
+        _appNotificationFacade = new Mock<IAppNotificationFacade>();
+        _logger = new Mock<ILogger<UserRegistrationService>>();
         _sut = new UserRegistrationService(
             _passwordHasher.Object,
             _credentialCommand.Object,
@@ -40,7 +46,9 @@ public class UserRegistrationServiceTests
             _userQuery.Object,
             _userAccountService.Object,
             _emailConfirmationService.Object,
-            _settingsService.Object);
+            _settingsService.Object,
+            _appNotificationFacade.Object,
+            _logger.Object);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Api/MobileCrashIngest/CrashReportParserTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/MobileCrashIngest/CrashReportParserTests.cs
@@ -1,0 +1,69 @@
+using DataGateMonitor.Services.Api.MobileCrashIngest;
+
+namespace DataGateMonitor.Tests.Services.Api.MobileCrashIngest;
+
+public class CrashReportParserTests
+{
+    private readonly ICrashReportParser _sut = new CrashReportParser();
+
+    [Fact]
+    public void Parse_ValidPayload_ReturnsParsedFieldsAndStacktrace()
+    {
+        var payload = """
+                      timestamp_utc=2026-05-01T00:00:00.000Z
+                      process=com.imkolganov.datagate.dev
+                      thread=main
+                      sdk=35
+                      device=Pixel 8
+                      kind=fatal
+                      exception=java.lang.RuntimeException
+                      message=boom
+                      tag=network
+
+                      java.lang.RuntimeException: boom
+                        at com.imkolganov.datagate.MainActivity.onCreate(MainActivity.kt:42)
+                      """;
+
+        var result = _sut.Parse(payload);
+
+        Assert.True(result.IsParsed);
+        Assert.Equal(DateTimeOffset.Parse("2026-05-01T00:00:00.000Z"), result.TimestampUtc);
+        Assert.Equal("com.imkolganov.datagate.dev", result.Process);
+        Assert.Equal("main", result.Thread);
+        Assert.Equal("35", result.Sdk);
+        Assert.Equal("Pixel 8", result.Device);
+        Assert.Equal("fatal", result.Kind);
+        Assert.Equal("java.lang.RuntimeException", result.Exception);
+        Assert.Equal("boom", result.Message);
+        Assert.Equal("network", result.Tag);
+        Assert.Contains("MainActivity", result.Stacktrace);
+    }
+
+    [Fact]
+    public void Parse_HeaderHasMalformedLine_ReturnsFailedAndPreservesStacktrace()
+    {
+        var payload = """
+                      process=com.imkolganov.datagate
+                      malformed-line-without-separator
+
+                      stack line 1
+                      stack line 2
+                      """;
+
+        var result = _sut.Parse(payload);
+
+        Assert.False(result.IsParsed);
+        Assert.Equal("stack line 1\nstack line 2", result.Stacktrace);
+    }
+
+    [Fact]
+    public void Parse_NoHeaderSeparator_ReturnsFailed()
+    {
+        var payload = "process=com.imkolganov.datagate\nthread=main";
+
+        var result = _sut.Parse(payload);
+
+        Assert.False(result.IsParsed);
+        Assert.Null(result.Stacktrace);
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/DataGateOpenVpnManagerMappingTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/DataGateOpenVpnManagerMappingTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Mapster;
+using DataGateMonitor.Mapping.DataGateOpenVpnManager.Mappings;
+using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerConflog.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager;
+
+public class DataGateOpenVpnManagerMappingTests
+{
+    private static TypeAdapterConfig BuildConfig()
+    {
+        var config = new TypeAdapterConfig();
+        new DataGateOpenVpnManagerMapping().Register(config);
+        return config;
+    }
+
+    [Fact]
+    public void VpnServerConflog_MapPayload_OldOpenVpnShape_DeserializesRootPayload()
+    {
+        // Arrange
+        var config = BuildConfig();
+        var root = new RootOpenVpnInfoResponse
+        {
+            Application = "DataGateOpenVpnManager",
+            Version = "1.2.5.50",
+            Environment = "Production",
+            Config = new ConfigInfoResponse
+            {
+                VpnSubnet = "10.51.15.0",
+                VpnNetmask = "255.255.255.0",
+                Port = "1390",
+                Proto = "tcp",
+                ApiPort = "5090",
+                OpenVpnManagement = new OpenVpnManagementInfoResponse
+                {
+                    Host = "localhost",
+                    Port = "5077"
+                }
+            }
+        };
+
+        var conflog = new VpnServerConflog
+        {
+            PayloadJson = JsonSerializer.Serialize(root, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            })
+        };
+
+        // Act
+        var dto = conflog.Adapt<VpnServerConflogDto>(config);
+
+        // Assert
+        Assert.NotNull(dto.Payload);
+        Assert.Equal("DataGateOpenVpnManager", dto.Payload!.Application);
+        Assert.Equal("1.2.5.50", dto.Payload.Version);
+        Assert.Equal("Production", dto.Payload.Environment);
+        Assert.Equal("10.51.15.0", dto.Payload.Config?.VpnSubnet);
+        Assert.Equal("5077", dto.Payload.Config?.OpenVpnManagement?.Port);
+    }
+
+    [Fact]
+    public void VpnServerConflog_MapPayload_NewDiagnosticsWrapper_DeserializesOpenVpnSection()
+    {
+        // Arrange
+        var config = BuildConfig();
+        var diagnostics = new VpnMicroserviceDiagnosticsDto
+        {
+            ServerType = VpnServerType.OpenVpn,
+            OpenVpn = new RootOpenVpnInfoResponse
+            {
+                Application = "DataGateOpenVpnManager",
+                Version = "1.2.5.51",
+                Environment = "Production",
+                Config = new ConfigInfoResponse
+                {
+                    VpnSubnet = "10.51.15.0",
+                    VpnNetmask = "255.255.255.0",
+                    Port = "1390",
+                    Proto = "tcp",
+                    ApiPort = "5090",
+                    OpenVpnManagement = new OpenVpnManagementInfoResponse
+                    {
+                        Host = "localhost",
+                        Port = "5077"
+                    }
+                }
+            }
+        };
+
+        var conflog = new VpnServerConflog
+        {
+            PayloadJson = JsonSerializer.Serialize(diagnostics, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            })
+        };
+
+        // Act
+        var dto = conflog.Adapt<VpnServerConflogDto>(config);
+
+        // Assert
+        Assert.NotNull(dto.Payload);
+        Assert.Equal("DataGateOpenVpnManager", dto.Payload!.Application);
+        Assert.Equal("1.2.5.51", dto.Payload.Version);
+        Assert.Equal("Production", dto.Payload.Environment);
+        Assert.Equal("10.51.15.0", dto.Payload.Config?.VpnSubnet);
+        Assert.Equal("localhost", dto.Payload.Config?.OpenVpnManagement?.Host);
+    }
+}

--- a/DataGateMonitor/Configurations/AdminEmailBroadcastConfiguration.cs
+++ b/DataGateMonitor/Configurations/AdminEmailBroadcastConfiguration.cs
@@ -1,0 +1,12 @@
+using DataGateMonitor.Services.AdminEmail;
+
+namespace DataGateMonitor.Configurations;
+
+public static class AdminEmailBroadcastConfiguration
+{
+    public static void ConfigureAdminEmailBroadcast(this IServiceCollection services)
+    {
+        services.AddScoped<IAdminEmailBroadcastService, AdminEmailBroadcastService>();
+        services.AddScoped<IAdminEmailTemplateService, AdminEmailTemplateService>();
+    }
+}

--- a/DataGateMonitor/Configurations/AdminEmailBroadcastConfiguration.cs
+++ b/DataGateMonitor/Configurations/AdminEmailBroadcastConfiguration.cs
@@ -1,4 +1,5 @@
 using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.Services.EmailTemplates;
 
 namespace DataGateMonitor.Configurations;
 
@@ -6,7 +7,9 @@ public static class AdminEmailBroadcastConfiguration
 {
     public static void ConfigureAdminEmailBroadcast(this IServiceCollection services)
     {
+        services.AddScoped<ISentEmailLogService, SentEmailLogService>();
         services.AddScoped<IAdminEmailBroadcastService, AdminEmailBroadcastService>();
         services.AddScoped<IAdminEmailTemplateService, AdminEmailTemplateService>();
+        services.AddScoped<ISystemTransactionalEmailService, SystemTransactionalEmailService>();
     }
 }

--- a/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
@@ -47,11 +47,11 @@ public static class AuthServiceConfiguration
         services.AddScoped<IUserQuotaPlanService, UserQuotaPlanService>();
 
         services.AddMemoryCache();
-        services.AddScoped<IAdminForgotPasswordService, AdminForgotPasswordService>();
         services.Configure<EmailSenderSettings>(configuration.GetSection("EmailSender"));
         services.AddScoped<SmtpEmailSenderService>();
         services.AddScoped<ResendEmailSenderService>();
         services.AddScoped<IEmailSenderService, ConfigurableEmailSenderService>();
+        services.AddScoped<IAdminForgotPasswordService, AdminForgotPasswordService>();
         services.AddScoped<IEmailConfirmationService, EmailConfirmationService>();
         services.AddScoped<ITelegramLoginCodeService, TelegramLoginCodeService>();
 

--- a/DataGateMonitor/Configurations/CrashIngestOptions.cs
+++ b/DataGateMonitor/Configurations/CrashIngestOptions.cs
@@ -3,16 +3,35 @@ namespace DataGateMonitor.Configurations;
 public sealed class CrashIngestOptions
 {
     public const string SectionName = "CrashIngest";
+    public const int DefaultMaxPayloadBytes = 1024 * 1024;
+    public const int DefaultRateLimitMaxRequests = 20;
+    public const int DefaultRateLimitWindowSeconds = 60;
+    public const int DefaultRecentMaxLimit = 200;
 
-    public int MaxPayloadBytes { get; set; } = 1024 * 1024;
+    public int MaxPayloadBytes { get; set; } = DefaultMaxPayloadBytes;
 
-    public int RateLimitMaxRequests { get; set; } = 20;
+    public int RateLimitMaxRequests { get; set; } = DefaultRateLimitMaxRequests;
 
-    public int RateLimitWindowSeconds { get; set; } = 60;
+    public int RateLimitWindowSeconds { get; set; } = DefaultRateLimitWindowSeconds;
 
     public bool RequireHttps { get; set; } = true;
 
-    public int RecentMaxLimit { get; set; } = 200;
+    public int RecentMaxLimit { get; set; } = DefaultRecentMaxLimit;
 
     public string? AuthToken { get; set; }
+
+    public void ApplyDefaults()
+    {
+        if (MaxPayloadBytes <= 0)
+            MaxPayloadBytes = DefaultMaxPayloadBytes;
+
+        if (RateLimitMaxRequests <= 0)
+            RateLimitMaxRequests = DefaultRateLimitMaxRequests;
+
+        if (RateLimitWindowSeconds <= 0)
+            RateLimitWindowSeconds = DefaultRateLimitWindowSeconds;
+
+        if (RecentMaxLimit <= 0)
+            RecentMaxLimit = DefaultRecentMaxLimit;
+    }
 }

--- a/DataGateMonitor/Configurations/CrashIngestOptions.cs
+++ b/DataGateMonitor/Configurations/CrashIngestOptions.cs
@@ -1,0 +1,18 @@
+namespace DataGateMonitor.Configurations;
+
+public sealed class CrashIngestOptions
+{
+    public const string SectionName = "CrashIngest";
+
+    public int MaxPayloadBytes { get; set; } = 1024 * 1024;
+
+    public int RateLimitMaxRequests { get; set; } = 20;
+
+    public int RateLimitWindowSeconds { get; set; } = 60;
+
+    public bool RequireHttps { get; set; } = true;
+
+    public int RecentMaxLimit { get; set; } = 200;
+
+    public string? AuthToken { get; set; }
+}

--- a/DataGateMonitor/Configurations/MapsterConfiguration.cs
+++ b/DataGateMonitor/Configurations/MapsterConfiguration.cs
@@ -10,6 +10,7 @@ using DataGateMonitor.Mapping.VpnServerEvent.Mappings;
 using DataGateMonitor.Mapping.VpnServerOvpnFileConfig.Mappings;
 using DataGateMonitor.Mapping.VpnServers.Mappings;
 using DataGateMonitor.Mapping.QuotaPlans.Mappings;
+using DataGateMonitor.Mapping.EmailBroadcast.Mappings;
 using DataGateMonitor.Mapping.TelegramBotIncomingMessageLog.Mappings;
 using DataGateMonitor.Mapping.TelegramBotUser.Mappings;
 
@@ -33,7 +34,8 @@ public static class MapsterConfiguration
             typeof(VpnServerClientMapping).Assembly,
             typeof(DataGateOpenVpnManagerMapping).Assembly,
             typeof(VpnServerEventMapping).Assembly,
-            typeof(QuotaPlanMapping).Assembly
+            typeof(QuotaPlanMapping).Assembly,
+            typeof(EmailBroadcastMapping).Assembly
         );
         // TypeAdapterConfig.GlobalSettings.Apply(config);
         

--- a/DataGateMonitor/Configurations/QueryCommandConfiguration.cs
+++ b/DataGateMonitor/Configurations/QueryCommandConfiguration.cs
@@ -21,6 +21,7 @@ using DataGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
 using DataGateMonitor.DataBase.Services.Query.QuotaPlanTable;
 using DataGateMonitor.DataBase.Services.Query.TagTable;
 using DataGateMonitor.DataBase.Services.Query.RoleTable;
+using DataGateMonitor.DataBase.Services.Query.TelegramBotUserProfilePhotoTable;
 using DataGateMonitor.DataBase.Services.Query.TelegramBotUserTable;
 using DataGateMonitor.DataBase.Services.Query.TelegramUserLanguagePreferenceTable;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
@@ -60,6 +61,7 @@ public static class QueryCommandConfiguration
         services.AddScoped<IVpnServerStatusLogQueryService, VpnServerStatusLogQueryService>();
         services.AddScoped<IVpnServerQueryService, VpnServerQueryService>();
         services.AddScoped<ITelegramBotUserQueryService, TelegramBotUserQueryService>();
+        services.AddScoped<ITelegramBotUserProfilePhotoQueryService, TelegramBotUserProfilePhotoQueryService>();
         services.AddScoped<ITelegramUserLanguagePreferenceQueryService, TelegramUserLanguagePreferenceQueryService>();
         
         

--- a/DataGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/ServiceConfiguration.cs
@@ -19,6 +19,7 @@ using DataGateMonitor.Services.UserRoles;
 using DataGateMonitor.Services.Users;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.Services.DataGateXRayManager.ClientLinks;
+using DataGateMonitor.Services.Api.MobileCrashIngest;
 using DataGateMonitor.Services.XrayNode;
 
 namespace DataGateMonitor.Configurations;
@@ -92,6 +93,10 @@ public static class ServiceConfiguration
         services.AddScoped<ITagService, TagService>();
         
         services.AddScoped<IUserCredentialQueryService, UserCredentialQueryService>();
+        services.AddScoped<ICrashReportParser, CrashReportParser>();
+        services.AddScoped<IMobileCrashIngestService, MobileCrashIngestService>();
+        services.AddSingleton<ICrashIngestRateLimiter, MemoryCrashIngestRateLimiter>();
+        services.AddSingleton<ICrashIngestMetrics, CrashIngestMetrics>();
         
         #region DataGateOpenVpnManager
 

--- a/DataGateMonitor/Configurations/TelegramServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/TelegramServiceConfiguration.cs
@@ -7,6 +7,7 @@ public static class TelegramServiceConfiguration
 {
     public static void ConfigureTelegramServices(this IServiceCollection services)
     {
+        services.AddScoped<ITelegramBotUserProfilePhotoService, TelegramBotUserProfilePhotoService>();
         services.AddScoped<ITelegramUserService, TelegramUserService>();
         services.AddScoped<ILocalizationService, LocalizationService>();
         services.AddScoped<IIncomingMessageLogService, IncomingMessageLogService>();

--- a/DataGateMonitor/Controllers/AdminEmailBroadcastController.cs
+++ b/DataGateMonitor/Controllers/AdminEmailBroadcastController.cs
@@ -1,0 +1,125 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateMonitor.Controllers;
+
+[ApiController]
+[Route("api/admin/email-broadcast")]
+[Authorize(Roles = "Admin,App")]
+public class AdminEmailBroadcastController(
+    IAdminEmailBroadcastService broadcastService,
+    IAdminEmailTemplateService templateService) : BaseController
+{
+    [HttpGet("history")]
+    public async Task<ActionResult<ApiResponse<GetSentEmailHistoryResponse>>> GetHistory(
+        [FromQuery] GetSentEmailHistoryRequest request,
+        CancellationToken cancellationToken)
+    {
+        var data = await broadcastService.GetHistoryAsync(request, cancellationToken);
+        return Ok(ApiResponse<GetSentEmailHistoryResponse>.SuccessResponse(data));
+    }
+
+    [HttpPost("send")]
+    public async Task<ActionResult<ApiResponse<SendAdminEmailResponse>>> Send(
+        [FromBody] SendAdminEmailRequest request,
+        CancellationToken cancellationToken)
+    {
+        int? sentBy = null;
+        var idStr = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (int.TryParse(idStr, out var uid))
+            sentBy = uid;
+
+        try
+        {
+            var data = await broadcastService.SendAsync(request, sentBy, cancellationToken);
+            return Ok(ApiResponse<SendAdminEmailResponse>.SuccessResponse(data));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ApiResponse<SendAdminEmailResponse>.ErrorResponse(ex.Message));
+        }
+    }
+
+    [HttpGet("templates")]
+    public async Task<ActionResult<ApiResponse<GetEmailTemplatesResponse>>> ListTemplates(
+        CancellationToken cancellationToken)
+    {
+        var data = await templateService.ListSummariesAsync(cancellationToken);
+        return Ok(ApiResponse<GetEmailTemplatesResponse>.SuccessResponse(data));
+    }
+
+    [HttpGet("templates/{id:int}")]
+    public async Task<ActionResult<ApiResponse<EmailBroadcastTemplateDto>>> GetTemplate(
+        [FromRoute] int id,
+        CancellationToken cancellationToken)
+    {
+        var dto = await templateService.GetByIdAsync(id, cancellationToken);
+        if (dto == null)
+            return NotFound(ApiResponse<EmailBroadcastTemplateDto>.ErrorResponse("Template not found."));
+        return Ok(ApiResponse<EmailBroadcastTemplateDto>.SuccessResponse(dto));
+    }
+
+    [HttpPost("templates")]
+    public async Task<ActionResult<ApiResponse<EmailBroadcastTemplateDto>>> CreateTemplate(
+        [FromBody] CreateEmailTemplateRequest request,
+        CancellationToken cancellationToken)
+    {
+        int? createdBy = null;
+        var idStr = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (int.TryParse(idStr, out var uid))
+            createdBy = uid;
+
+        try
+        {
+            var dto = await templateService.CreateAsync(request, createdBy, cancellationToken);
+            return Ok(ApiResponse<EmailBroadcastTemplateDto>.SuccessResponse(dto));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ApiResponse<EmailBroadcastTemplateDto>.ErrorResponse(ex.Message));
+        }
+    }
+
+    [HttpPut("templates/{id:int}")]
+    public async Task<ActionResult<ApiResponse<EmailBroadcastTemplateDto>>> UpdateTemplate(
+        [FromRoute] int id,
+        [FromBody] UpdateEmailTemplateRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var dto = await templateService.UpdateAsync(id, request, cancellationToken);
+            return Ok(ApiResponse<EmailBroadcastTemplateDto>.SuccessResponse(dto));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ApiResponse<EmailBroadcastTemplateDto>.ErrorResponse(ex.Message));
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ApiResponse<EmailBroadcastTemplateDto>.ErrorResponse(ex.Message));
+        }
+    }
+
+    [HttpDelete("templates/{id:int}")]
+    public async Task<ActionResult<ApiResponse<bool>>> DeleteTemplate(
+        [FromRoute] int id,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await templateService.DeleteAsync(id, cancellationToken);
+            return Ok(ApiResponse<bool>.SuccessResponse(true));
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ApiResponse<bool>.ErrorResponse(ex.Message));
+        }
+    }
+}

--- a/DataGateMonitor/Controllers/MobileCrashIngestController.cs
+++ b/DataGateMonitor/Controllers/MobileCrashIngestController.cs
@@ -1,0 +1,195 @@
+using System.Text;
+using DataGateMonitor.Configurations;
+using DataGateMonitor.Services.Api.MobileCrashIngest;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace DataGateMonitor.Controllers;
+
+[ApiController]
+[Route("api/v1/mobile/crash-ingest")]
+public sealed class MobileCrashIngestController(
+    IMobileCrashIngestService ingestService,
+    ICrashIngestRateLimiter rateLimiter,
+    ICrashIngestMetrics metrics,
+    IOptions<CrashIngestOptions> options,
+    ILogger<MobileCrashIngestController> logger) : ControllerBase
+{
+    private const string CrashFilenameHeader = "X-Crash-Filename";
+    private const string CrashProcessHeader = "X-Crash-Process";
+    private const string CrashTokenHeader = "X-Crash-Token";
+
+    [HttpPost]
+    [AllowAnonymous]
+    [Consumes("text/plain")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status413PayloadTooLarge)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Ingest(CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (options.Value.RequireHttps && !Request.IsHttps)
+            {
+                metrics.RecordRejected4xx();
+                return BadRequest("HTTPS is required.");
+            }
+
+            if (!HasPlainTextContentType(Request.ContentType))
+            {
+                metrics.RecordRejected4xx();
+                return BadRequest("Content-Type must be text/plain.");
+            }
+
+            var configuredToken = ResolveConfiguredToken();
+            if (!string.IsNullOrWhiteSpace(configuredToken))
+            {
+                var incomingToken = Request.Headers[CrashTokenHeader].ToString();
+                if (!FixedTimeEquals(incomingToken, configuredToken))
+                {
+                    metrics.RecordRejected4xx();
+                    return Unauthorized();
+                }
+            }
+
+            var appProcess = Request.Headers[CrashProcessHeader].ToString().Trim();
+            var fileName = Request.Headers[CrashFilenameHeader].ToString().Trim();
+            if (string.IsNullOrWhiteSpace(appProcess) || string.IsNullOrWhiteSpace(fileName))
+            {
+                metrics.RecordRejected4xx();
+                return BadRequest($"Headers {CrashProcessHeader} and {CrashFilenameHeader} are required.");
+            }
+
+            var rateLimitKey = BuildRateLimitKey(HttpContext, appProcess);
+            if (!rateLimiter.TryConsume(rateLimitKey, out var retryAfterSeconds))
+            {
+                Response.Headers.RetryAfter = retryAfterSeconds.ToString();
+                metrics.RecordRejected4xx();
+                return StatusCode(StatusCodes.Status429TooManyRequests, "Too many crash reports. Try again later.");
+            }
+
+            var readResult = await ReadBodyWithLimitAsync(
+                Request.Body,
+                Math.Max(1, options.Value.MaxPayloadBytes),
+                cancellationToken);
+
+            if (readResult.TooLarge)
+            {
+                metrics.RecordRejected4xx();
+                return StatusCode(StatusCodes.Status413PayloadTooLarge, "Payload is too large.");
+            }
+
+            if (!readResult.IsValidUtf8 || string.IsNullOrWhiteSpace(readResult.Payload))
+            {
+                metrics.RecordRejected4xx();
+                return BadRequest("Body is empty or invalid.");
+            }
+
+            await ingestService.SaveAsync(appProcess, fileName, readResult.Payload, cancellationToken);
+            metrics.RecordAccepted(readResult.PayloadBytes);
+            return NoContent();
+        }
+        catch (Exception ex)
+        {
+            metrics.RecordRejected5xx();
+            logger.LogError(ex, "Crash ingest failed. Process={AppProcess}; File={FileName}; TraceId={TraceId}",
+                Request.Headers[CrashProcessHeader].ToString(),
+                Request.Headers[CrashFilenameHeader].ToString(),
+                HttpContext.TraceIdentifier);
+            throw;
+        }
+    }
+
+    [HttpGet("recent")]
+    [Authorize(Roles = "Admin")]
+    [ProducesResponseType(typeof(IReadOnlyList<RecentCrashReportDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IReadOnlyList<RecentCrashReportDto>>> Recent(
+        [FromQuery] int limit = 50,
+        CancellationToken cancellationToken = default)
+    {
+        if (limit <= 0)
+            return BadRequest("limit must be > 0.");
+
+        var safeLimit = Math.Min(limit, Math.Max(1, options.Value.RecentMaxLimit));
+        var recent = await ingestService.GetRecentAsync(safeLimit, cancellationToken);
+        return Ok(recent);
+    }
+
+    private string ResolveConfiguredToken()
+    {
+        var fromEnvironment = Environment.GetEnvironmentVariable("X_CRASH_TOKEN");
+        return string.IsNullOrWhiteSpace(fromEnvironment) ? options.Value.AuthToken ?? string.Empty : fromEnvironment;
+    }
+
+    private static string BuildRateLimitKey(HttpContext context, string process)
+    {
+        var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return $"crash-ingest:{ip}:{process}";
+    }
+
+    private static bool HasPlainTextContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+            return false;
+
+        return contentType.StartsWith("text/plain", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool FixedTimeEquals(string left, string right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(left),
+            Encoding.UTF8.GetBytes(right));
+    }
+
+    private static async Task<BodyReadResult> ReadBodyWithLimitAsync(
+        Stream body,
+        int maxBytes,
+        CancellationToken cancellationToken)
+    {
+        using var ms = new MemoryStream(capacity: Math.Min(maxBytes, 1024 * 64));
+        var buffer = new byte[8192];
+        var totalRead = 0;
+
+        while (true)
+        {
+            var read = await body.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
+            if (read <= 0)
+                break;
+
+            totalRead += read;
+            if (totalRead > maxBytes)
+                return BodyReadResult.TooLargePayload(totalRead);
+
+            ms.Write(buffer, 0, read);
+        }
+
+        if (totalRead <= 0)
+            return BodyReadResult.InvalidPayload(totalRead);
+
+        try
+        {
+            var payload = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                .GetString(ms.ToArray());
+            return BodyReadResult.Valid(payload, totalRead);
+        }
+        catch (DecoderFallbackException)
+        {
+            return BodyReadResult.InvalidPayload(totalRead);
+        }
+    }
+
+    private readonly record struct BodyReadResult(string? Payload, bool TooLarge, bool IsValidUtf8, int PayloadBytes)
+    {
+        public static BodyReadResult Valid(string payload, int payloadBytes) => new(payload, false, true, payloadBytes);
+        public static BodyReadResult TooLargePayload(int payloadBytes) => new(null, true, true, payloadBytes);
+        public static BodyReadResult InvalidPayload(int payloadBytes) => new(null, false, false, payloadBytes);
+    }
+}

--- a/DataGateMonitor/Controllers/OpenVpnFilesController.cs
+++ b/DataGateMonitor/Controllers/OpenVpnFilesController.cs
@@ -291,7 +291,7 @@ public class OpenVpnFilesController(
             return files;
         var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
         if (uqp is null)
-            return [];
+            return files;
         var allowed = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(uqp.QuotaPlanId, ct);
         return files.Where(f => allowed.Contains(f.VpnServerId)).ToList();
     }

--- a/DataGateMonitor/Controllers/TelegramBotUserController.cs
+++ b/DataGateMonitor/Controllers/TelegramBotUserController.cs
@@ -12,7 +12,9 @@ namespace DataGateMonitor.Controllers;
 [Route("api/tgbot-users")]
 [Authorize(Roles = "Admin,App")]
 [Authorize]
-public class TelegramBotUserController(ITelegramUserService telegramUserService) : BaseController
+public class TelegramBotUserController(
+    ITelegramUserService telegramUserService,
+    ITelegramBotUserProfilePhotoService telegramBotUserProfilePhotoService) : BaseController
 {
     [HttpGet("check-exists/{telegramId}")]
     public async Task<ActionResult<ApiResponse<bool>>> UserExists([FromRoute] TelegramUserActionRequest request, 
@@ -46,7 +48,37 @@ public class TelegramBotUserController(ITelegramUserService telegramUserService)
         return Ok(ApiResponse<GetAllTelegramUsersResponse>.SuccessResponse(
             telegramBotUsers.Adapt<GetAllTelegramUsersResponse>()));
     }
-    
+
+    [HttpPost("profile-photo")]
+    public async Task<ActionResult<ApiResponse<UpsertTelegramBotUserProfilePhotoResponse>>> UpsertProfilePhoto(
+        [FromBody] UpsertTelegramBotUserProfilePhotoRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await telegramBotUserProfilePhotoService.UpsertAsync(request, cancellationToken);
+        return Ok(ApiResponse<UpsertTelegramBotUserProfilePhotoResponse>.SuccessResponse(result));
+    }
+
+    [HttpGet("profile-photo-meta/{telegramId:long}")]
+    public async Task<ActionResult<ApiResponse<TelegramBotUserProfilePhotoMetaResponse>>> GetProfilePhotoMeta(
+        [FromRoute] long telegramId,
+        CancellationToken cancellationToken)
+    {
+        var meta = await telegramBotUserProfilePhotoService.GetMetaByTelegramIdAsync(telegramId, cancellationToken);
+        if (meta is null)
+            return NotFound(ApiResponse<TelegramBotUserProfilePhotoMetaResponse>.ErrorResponse("Telegram user not found."));
+        return Ok(ApiResponse<TelegramBotUserProfilePhotoMetaResponse>.SuccessResponse(meta));
+    }
+
+    [HttpGet("profile-photo-file/{telegramId:long}")]
+    public async Task<IActionResult> GetProfilePhotoFile([FromRoute] long telegramId,
+        CancellationToken cancellationToken)
+    {
+        var image = await telegramBotUserProfilePhotoService.GetImageByTelegramIdAsync(telegramId, cancellationToken);
+        if (image is null)
+            return NotFound();
+        return File(image.Value.Bytes, image.Value.MimeType);
+    }
+
     [HttpPost("block")]
     public async Task<ActionResult<ApiResponse<bool>>> BlockUser([FromBody] TelegramUserActionRequest request,
         CancellationToken cancellationToken)

--- a/DataGateMonitor/Controllers/UserController.cs
+++ b/DataGateMonitor/Controllers/UserController.cs
@@ -47,4 +47,22 @@ public class UserController(IUserService userService) : BaseController
         var telegramBotUsers = await userService.GetUserByExternalId(request, cancellationToken);
         return Ok(ApiResponse<UsersResponse>.SuccessResponse(telegramBotUsers.Adapt<UsersResponse>()));
     }
+
+    [HttpGet("email-confirmation-status/{id:int}")]
+    public async Task<ActionResult<ApiResponse<GetUserEmailConfirmationStatusResponse>>> GetEmailConfirmationStatus(
+        [FromRoute] GetUserEmailConfirmationStatusRequest request,
+        CancellationToken cancellationToken)
+    {
+        var response = await userService.GetEmailConfirmationStatus(request, cancellationToken);
+        return Ok(ApiResponse<GetUserEmailConfirmationStatusResponse>.SuccessResponse(response));
+    }
+
+    [HttpPost("confirm-email/{id:int}")]
+    public async Task<ActionResult<ApiResponse<ConfirmUserEmailResponse>>> ConfirmEmail(
+        [FromRoute] ConfirmUserEmailRequest request,
+        CancellationToken cancellationToken)
+    {
+        var response = await userService.ConfirmEmailManually(request, cancellationToken);
+        return Ok(ApiResponse<ConfirmUserEmailResponse>.SuccessResponse(response));
+    }
 }

--- a/DataGateMonitor/Controllers/VpnServersController.cs
+++ b/DataGateMonitor/Controllers/VpnServersController.cs
@@ -55,16 +55,36 @@ public class VpnServersController(IVpnDataService vpnDataService,
                     includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId: uqp.QuotaPlanId, ct);
         }
 
-        var baseResponse = result.Adapt<VpnServerWithStatusesResponse>();
-        var response = new LegacyVpnServerWithStatusesResponse
+        var baseResponse = new VpnServerWithStatusesResponse
         {
-            VpnServerWithStatuses = baseResponse.VpnServerWithStatuses
+            VpnServerWithStatuses = result
         };
-        await FillTagsForOverviewResponse(response, ct);
-        ApplyLegacyOpenVpnAliases(response);
+        await FillTagsForOverviewResponse(baseResponse, ct);
 
-        // Legacy mobile clients parse strict camelCase + OpenVpn* keys.
-        var envelope = LegacyApiResponse<LegacyVpnServerWithStatusesResponse>.SuccessResponse(response);
+        // Legacy mobile clients parse strict camelCase + openVpn* keys.
+        var legacyItems = baseResponse.VpnServerWithStatuses.Select(item => new
+        {
+            openVpnServerResponses = new
+            {
+                openVpnServer = item.VpnServerResponses.VpnServer
+            },
+            openVpnServerStatusLogResponse = item.VpnServerStatusLogResponse,
+            countConnectedClients = item.CountConnectedClients,
+            countSessions = item.CountSessions,
+            totalBytesIn = item.TotalBytesIn,
+            totalBytesOut = item.TotalBytesOut
+        }).ToList();
+
+        var envelope = new
+        {
+            success = true,
+            message = "Success",
+            data = new
+            {
+                openVpnServerWithStatuses = legacyItems
+            }
+        };
+
         var json = JsonConvert.SerializeObject(
             envelope,
             new JsonSerializerSettings
@@ -243,54 +263,4 @@ public class VpnServersController(IVpnDataService vpnDataService,
         }
     }
 
-    // Keep old Windows clients working after DTO renames (OpenVpn* -> Vpn*).
-    private static void ApplyLegacyOpenVpnAliases(VpnServerWithStatusesResponse response)
-    {
-        response.VpnServerWithStatuses = response.VpnServerWithStatuses
-            .Select(item => new LegacyVpnServerWithStatusDto
-            {
-                VpnServerResponses = new LegacyVpnServerResponse
-                {
-                    VpnServer = item.VpnServerResponses.VpnServer
-                },
-                VpnServerStatusLogResponse = item.VpnServerStatusLogResponse,
-                CountConnectedClients = item.CountConnectedClients,
-                CountSessions = item.CountSessions,
-                TotalBytesIn = item.TotalBytesIn,
-                TotalBytesOut = item.TotalBytesOut
-            })
-            .Cast<VpnServerWithStatusDto>()
-            .ToList();
-    }
-
-    private sealed class LegacyVpnServerWithStatusDto : VpnServerWithStatusDto
-    {
-        [JsonProperty("OpenVpnServerResponses")]
-        public VpnServerResponse OpenVpnServerResponses => VpnServerResponses;
-
-        [JsonProperty("OpenVpnServerStatusLogResponse")]
-        public VpnServerStatusLogResponse? OpenVpnServerStatusLogResponse => VpnServerStatusLogResponse;
-    }
-
-    private sealed class LegacyVpnServerWithStatusesResponse : VpnServerWithStatusesResponse
-    {
-        [JsonProperty("OpenVpnServerWithStatuses")]
-        public List<VpnServerWithStatusDto> OpenVpnServerWithStatuses => VpnServerWithStatuses;
-    }
-
-    private sealed class LegacyVpnServerResponse : VpnServerResponse
-    {
-        [JsonProperty("OpenVpnServer")]
-        public VpnServerDto OpenVpnServer => VpnServer;
-    }
-
-    private sealed class LegacyApiResponse<T>
-    {
-        public bool Success { get; set; }
-        public string Message { get; set; } = string.Empty;
-        public T? Data { get; set; }
-
-        public static LegacyApiResponse<T> SuccessResponse(T data, string message = "Success") =>
-            new() { Success = true, Message = message, Data = data };
-    }
 }

--- a/DataGateMonitor/Controllers/VpnServersController.cs
+++ b/DataGateMonitor/Controllers/VpnServersController.cs
@@ -2,6 +2,7 @@ using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTagTable;
 using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
@@ -31,7 +32,7 @@ public class VpnServersController(IVpnDataService vpnDataService,
     IVpnServerAccessQueryService vpnServerAccessQueryService) : BaseController
 {
     [HttpGet("get-all-with-status")]
-    public async Task<ActionResult<ApiResponse<VpnServerWithStatusesResponse>>> GetAllServersWithStatus(
+    public async Task<ActionResult> GetAllServersWithStatus(
         [FromQuery] bool includeDeleted = false,
         CancellationToken ct = default)
     {
@@ -47,20 +48,32 @@ public class VpnServersController(IVpnDataService vpnDataService,
                 return Unauthorized(ApiResponse<VpnServerWithStatusesResponse>.ErrorResponse("User id missing from token."));
             var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
             if (uqp is null)
-                result = [];
+                result = await openVpnServerOverviewQuery.GetAllVpnServersWithStatusAsync(
+                    includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId: null, ct);
             else
                 result = await openVpnServerOverviewQuery.GetAllVpnServersWithStatusAsync(
                     includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId: uqp.QuotaPlanId, ct);
         }
 
-        VpnServerWithStatusesResponse response = result.Adapt<VpnServerWithStatusesResponse>();
-        response = new LegacyVpnServerWithStatusesResponse
+        var baseResponse = result.Adapt<VpnServerWithStatusesResponse>();
+        var response = new LegacyVpnServerWithStatusesResponse
         {
-            VpnServerWithStatuses = response.VpnServerWithStatuses
+            VpnServerWithStatuses = baseResponse.VpnServerWithStatuses
         };
         await FillTagsForOverviewResponse(response, ct);
         ApplyLegacyOpenVpnAliases(response);
-        return Ok(ApiResponse<VpnServerWithStatusesResponse>.SuccessResponse(response));
+
+        // Legacy mobile clients parse strict camelCase + OpenVpn* keys.
+        var envelope = LegacyApiResponse<LegacyVpnServerWithStatusesResponse>.SuccessResponse(response);
+        var json = JsonConvert.SerializeObject(
+            envelope,
+            new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                NullValueHandling = NullValueHandling.Ignore
+            });
+
+        return Content(json, "application/json");
     }
 
     [HttpGet("get-server-with-status/{VpnServerId:int}")]
@@ -120,7 +133,8 @@ public class VpnServersController(IVpnDataService vpnDataService,
                 return Unauthorized(ApiResponse<VpnServersResponse>.ErrorResponse("User id missing from token."));
             var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
             if (uqp is null)
-                serversList = [];
+                serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: false,
+                    restrictToQuotaPlanId: null, ct);
             else
                 serversList = await openVpnServerQueryService.GetAll(includeDeleted, requireQuotaPlanAssignment: false,
                     restrictToQuotaPlanId: uqp.QuotaPlanId, ct);
@@ -253,6 +267,9 @@ public class VpnServersController(IVpnDataService vpnDataService,
     {
         [JsonProperty("OpenVpnServerResponses")]
         public VpnServerResponse OpenVpnServerResponses => VpnServerResponses;
+
+        [JsonProperty("OpenVpnServerStatusLogResponse")]
+        public VpnServerStatusLogResponse? OpenVpnServerStatusLogResponse => VpnServerStatusLogResponse;
     }
 
     private sealed class LegacyVpnServerWithStatusesResponse : VpnServerWithStatusesResponse
@@ -265,5 +282,15 @@ public class VpnServersController(IVpnDataService vpnDataService,
     {
         [JsonProperty("OpenVpnServer")]
         public VpnServerDto OpenVpnServer => VpnServer;
+    }
+
+    private sealed class LegacyApiResponse<T>
+    {
+        public bool Success { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public T? Data { get; set; }
+
+        public static LegacyApiResponse<T> SuccessResponse(T data, string message = "Success") =>
+            new() { Success = true, Message = message, Data = data };
     }
 }

--- a/DataGateMonitor/Controllers/VpnServersV2Controller.cs
+++ b/DataGateMonitor/Controllers/VpnServersV2Controller.cs
@@ -114,7 +114,7 @@ public class VpnServersV2Controller(
             return (null, false);
         var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
         if (uqp is null)
-            return (new HashSet<int>(), true);
+            return (null, true);
         var set = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(uqp.QuotaPlanId, ct);
         return (set, true);
     }

--- a/DataGateMonitor/Controllers/XrayClientLinksController.cs
+++ b/DataGateMonitor/Controllers/XrayClientLinksController.cs
@@ -266,7 +266,7 @@ public class XrayClientLinksController(
             return files;
         var uqp = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
         if (uqp is null)
-            return [];
+            return files;
         var allowed = await quotaPlanAllowedServerQueryService.GetVpnServerIdsByQuotaPlanId(uqp.QuotaPlanId, ct);
         return files.Where(f => allowed.Contains(f.VpnServerId)).ToList();
     }

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.26</Version>
-        <AssemblyVersion>1.0.3.26</AssemblyVersion>
-        <FileVersion>1.0.3.26</FileVersion>
+        <Version>1.0.3.27</Version>
+        <AssemblyVersion>1.0.3.27</AssemblyVersion>
+        <FileVersion>1.0.3.27</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.23</Version>
-        <AssemblyVersion>1.0.3.23</AssemblyVersion>
-        <FileVersion>1.0.3.23</FileVersion>
+        <Version>1.0.3.24</Version>
+        <AssemblyVersion>1.0.3.24</AssemblyVersion>
+        <FileVersion>1.0.3.24</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.22</Version>
-        <AssemblyVersion>1.0.3.22</AssemblyVersion>
-        <FileVersion>1.0.3.22</FileVersion>
+        <Version>1.0.3.23</Version>
+        <AssemblyVersion>1.0.3.23</AssemblyVersion>
+        <FileVersion>1.0.3.23</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.12" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.20</Version>
-        <AssemblyVersion>1.0.3.20</AssemblyVersion>
-        <FileVersion>1.0.3.20</FileVersion>
+        <Version>1.0.3.21</Version>
+        <AssemblyVersion>1.0.3.21</AssemblyVersion>
+        <FileVersion>1.0.3.21</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.21</Version>
-        <AssemblyVersion>1.0.3.21</AssemblyVersion>
-        <FileVersion>1.0.3.21</FileVersion>
+        <Version>1.0.3.22</Version>
+        <AssemblyVersion>1.0.3.22</AssemblyVersion>
+        <FileVersion>1.0.3.22</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.13" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.14" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.25</Version>
-        <AssemblyVersion>1.0.3.25</AssemblyVersion>
-        <FileVersion>1.0.3.25</FileVersion>
+        <Version>1.0.3.26</Version>
+        <AssemblyVersion>1.0.3.26</AssemblyVersion>
+        <FileVersion>1.0.3.26</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -34,7 +34,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.8" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.9" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -15,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.5" />
+        <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.6" />
         <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
         <PackageReference Include="Mapster" Version="10.0.7" />
         <PackageReference Include="Mapster.DependencyInjection" Version="10.0.7" />
@@ -34,7 +34,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only (never ProjectReference). After DTO changes in SharedModels, bump version and publish to nuget.org. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.10" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.11" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.27</Version>
-        <AssemblyVersion>1.0.3.27</AssemblyVersion>
-        <FileVersion>1.0.3.27</FileVersion>
+        <Version>1.0.3.28</Version>
+        <AssemblyVersion>1.0.3.28</AssemblyVersion>
+        <FileVersion>1.0.3.28</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.24</Version>
-        <AssemblyVersion>1.0.3.24</AssemblyVersion>
-        <FileVersion>1.0.3.24</FileVersion>
+        <Version>1.0.3.25</Version>
+        <AssemblyVersion>1.0.3.25</AssemblyVersion>
+        <FileVersion>1.0.3.25</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/Program.Partial.cs
+++ b/DataGateMonitor/Program.Partial.cs
@@ -1,0 +1,1 @@
+public partial class Program;

--- a/DataGateMonitor/Program.cs
+++ b/DataGateMonitor/Program.cs
@@ -44,11 +44,11 @@ builder.Services.ConfigureServices(builder.Configuration, databaseRuntime);
 builder.Services.ConfigureQueryCommand();
 builder.Services.ConfigureTelegramServices();
 builder.Services.ConfigureGeoLiteServices(databaseRuntime);
+builder.Services.ConfigureAdminEmailBroadcast();
 builder.Services.ConfigureAuthServices(builder.Configuration);
 builder.Services.DataBaseServices(builder.Configuration, logger, databaseRuntime);
 builder.Services.ConfigureJwt(builder.Configuration);
 builder.Services.ConfigureMapster();
-builder.Services.ConfigureAdminEmailBroadcast();
 builder.Services.ConfigureNotificationServices();
 builder.Services.ConfigureHealthCheckServices(databaseRuntime);
 

--- a/DataGateMonitor/Program.cs
+++ b/DataGateMonitor/Program.cs
@@ -51,6 +51,7 @@ builder.Services.ConfigureJwt(builder.Configuration);
 builder.Services.ConfigureMapster();
 builder.Services.ConfigureNotificationServices();
 builder.Services.ConfigureHealthCheckServices(databaseRuntime);
+builder.Services.Configure<CrashIngestOptions>(builder.Configuration.GetSection(CrashIngestOptions.SectionName));
 
 builder.ConfigureWebHost();
 builder.ConfigureExternalIpServices();

--- a/DataGateMonitor/Program.cs
+++ b/DataGateMonitor/Program.cs
@@ -52,6 +52,7 @@ builder.Services.ConfigureMapster();
 builder.Services.ConfigureNotificationServices();
 builder.Services.ConfigureHealthCheckServices(databaseRuntime);
 builder.Services.Configure<CrashIngestOptions>(builder.Configuration.GetSection(CrashIngestOptions.SectionName));
+builder.Services.PostConfigure<CrashIngestOptions>(options => options.ApplyDefaults());
 
 builder.ConfigureWebHost();
 builder.ConfigureExternalIpServices();

--- a/DataGateMonitor/Program.cs
+++ b/DataGateMonitor/Program.cs
@@ -48,6 +48,7 @@ builder.Services.ConfigureAuthServices(builder.Configuration);
 builder.Services.DataBaseServices(builder.Configuration, logger, databaseRuntime);
 builder.Services.ConfigureJwt(builder.Configuration);
 builder.Services.ConfigureMapster();
+builder.Services.ConfigureAdminEmailBroadcast();
 builder.Services.ConfigureNotificationServices();
 builder.Services.ConfigureHealthCheckServices(databaseRuntime);
 

--- a/DataGateMonitor/Services/AdminEmail/AdminEmailBroadcastService.cs
+++ b/DataGateMonitor/Services/AdminEmail/AdminEmailBroadcastService.cs
@@ -1,0 +1,135 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+using MapsterMapper;
+
+namespace DataGateMonitor.Services.AdminEmail;
+
+public sealed class AdminEmailBroadcastService(
+    IEmailSenderService emailSender,
+    ICommandService<SentEmailLog, int> sentEmailCommand,
+    IQueryService<SentEmailLog, int> sentEmailQuery,
+    IUserQueryService userQuery,
+    IMapper mapper,
+    ILogger<AdminEmailBroadcastService> logger
+) : IAdminEmailBroadcastService
+{
+    private const int MaxHtmlLength = 512_000;
+    private const int MaxPageSize = 100;
+
+    public async Task<GetSentEmailHistoryResponse> GetHistoryAsync(GetSentEmailHistoryRequest request,
+        CancellationToken ct)
+    {
+        var page = request.Page < 1 ? 1 : request.Page;
+        var pageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, MaxPageSize);
+
+        var paged = await sentEmailQuery.Page(
+            page,
+            pageSize,
+            predicate: null,
+            orderBy: q => q.OrderByDescending(x => x.CreateDate).ThenByDescending(x => x.Id),
+            asNoTracking: true,
+            ct: ct);
+
+        var items = mapper.Map<List<SentEmailLogDto>>(paged.Items);
+
+        return new GetSentEmailHistoryResponse
+        {
+            Page = paged.Page,
+            PageSize = paged.PageSize,
+            TotalCount = paged.TotalCount,
+            Items = items
+        };
+    }
+
+    public async Task<SendAdminEmailResponse> SendAsync(SendAdminEmailRequest request, int? sentByUserId,
+        CancellationToken ct)
+    {
+        var subject = (request.Subject ?? string.Empty).Trim();
+        var html = request.HtmlBody ?? string.Empty;
+        if (string.IsNullOrEmpty(subject))
+            throw new ArgumentException("Subject is required.");
+        if (string.IsNullOrWhiteSpace(html))
+            throw new ArgumentException("HTML body is required.");
+        if (html.Length > MaxHtmlLength)
+            throw new ArgumentException($"HTML body exceeds {MaxHtmlLength} characters.");
+
+        List<(User? User, string Email)> recipients = new();
+
+        var targetUserId = request.TargetUserId;
+        if (targetUserId.HasValue && targetUserId.Value > 0)
+        {
+            var tid = targetUserId.Value;
+            var user = await userQuery.GetById(tid, ct)
+                       ?? throw new ArgumentException($"User {tid} not found.");
+            if (string.IsNullOrWhiteSpace(user.Email))
+                throw new ArgumentException("Target user has no email address.");
+            recipients.Add((user, user.Email.Trim()));
+        }
+        else
+        {
+            var users = await userQuery.GetUsersWithNonEmptyEmailAsync(ct);
+            foreach (var u in users)
+            {
+                if (string.IsNullOrWhiteSpace(u.Email))
+                    continue;
+                recipients.Add((u, u.Email.Trim()));
+            }
+
+            if (recipients.Count == 0)
+                throw new ArgumentException("No users with an email address.");
+        }
+
+        var attempted = 0;
+        var succeeded = 0;
+        var failed = 0;
+
+        foreach (var (user, email) in recipients)
+        {
+            attempted++;
+            var now = DateTimeOffset.UtcNow;
+            var log = new SentEmailLog
+            {
+                RecipientUserId = user?.Id,
+                RecipientEmail = email,
+                Subject = subject,
+                BodyHtml = html,
+                Success = false,
+                ErrorMessage = null,
+                SentByUserId = sentByUserId,
+                CreateDate = now,
+                LastUpdate = now
+            };
+
+            try
+            {
+                await emailSender.SendAsync(email, subject, html, ct);
+                log.Success = true;
+                succeeded++;
+            }
+            catch (Exception ex)
+            {
+                var msg = ex.Message;
+                if (msg.Length > 4000)
+                    msg = msg[..4000];
+                log.ErrorMessage = msg;
+                failed++;
+                logger.LogWarning(ex, "Admin email send failed for {Email}", email);
+            }
+
+            await sentEmailCommand.Add(log, saveChanges: true, ct);
+        }
+
+        return new SendAdminEmailResponse
+        {
+            Attempted = attempted,
+            Succeeded = succeeded,
+            Failed = failed
+        };
+    }
+}

--- a/DataGateMonitor/Services/AdminEmail/AdminEmailTemplateService.cs
+++ b/DataGateMonitor/Services/AdminEmail/AdminEmailTemplateService.cs
@@ -1,0 +1,104 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query;
+using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+using MapsterMapper;
+
+namespace DataGateMonitor.Services.AdminEmail;
+
+public sealed class AdminEmailTemplateService(
+    IQueryService<EmailBroadcastTemplate, int> templateQuery,
+    ICommandService<EmailBroadcastTemplate, int> templateCommand,
+    IMapper mapper
+) : IAdminEmailTemplateService
+{
+    private const int MaxHtmlLength = 512_000;
+
+    public async Task<GetEmailTemplatesResponse> ListSummariesAsync(CancellationToken ct)
+    {
+        var list = await templateQuery.Where(
+            predicate: _ => true,
+            orderBy: q => q.OrderBy(t => t.Name),
+            asNoTracking: true,
+            ct: ct);
+
+        return new GetEmailTemplatesResponse
+        {
+            Items = mapper.Map<List<EmailBroadcastTemplateSummaryDto>>(list)
+        };
+    }
+
+    public async Task<EmailBroadcastTemplateDto?> GetByIdAsync(int id, CancellationToken ct)
+    {
+        var entity = await templateQuery.FindById(id, asNoTracking: true, ct: ct);
+        return entity == null ? null : mapper.Map<EmailBroadcastTemplateDto>(entity);
+    }
+
+    public async Task<EmailBroadcastTemplateDto> CreateAsync(CreateEmailTemplateRequest request,
+        int? createdByUserId, CancellationToken ct)
+    {
+        Validate(request.Name, request.Subject, request.HtmlBody);
+        var name = request.Name.Trim();
+        if (await templateQuery.Any(t => t.Name == name, ct))
+            throw new ArgumentException($"A template named '{name}' already exists.");
+
+        var now = DateTimeOffset.UtcNow;
+        var entity = new EmailBroadcastTemplate
+        {
+            Name = name,
+            Description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim(),
+            Subject = request.Subject.Trim(),
+            BodyHtml = request.HtmlBody,
+            CreatedByUserId = createdByUserId,
+            CreateDate = now,
+            LastUpdate = now
+        };
+
+        entity = await templateCommand.Add(entity, saveChanges: true, ct);
+        return mapper.Map<EmailBroadcastTemplateDto>(entity);
+    }
+
+    public async Task<EmailBroadcastTemplateDto> UpdateAsync(int id, UpdateEmailTemplateRequest request,
+        CancellationToken ct)
+    {
+        Validate(request.Name, request.Subject, request.HtmlBody);
+        var name = request.Name.Trim();
+        if (await templateQuery.Any(t => t.Name == name && t.Id != id, ct))
+            throw new ArgumentException($"Another template is already named '{name}'.");
+
+        var entity = await templateQuery.FindById(id, asNoTracking: false, ct: ct)
+                     ?? throw new KeyNotFoundException($"Template {id} not found.");
+
+        entity.Name = name;
+        entity.Description = string.IsNullOrWhiteSpace(request.Description) ? null : request.Description.Trim();
+        entity.Subject = request.Subject.Trim();
+        entity.BodyHtml = request.HtmlBody;
+        entity.LastUpdate = DateTimeOffset.UtcNow;
+
+        await templateCommand.Update(entity, saveChanges: true, ct);
+        return mapper.Map<EmailBroadcastTemplateDto>(entity);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken ct)
+    {
+        var entity = await templateQuery.FindById(id, asNoTracking: false, ct: ct)
+                     ?? throw new KeyNotFoundException($"Template {id} not found.");
+        await templateCommand.Delete(entity, saveChanges: true, ct);
+    }
+
+    private static void Validate(string name, string subject, string html)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Template name is required.");
+        if (name.Trim().Length > 128)
+            throw new ArgumentException("Name must be at most 128 characters.");
+        if (string.IsNullOrWhiteSpace(subject))
+            throw new ArgumentException("Subject is required.");
+        if (string.IsNullOrWhiteSpace(html))
+            throw new ArgumentException("HTML body is required.");
+        if (html.Length > MaxHtmlLength)
+            throw new ArgumentException($"HTML body exceeds {MaxHtmlLength} characters.");
+    }
+}

--- a/DataGateMonitor/Services/AdminEmail/IAdminEmailBroadcastService.cs
+++ b/DataGateMonitor/Services/AdminEmail/IAdminEmailBroadcastService.cs
@@ -1,0 +1,11 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+
+namespace DataGateMonitor.Services.AdminEmail;
+
+public interface IAdminEmailBroadcastService
+{
+    Task<GetSentEmailHistoryResponse> GetHistoryAsync(GetSentEmailHistoryRequest request, CancellationToken ct);
+
+    Task<SendAdminEmailResponse> SendAsync(SendAdminEmailRequest request, int? sentByUserId, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/AdminEmail/IAdminEmailTemplateService.cs
+++ b/DataGateMonitor/Services/AdminEmail/IAdminEmailTemplateService.cs
@@ -1,0 +1,19 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+
+namespace DataGateMonitor.Services.AdminEmail;
+
+public interface IAdminEmailTemplateService
+{
+    Task<GetEmailTemplatesResponse> ListSummariesAsync(CancellationToken ct);
+
+    Task<EmailBroadcastTemplateDto?> GetByIdAsync(int id, CancellationToken ct);
+
+    Task<EmailBroadcastTemplateDto> CreateAsync(CreateEmailTemplateRequest request, int? createdByUserId,
+        CancellationToken ct);
+
+    Task<EmailBroadcastTemplateDto> UpdateAsync(int id, UpdateEmailTemplateRequest request, CancellationToken ct);
+
+    Task DeleteAsync(int id, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/AdminEmail/ISentEmailLogService.cs
+++ b/DataGateMonitor/Services/AdminEmail/ISentEmailLogService.cs
@@ -1,0 +1,15 @@
+namespace DataGateMonitor.Services.AdminEmail;
+
+/// <summary>Appends a row to SentEmailLogs for any outbound transactional email.</summary>
+public interface ISentEmailLogService
+{
+    Task LogAsync(
+        int? recipientUserId,
+        string recipientEmail,
+        string subject,
+        string bodyHtml,
+        bool success,
+        string? errorMessage,
+        int? sentByUserId,
+        CancellationToken ct);
+}

--- a/DataGateMonitor/Services/AdminEmail/SentEmailLogService.cs
+++ b/DataGateMonitor/Services/AdminEmail/SentEmailLogService.cs
@@ -1,0 +1,44 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.Services.AdminEmail;
+
+public sealed class SentEmailLogService(ICommandService<SentEmailLog, int> command) : ISentEmailLogService
+{
+    private const int MaxErrorLen = 4000;
+
+    public async Task LogAsync(
+        int? recipientUserId,
+        string recipientEmail,
+        string subject,
+        string bodyHtml,
+        bool success,
+        string? errorMessage,
+        int? sentByUserId,
+        CancellationToken ct)
+    {
+        var email = (recipientEmail ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(email))
+            return;
+
+        var now = DateTimeOffset.UtcNow;
+        var err = errorMessage;
+        if (err != null && err.Length > MaxErrorLen)
+            err = err[..MaxErrorLen];
+
+        var log = new SentEmailLog
+        {
+            RecipientUserId = recipientUserId,
+            RecipientEmail = email,
+            Subject = (subject ?? string.Empty).Trim().Length > 0 ? subject!.Trim() : "(no subject)",
+            BodyHtml = bodyHtml ?? string.Empty,
+            Success = success,
+            ErrorMessage = err,
+            SentByUserId = sentByUserId,
+            CreateDate = now,
+            LastUpdate = now
+        };
+
+        await command.Add(log, saveChanges: true, ct);
+    }
+}

--- a/DataGateMonitor/Services/Api/Auth/EmailConfirmation/EmailConfirmationService.cs
+++ b/DataGateMonitor/Services/Api/Auth/EmailConfirmation/EmailConfirmationService.cs
@@ -1,10 +1,11 @@
 using System.Collections.Concurrent;
-using System.Net;
 using System.Security.Cryptography;
 using Microsoft.Extensions.Caching.Memory;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.Services.EmailTemplates;
 using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.Api.Auth.EmailConfirmation.Models;
 
@@ -15,7 +16,9 @@ public sealed class EmailConfirmationService(
     IUserQueryService userQueryService,
     ICommandService<User, int> userCommandService,
     IEmailSenderService emailSenderService,
-    ISettingsService settingsService) : IEmailConfirmationService
+    ISettingsService settingsService,
+    ISentEmailLogService sentEmailLogService,
+    ISystemTransactionalEmailService systemTransactionalEmail) : IEmailConfirmationService
 {
     private const int CodeLength = 6;
     private const int DefaultCodeTtlMinutes = 30;
@@ -46,9 +49,28 @@ public sealed class EmailConfirmationService(
                 AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(codeTtlMinutes)
             });
 
-        var subject = "Confirm your DataGate email";
-        var body = BuildEmailConfirmationHtml(code, codeTtlMinutes);
-        await emailSenderService.SendAsync(email, subject, body, ct);
+        var (subject, body) = await systemTransactionalEmail.GetEmailConfirmationAsync(code, codeTtlMinutes, ct);
+        try
+        {
+            await emailSenderService.SendAsync(email, subject, body, ct);
+            await sentEmailLogService.LogAsync(userId, email, subject, body, true, null, null, ct);
+        }
+        catch (Exception ex)
+        {
+            var msg = ex.Message;
+            if (msg.Length > 4000)
+                msg = msg[..4000];
+            try
+            {
+                await sentEmailLogService.LogAsync(userId, email, subject, body, false, msg, null, ct);
+            }
+            catch
+            {
+                // ignore secondary logging failures
+            }
+
+            throw;
+        }
     }
 
     public async Task<ConfirmEmailResponse> ConfirmAsync(string email, string code, CancellationToken ct)
@@ -148,71 +170,4 @@ public sealed class EmailConfirmationService(
         return value;
     }
 
-    private static string BuildEmailConfirmationHtml(string code, int codeTtlMinutes)
-    {
-        var safeCode = WebUtility.HtmlEncode(code);
-        return $"""
-                <!doctype html>
-                <html lang="en">
-                <head>
-                  <meta charset="UTF-8">
-                  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                  <title>DataGate Email Confirmation</title>
-                </head>
-                <body style="margin:0;padding:0;background:#0d1117;color:#c9d1d9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;">
-                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0d1117;padding:24px 12px;">
-                    <tr>
-                      <td align="center">
-                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:640px;background:linear-gradient(180deg,rgba(18,23,30,0.96),rgba(13,17,23,0.99));border:1px solid #30363d;border-radius:14px;overflow:hidden;">
-                          <tr>
-                            <td style="padding:28px 28px 12px 28px;">
-                              <div style="display:inline-block;padding:6px 12px;border-radius:999px;background:rgba(56,139,253,0.14);border:1px solid rgba(88,166,255,0.24);color:#9ecbff;font-size:12px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;">DataGate</div>
-                              <h1 style="margin:16px 0 8px 0;font-size:28px;line-height:1.2;color:#ffffff;">Confirm your email</h1>
-                              <p style="margin:0;color:#8b949e;font-size:15px;line-height:1.6;">
-                                Use the confirmation code below to finish registration in DataGate.
-                              </p>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td style="padding:8px 28px 22px 28px;">
-                              <div style="background:#161b22;border:1px solid #30363d;border-radius:12px;padding:18px;text-align:center;">
-                                <div style="font-size:12px;color:#8b949e;letter-spacing:.08em;text-transform:uppercase;margin-bottom:8px;">Confirmation code</div>
-                                <div style="font-size:34px;font-weight:700;letter-spacing:6px;color:#58a6ff;">{safeCode}</div>
-                                <div style="margin-top:10px;font-size:13px;color:#8b949e;">Valid for {codeTtlMinutes} minutes</div>
-                              </div>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td style="padding:0 28px 18px 28px;">
-                              <div style="background:#161b22;border:1px solid #30363d;border-radius:12px;padding:16px;">
-                                <p style="margin:0 0 8px 0;color:#c9d1d9;font-size:14px;font-weight:600;">Get DataGate clients</p>
-                                <p style="margin:0 0 10px 0;color:#8b949e;font-size:14px;">Download all available clients here:</p>
-                                <a href="https://datagateapp.com/download" style="color:#58a6ff;text-decoration:none;">https://datagateapp.com/download</a>
-                              </div>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td style="padding:0 28px 28px 28px;">
-                              <div style="background:#161b22;border:1px solid #30363d;border-radius:12px;padding:16px;">
-                                <p style="margin:0 0 8px 0;color:#c9d1d9;font-size:14px;font-weight:600;">Follow our Telegram channel</p>
-                                <a href="https://t.me/datagateapp" style="color:#58a6ff;text-decoration:none;">https://t.me/datagateapp</a>
-                              </div>
-                            </td>
-                          </tr>
-                          <tr>
-                            <td style="padding:0 28px 28px 28px;">
-                              <p style="margin:0;color:#6e7681;font-size:12px;line-height:1.6;">
-                                If you did not request this email, you can safely ignore it.<br>
-                                DataGate Team
-                              </p>
-                            </td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
-                </body>
-                </html>
-                """;
-    }
 }

--- a/DataGateMonitor/Services/Api/Auth/ForgotPassword/AdminForgotPasswordService.cs
+++ b/DataGateMonitor/Services/Api/Auth/ForgotPassword/AdminForgotPasswordService.cs
@@ -8,6 +8,10 @@ using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
 using DataGateMonitor.DataBase.Services.Query.UserRoleTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+using DataGateMonitor.Services.EmailTemplates;
+using DataGateMonitor.Services.Others.Notifications;
 using DataGateMonitor.SharedModels.Auth;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
@@ -21,6 +25,10 @@ public sealed class AdminForgotPasswordService(
     ICommandService<UserCredential, int> credentialCommandService,
     IPasswordHasher<User> passwordHasher,
     IMemoryCache cache,
+    IEmailSenderService emailSender,
+    ISentEmailLogService sentEmailLogService,
+    ISystemTransactionalEmailService systemTransactionalEmail,
+    IAppNotificationFacade appNotificationFacade,
     ILogger<AdminForgotPasswordService> logger) : IAdminForgotPasswordService
 {
     private const int RateLimitWindowMinutes = 15;
@@ -31,7 +39,7 @@ public sealed class AdminForgotPasswordService(
     private static readonly ConcurrentDictionary<string, object> RateLimitLocks = new();
 
     public const string SameMessageForAll =
-        "If an admin account with this login exists and uses password sign-in, a reset code has been written to the server console. Otherwise, no such user was found.";
+        "If an admin account with this login exists and uses password sign-in, a reset code has been sent to the account email (when configured) and written to the server console. Otherwise, no such user was found.";
 
     public const string RateLimitMessage = "Too many requests. Try again later.";
 
@@ -78,8 +86,33 @@ public sealed class AdminForgotPasswordService(
         var expiry = TimeSpan.FromMinutes(CodeExpirationMinutes);
         cache.Set($"forgotpwd:code:{code}", credential.UserId, new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = expiry });
 
+        var (subject, body) = await systemTransactionalEmail.GetAdminPasswordResetAsync(code, CodeExpirationMinutes, ct);
+
+        if (!string.IsNullOrWhiteSpace(user.Email))
+        {
+            var to = user.Email.Trim();
+            try
+            {
+                await emailSender.SendAsync(to, subject, body, ct);
+                await sentEmailLogService.LogAsync(user.Id, to, subject, body, true, null, null, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to send admin reset email to {Email}", to);
+                try
+                {
+                    var msg = ex.Message.Length > 4000 ? ex.Message[..4000] : ex.Message;
+                    await sentEmailLogService.LogAsync(user.Id, to, subject, body, false, msg, null, ct);
+                }
+                catch
+                {
+                    // ignore secondary logging failures
+                }
+            }
+        }
+
         logger.LogInformation(
-            "Admin password reset code for login '{Login}' (userId={UserId}): {Code}. Valid for {Minutes} minutes. Get it from the server console.",
+            "Admin password reset code for login '{Login}' (userId={UserId}): {Code}. Valid for {Minutes} minutes. Check email (if sent) or server console.",
             credential.Login,
             credential.UserId,
             code,
@@ -121,6 +154,20 @@ public sealed class AdminForgotPasswordService(
         credential.FailedCount = 0;
         credential.LockoutUntilUtc = null;
         await credentialCommandService.Update(credential, saveChanges: true, ct);
+
+        try
+        {
+            await appNotificationFacade.UserPasswordChanged(
+                user.Id,
+                user.DisplayName ?? user.Email ?? "",
+                credential.Login,
+                "reset-password (one-time code)",
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to notify admins about password reset for user {UserId}", user.Id);
+        }
 
         return new AdminResetPasswordResponse { Success = true, Message = "Password has been reset." };
     }

--- a/DataGateMonitor/Services/Api/Auth/ForgotPassword/AdminForgotPasswordService.cs
+++ b/DataGateMonitor/Services/Api/Auth/ForgotPassword/AdminForgotPasswordService.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
-using DataGateMonitor.DataBase.Services.Query.UserRoleTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.AdminEmail;
@@ -21,7 +20,6 @@ namespace DataGateMonitor.Services.Api.Auth.ForgotPassword;
 public sealed class AdminForgotPasswordService(
     IUserCredentialQueryService credentialQueryService,
     IUserQueryService userQueryService,
-    IUserRoleQueryService userRoleQueryService,
     ICommandService<UserCredential, int> credentialCommandService,
     IPasswordHasher<User> passwordHasher,
     IMemoryCache cache,
@@ -39,7 +37,7 @@ public sealed class AdminForgotPasswordService(
     private static readonly ConcurrentDictionary<string, object> RateLimitLocks = new();
 
     public const string SameMessageForAll =
-        "If an admin account with this login exists and uses password sign-in, a reset code has been sent to the account email (when configured) and written to the server console. Otherwise, no such user was found.";
+        "If an account with this login or email exists and uses password sign-in, a reset code has been sent to the account email (when configured) and written to the server console. Otherwise, no such user was found.";
 
     public const string RateLimitMessage = "Too many requests. Try again later.";
 
@@ -78,10 +76,6 @@ public sealed class AdminForgotPasswordService(
         if (user is null)
             return new AdminForgotPasswordResponse { Message = SameMessageForAll };
 
-        var role = await userRoleQueryService.GetByUserId(user.Id, ct);
-        if (role is null || role.RoleId != SystemRoles.AdminId)
-            return new AdminForgotPasswordResponse { Message = SameMessageForAll };
-
         var code = GenerateCode();
         var expiry = TimeSpan.FromMinutes(CodeExpirationMinutes);
         cache.Set($"forgotpwd:code:{code}", credential.UserId, new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = expiry });
@@ -112,7 +106,7 @@ public sealed class AdminForgotPasswordService(
         }
 
         logger.LogInformation(
-            "Admin password reset code for login '{Login}' (userId={UserId}): {Code}. Valid for {Minutes} minutes. Check email (if sent) or server console.",
+            "Password reset code for login '{Login}' (userId={UserId}): {Code}. Valid for {Minutes} minutes. Check email (if sent) or server console.",
             credential.Login,
             credential.UserId,
             code,

--- a/DataGateMonitor/Services/Api/Auth/Handlers/VpnServerAccessQueryService.cs
+++ b/DataGateMonitor/Services/Api/Auth/Handlers/VpnServerAccessQueryService.cs
@@ -13,7 +13,7 @@ public sealed class VpnServerAccessQueryService(
     {
         var userQuotaPlan = await userQuotaPlanQueryService.GetActiveByUserId(userId, ct);
         if (userQuotaPlan is null)
-            return false;
+            return true;
 
         var quotaPlanId = userQuotaPlan.QuotaPlanId;
 

--- a/DataGateMonitor/Services/Api/Auth/Login/TokenService.cs
+++ b/DataGateMonitor/Services/Api/Auth/Login/TokenService.cs
@@ -170,6 +170,9 @@ public sealed class TokenService(
             new("email", user.Email ?? string.Empty),
         };
 
+        if (!string.IsNullOrWhiteSpace(user.AvatarUrl))
+            claims.Add(new Claim("avatarUrl", user.AvatarUrl));
+
         var tokenDescriptor = new JwtSecurityToken(
             issuer: issuer,
             audience: audience,

--- a/DataGateMonitor/Services/Api/Auth/Login/UserLoginService.cs
+++ b/DataGateMonitor/Services/Api/Auth/Login/UserLoginService.cs
@@ -135,6 +135,14 @@ public sealed class UserLoginService(
             await userCommandService.Update(user, saveChanges: true, ct);
         }
 
+        var normalizedPicture = NormalizeGoogleProfilePictureUrl(googleUser.Picture);
+        if (!string.IsNullOrEmpty(normalizedPicture)
+            && !string.Equals(user.AvatarUrl ?? "", normalizedPicture, StringComparison.Ordinal))
+        {
+            user.AvatarUrl = normalizedPicture;
+            await userCommandService.Update(user, saveChanges: true, ct);
+        }
+
         var (deviceId, userAgent) = GetClientInfo();
 
         var tokenPair = await tokenService.IssueAsync(
@@ -153,8 +161,25 @@ public sealed class UserLoginService(
             UserId = user.Id,
             DisplayName = user.DisplayName,
             Email = user.Email,
-            IsNewUser = isNew
+            IsNewUser = isNew,
+            AvatarUrl = user.AvatarUrl
         };
+    }
+
+    /// <summary>Google profile images are HTTPS URLs; reject anything else.</summary>
+    private static string? NormalizeGoogleProfilePictureUrl(string? picture)
+    {
+        if (string.IsNullOrWhiteSpace(picture))
+            return null;
+
+        var t = picture.Trim();
+        if (t.Length > 2048)
+            t = t[..2048];
+
+        if (!t.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return t;
     }
 
     private (string? DeviceId, string? UserAgent) GetClientInfo()

--- a/DataGateMonitor/Services/Api/Auth/Registers/GoogleTokenValidator.cs
+++ b/DataGateMonitor/Services/Api/Auth/Registers/GoogleTokenValidator.cs
@@ -45,7 +45,8 @@ public sealed class GoogleTokenValidator(IConfiguration configuration) : IGoogle
             Subject = payload.Subject,
             Email = payload.Email,
             EmailVerified = payload.EmailVerified,
-            Name = payload.Name
+            Name = payload.Name,
+            Picture = string.IsNullOrWhiteSpace(payload.Picture) ? null : payload.Picture.Trim()
         };
     }
 }

--- a/DataGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
+++ b/DataGateMonitor/Services/Api/Auth/Registers/UserRegistrationService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -7,6 +8,7 @@ using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Users;
 using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.Others.Notifications;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
 
@@ -19,7 +21,9 @@ public sealed class UserRegistrationService(
     IUserQueryService userQueryService,
     IUserAccountService userAccountService,
     IEmailConfirmationService emailConfirmationService,
-    ISettingsService settingsService
+    ISettingsService settingsService,
+    IAppNotificationFacade appNotificationFacade,
+    ILogger<UserRegistrationService> logger
 ) : IUserRegistrationService
 {
     public async Task<RegisterUserResponse> RegisterAsync(RegisterUserRequest request, CancellationToken ct)
@@ -86,10 +90,19 @@ public sealed class UserRegistrationService(
         if (requireEmailConfirmation && !string.IsNullOrWhiteSpace(user.Email))
             await emailConfirmationService.SendConfirmationAsync(user.Id, user.Email, ct);
 
+        try
+        {
+            await appNotificationFacade.UserRegistered(user.Id, user.DisplayName ?? "", login, user.Email, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to notify admins about new user {UserId}", user.Id);
+        }
+
         return new RegisterUserResponse
         {
             UserId = user.Id,
-            DisplayName = user.DisplayName,
+            DisplayName = user.DisplayName ?? "",
             Email = user.Email,
             HasDashboardAccess = user.HasDashboardAccess
         };

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/CrashIngestMetrics.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/CrashIngestMetrics.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.Metrics;
+
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public sealed class CrashIngestMetrics : ICrashIngestMetrics, IDisposable
+{
+    private readonly Meter _meter = new("DataGateMonitor.MobileCrashIngest", "1.0.0");
+    private readonly Counter<long> _acceptedCounter;
+    private readonly Counter<long> _rejected4xxCounter;
+    private readonly Counter<long> _rejected5xxCounter;
+    private readonly Histogram<long> _payloadSizeBytes;
+
+    private long _acceptedPayloadBytesTotal;
+    private long _acceptedCount;
+
+    public CrashIngestMetrics()
+    {
+        _acceptedCounter = _meter.CreateCounter<long>("mobile_crash_ingest_accepted");
+        _rejected4xxCounter = _meter.CreateCounter<long>("mobile_crash_ingest_rejected_4xx");
+        _rejected5xxCounter = _meter.CreateCounter<long>("mobile_crash_ingest_rejected_5xx");
+        _payloadSizeBytes = _meter.CreateHistogram<long>("mobile_crash_ingest_payload_size_bytes");
+        _meter.CreateObservableGauge<double>(
+            "mobile_crash_ingest_avg_payload_size_bytes",
+            ObserveAveragePayloadSize);
+    }
+
+    public void RecordAccepted(int payloadBytes)
+    {
+        _acceptedCounter.Add(1);
+        _payloadSizeBytes.Record(payloadBytes);
+        Interlocked.Add(ref _acceptedPayloadBytesTotal, payloadBytes);
+        Interlocked.Increment(ref _acceptedCount);
+    }
+
+    public void RecordRejected4xx() => _rejected4xxCounter.Add(1);
+
+    public void RecordRejected5xx() => _rejected5xxCounter.Add(1);
+
+    public void Dispose()
+    {
+        _meter.Dispose();
+    }
+
+    private IEnumerable<Measurement<double>> ObserveAveragePayloadSize()
+    {
+        var count = Interlocked.Read(ref _acceptedCount);
+        if (count <= 0)
+            return [new Measurement<double>(0)];
+
+        var total = Interlocked.Read(ref _acceptedPayloadBytesTotal);
+        var avg = total / (double)count;
+        return [new Measurement<double>(avg)];
+    }
+}

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/CrashReportParseResult.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/CrashReportParseResult.cs
@@ -1,0 +1,26 @@
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public sealed class CrashReportParseResult
+{
+    public bool IsParsed { get; init; }
+
+    public DateTimeOffset? TimestampUtc { get; init; }
+
+    public string? Process { get; init; }
+
+    public string? Thread { get; init; }
+
+    public string? Sdk { get; init; }
+
+    public string? Device { get; init; }
+
+    public string? Kind { get; init; }
+
+    public string? Exception { get; init; }
+
+    public string? Message { get; init; }
+
+    public string? Tag { get; init; }
+
+    public string? Stacktrace { get; init; }
+}

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/CrashReportParser.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/CrashReportParser.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public sealed class CrashReportParser : ICrashReportParser
+{
+    private static readonly StringComparer KeyComparer = StringComparer.OrdinalIgnoreCase;
+
+    public CrashReportParseResult Parse(string payloadRaw)
+    {
+        if (string.IsNullOrWhiteSpace(payloadRaw))
+            return new CrashReportParseResult { IsParsed = false };
+
+        var normalized = payloadRaw.Replace("\r\n", "\n");
+        var splitIndex = normalized.IndexOf("\n\n", StringComparison.Ordinal);
+        if (splitIndex < 0)
+            return new CrashReportParseResult { IsParsed = false, Stacktrace = null };
+
+        var headerBlock = normalized[..splitIndex];
+        var stacktrace = normalized[(splitIndex + 2)..].Trim();
+
+        if (string.IsNullOrWhiteSpace(headerBlock))
+            return new CrashReportParseResult { IsParsed = false, Stacktrace = stacktrace };
+
+        var parsedPairs = new Dictionary<string, string>(KeyComparer);
+        var headerLines = headerBlock.Split('\n', StringSplitOptions.TrimEntries);
+        foreach (var line in headerLines)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var separatorIndex = line.IndexOf('=');
+            if (separatorIndex <= 0 || separatorIndex == line.Length - 1)
+                return new CrashReportParseResult { IsParsed = false, Stacktrace = stacktrace };
+
+            var key = line[..separatorIndex].Trim();
+            var value = line[(separatorIndex + 1)..].Trim();
+
+            if (string.IsNullOrWhiteSpace(key))
+                return new CrashReportParseResult { IsParsed = false, Stacktrace = stacktrace };
+
+            parsedPairs[key] = value;
+        }
+
+        if (parsedPairs.Count == 0)
+            return new CrashReportParseResult { IsParsed = false, Stacktrace = stacktrace };
+
+        parsedPairs.TryGetValue("timestamp_utc", out var timestampRaw);
+        parsedPairs.TryGetValue("process", out var process);
+        parsedPairs.TryGetValue("thread", out var thread);
+        parsedPairs.TryGetValue("sdk", out var sdk);
+        parsedPairs.TryGetValue("device", out var device);
+        parsedPairs.TryGetValue("kind", out var kind);
+        parsedPairs.TryGetValue("exception", out var exception);
+        parsedPairs.TryGetValue("message", out var message);
+        parsedPairs.TryGetValue("tag", out var tag);
+
+        DateTimeOffset? timestampUtc = null;
+        if (!string.IsNullOrWhiteSpace(timestampRaw) &&
+            DateTimeOffset.TryParse(timestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsedTimestamp))
+        {
+            timestampUtc = parsedTimestamp.ToUniversalTime();
+        }
+
+        return new CrashReportParseResult
+        {
+            IsParsed = true,
+            TimestampUtc = timestampUtc,
+            Process = EmptyToNull(process),
+            Thread = EmptyToNull(thread),
+            Sdk = EmptyToNull(sdk),
+            Device = EmptyToNull(device),
+            Kind = EmptyToNull(kind),
+            Exception = EmptyToNull(exception),
+            Message = EmptyToNull(message),
+            Tag = EmptyToNull(tag),
+            Stacktrace = string.IsNullOrWhiteSpace(stacktrace) ? null : stacktrace
+        };
+    }
+
+    private static string? EmptyToNull(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+}

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/ICrashIngestMetrics.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/ICrashIngestMetrics.cs
@@ -1,0 +1,10 @@
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public interface ICrashIngestMetrics
+{
+    void RecordAccepted(int payloadBytes);
+
+    void RecordRejected4xx();
+
+    void RecordRejected5xx();
+}

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/ICrashIngestRateLimiter.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/ICrashIngestRateLimiter.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public interface ICrashIngestRateLimiter
+{
+    bool TryConsume(string key, out int retryAfterSeconds);
+}

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/ICrashReportParser.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/ICrashReportParser.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public interface ICrashReportParser
+{
+    CrashReportParseResult Parse(string payloadRaw);
+}

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/MemoryCrashIngestRateLimiter.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/MemoryCrashIngestRateLimiter.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+using DataGateMonitor.Configurations;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public sealed class MemoryCrashIngestRateLimiter(
+    IMemoryCache cache,
+    IOptions<CrashIngestOptions> options) : ICrashIngestRateLimiter
+{
+    private static readonly ConcurrentDictionary<string, object> Locks = new();
+
+    public bool TryConsume(string key, out int retryAfterSeconds)
+    {
+        var windowSeconds = Math.Max(1, options.Value.RateLimitWindowSeconds);
+        var maxRequests = Math.Max(1, options.Value.RateLimitMaxRequests);
+        retryAfterSeconds = windowSeconds;
+
+        var lockObject = Locks.GetOrAdd(key, _ => new object());
+        lock (lockObject)
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (!cache.TryGetValue(key, out RateLimitEntry? entry) || entry is null)
+            {
+                cache.Set(key, new RateLimitEntry(now, 1), TimeSpan.FromSeconds(windowSeconds + 1));
+                return true;
+            }
+
+            var elapsed = now - entry.FirstRequestUtc;
+            if (elapsed.TotalSeconds > windowSeconds)
+            {
+                cache.Set(key, new RateLimitEntry(now, 1), TimeSpan.FromSeconds(windowSeconds + 1));
+                return true;
+            }
+
+            if (entry.Count >= maxRequests)
+            {
+                var secondsLeft = windowSeconds - (int)elapsed.TotalSeconds;
+                retryAfterSeconds = Math.Max(1, secondsLeft);
+                return false;
+            }
+
+            cache.Set(key, new RateLimitEntry(entry.FirstRequestUtc, entry.Count + 1), TimeSpan.FromSeconds(windowSeconds + 1));
+            return true;
+        }
+    }
+
+    private sealed record RateLimitEntry(DateTimeOffset FirstRequestUtc, int Count);
+}

--- a/DataGateMonitor/Services/Api/MobileCrashIngest/MobileCrashIngestService.cs
+++ b/DataGateMonitor/Services/Api/MobileCrashIngest/MobileCrashIngestService.cs
@@ -1,0 +1,138 @@
+using System.Text.RegularExpressions;
+using DataGateMonitor.DataBase.Contexts;
+using DataGateMonitor.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DataGateMonitor.Services.Api.MobileCrashIngest;
+
+public interface IMobileCrashIngestService
+{
+    Task SaveAsync(string appProcess, string fileName, string payloadRaw, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<RecentCrashReportDto>> GetRecentAsync(int limit, CancellationToken cancellationToken);
+}
+
+public sealed class MobileCrashIngestService(
+    ApplicationDbContext dbContext,
+    ICrashReportParser parser) : IMobileCrashIngestService
+{
+    private static readonly Regex EmailRegex = new(
+        @"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex SecretRegex = new(
+        @"(?im)\b(password|passwd|token|secret|authorization|api[_-]?key)\b\s*[:=]\s*(.+)$",
+        RegexOptions.Compiled);
+
+    public async Task SaveAsync(string appProcess, string fileName, string payloadRaw, CancellationToken cancellationToken)
+    {
+        var parsed = parser.Parse(payloadRaw);
+        var row = new MobileCrashReport
+        {
+            AppProcess = appProcess,
+            FileName = fileName,
+            PayloadRaw = payloadRaw,
+            ParseStatus = parsed.IsParsed ? "parsed" : "failed",
+            TimestampUtc = parsed.TimestampUtc,
+            Process = parsed.Process,
+            Thread = parsed.Thread,
+            Sdk = parsed.Sdk,
+            Device = parsed.Device,
+            Kind = parsed.Kind,
+            Exception = parsed.Exception,
+            Message = parsed.Message,
+            Tag = parsed.Tag,
+            Stacktrace = parsed.Stacktrace
+        };
+
+        dbContext.MobileCrashReports.Add(row);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<RecentCrashReportDto>> GetRecentAsync(int limit, CancellationToken cancellationToken)
+    {
+        var rows = await dbContext.MobileCrashReports
+            .OrderByDescending(x => x.CreateDate)
+            .Take(limit)
+            .Select(x => new
+            {
+                x.Id,
+                ReceivedAt = x.CreateDate,
+                x.AppProcess,
+                x.FileName,
+                x.ParseStatus,
+                x.TimestampUtc,
+                x.Process,
+                x.Thread,
+                x.Sdk,
+                x.Device,
+                x.Kind,
+                x.Exception,
+                x.Message,
+                x.Tag,
+                x.Stacktrace,
+                x.PayloadRaw
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows
+            .Select(x => new RecentCrashReportDto
+            {
+                Id = x.Id,
+                ReceivedAt = x.ReceivedAt.UtcDateTime,
+                AppProcess = x.AppProcess,
+                FileName = x.FileName,
+                ParseStatus = x.ParseStatus,
+                TimestampUtc = x.TimestampUtc?.UtcDateTime,
+                Process = x.Process,
+                Thread = x.Thread,
+                Sdk = x.Sdk,
+                Device = x.Device,
+                Kind = x.Kind,
+                Exception = x.Exception,
+                Message = MaskSensitive(x.Message),
+                Tag = x.Tag,
+                Stacktrace = Truncate(MaskSensitive(x.Stacktrace), 8000),
+                PayloadRaw = Truncate(MaskSensitive(x.PayloadRaw), 8000)
+            })
+            .ToList();
+    }
+
+    private static string? MaskSensitive(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return value;
+
+        var masked = EmailRegex.Replace(value, "[redacted-email]");
+        masked = SecretRegex.Replace(masked, "$1=[redacted]");
+        return masked;
+    }
+
+    private static string? Truncate(string? value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= maxLength)
+            return value;
+
+        return value[..maxLength] + "...[truncated]";
+    }
+}
+
+public sealed class RecentCrashReportDto
+{
+    public long Id { get; set; }
+    public DateTime ReceivedAt { get; set; }
+    public string AppProcess { get; set; } = null!;
+    public string FileName { get; set; } = null!;
+    public string ParseStatus { get; set; } = null!;
+    public DateTime? TimestampUtc { get; set; }
+    public string? Process { get; set; }
+    public string? Thread { get; set; }
+    public string? Sdk { get; set; }
+    public string? Device { get; set; }
+    public string? Kind { get; set; }
+    public string? Exception { get; set; }
+    public string? Message { get; set; }
+    public string? Tag { get; set; }
+    public string? Stacktrace { get; set; }
+    public string? PayloadRaw { get; set; }
+}

--- a/DataGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
+++ b/DataGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
@@ -75,8 +75,13 @@ public class OpenVpnBackgroundService : BackgroundService, IOpenVpnBackgroundSer
             var openVpnServers = await openVpnServerQueryService.GetAll(ct: cancellationToken);
             _statusManager.ClearAllStatuses();
 
-            openVpnServers = openVpnServers.Where(x => x.IsDisable != true).ToList();
-            await Parallel.ForEachAsync(openVpnServers, cancellationToken, async (server, ct) =>
+            // Disabled rows are never polled — still publish Idle so the status stream is not empty and
+            // clients do not treat "missing server" as Pending for the whole fleet.
+            foreach (var skipped in openVpnServers.Where(s => s.IsDisable))
+                _statusManager.UpdateStatus(skipped.Id, ServiceStatus.Idle, nextRunSeconds);
+
+            var serversToPoll = openVpnServers.Where(x => x.IsDisable != true).ToList();
+            await Parallel.ForEachAsync(serversToPoll, cancellationToken, async (server, ct) =>
             {
                 _logger.LogInformation(
                     $"VpnServerId: {server.Id}. VpnServerName: {server.ServerName} Processing server: {server.ApiUrl}");

--- a/DataGateMonitor/Services/EmailTemplates/ISystemTransactionalEmailService.cs
+++ b/DataGateMonitor/Services/EmailTemplates/ISystemTransactionalEmailService.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.Services.EmailTemplates;
+
+public interface ISystemTransactionalEmailService
+{
+    Task<(string Subject, string BodyHtml)> GetEmailConfirmationAsync(string code, int ttlMinutes, CancellationToken ct);
+
+    Task<(string Subject, string BodyHtml)> GetAdminPasswordResetAsync(string code, int ttlMinutes, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/EmailTemplates/SystemTransactionalEmailService.cs
+++ b/DataGateMonitor/Services/EmailTemplates/SystemTransactionalEmailService.cs
@@ -1,0 +1,50 @@
+using DataGateMonitor.DataBase.Services.Query;
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.EmailTemplates;
+
+namespace DataGateMonitor.Services.EmailTemplates;
+
+public sealed class SystemTransactionalEmailService(IQueryService<EmailBroadcastTemplate, int> templateQuery)
+    : ISystemTransactionalEmailService
+{
+    public async Task<(string Subject, string BodyHtml)> GetEmailConfirmationAsync(string code, int ttlMinutes,
+        CancellationToken ct)
+    {
+        var entity = await templateQuery.FirstOrDefault(
+            t => t.Name == SystemEmailTemplateNames.EmailConfirmation,
+            orderBy: q => q.OrderBy(t => t.Id),
+            asNoTracking: true,
+            ct: ct);
+
+        if (entity is { BodyHtml: { Length: > 0 } body })
+        {
+            var subject = string.IsNullOrWhiteSpace(entity.Subject)
+                ? TransactionalEmailHtml.DefaultConfirmationSubject
+                : entity.Subject.Trim();
+            return (subject, TransactionalEmailHtml.ApplyConfirmationPlaceholders(body, code, ttlMinutes));
+        }
+
+        return (TransactionalEmailHtml.DefaultConfirmationSubject, TransactionalEmailHtml.BuildEmailConfirmation(code, ttlMinutes));
+    }
+
+    public async Task<(string Subject, string BodyHtml)> GetAdminPasswordResetAsync(string code, int ttlMinutes,
+        CancellationToken ct)
+    {
+        var entity = await templateQuery.FirstOrDefault(
+            t => t.Name == SystemEmailTemplateNames.AdminPasswordReset,
+            orderBy: q => q.OrderBy(t => t.Id),
+            asNoTracking: true,
+            ct: ct);
+
+        if (entity is { BodyHtml: { Length: > 0 } body })
+        {
+            var subject = string.IsNullOrWhiteSpace(entity.Subject)
+                ? TransactionalEmailHtml.DefaultAdminPasswordResetSubject
+                : entity.Subject.Trim();
+            return (subject, TransactionalEmailHtml.ApplyPasswordResetPlaceholders(body, code, ttlMinutes));
+        }
+
+        return (TransactionalEmailHtml.DefaultAdminPasswordResetSubject,
+            TransactionalEmailHtml.BuildAdminPasswordReset(code, ttlMinutes));
+    }
+}

--- a/DataGateMonitor/Services/Others/Notifications/AppNotificationFacade.cs
+++ b/DataGateMonitor/Services/Others/Notifications/AppNotificationFacade.cs
@@ -33,4 +33,16 @@ public class AppNotificationFacade(
         var env = catalog.ServerUp(serverId, serverName);
         return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
     }
+
+    public Task UserRegistered(int userId, string displayName, string? login, string? email, CancellationToken ct)
+    {
+        var env = catalog.UserRegistered(userId, displayName, login, email);
+        return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
+    }
+
+    public Task UserPasswordChanged(int userId, string displayName, string login, string reason, CancellationToken ct)
+    {
+        var env = catalog.UserPasswordChanged(userId, displayName, login, reason);
+        return notificationService.NotifyAdmins(env.Request, env.Channels, ct);
+    }
 }

--- a/DataGateMonitor/Services/Others/Notifications/IAppNotificationFacade.cs
+++ b/DataGateMonitor/Services/Others/Notifications/IAppNotificationFacade.cs
@@ -7,4 +7,8 @@ public interface IAppNotificationFacade
     Task CertIssued(int actorUserId, string commonName, int? serverId, CancellationToken ct);
     Task ServerDown(int serverId, string serverName, CancellationToken ct);
     Task ServerUp(int serverId, string serverName, CancellationToken ct);
+
+    Task UserRegistered(int userId, string displayName, string? login, string? email, CancellationToken ct);
+
+    Task UserPasswordChanged(int userId, string displayName, string login, string reason, CancellationToken ct);
 }

--- a/DataGateMonitor/Services/Others/Notifications/INotificationCatalog.cs
+++ b/DataGateMonitor/Services/Others/Notifications/INotificationCatalog.cs
@@ -7,4 +7,8 @@ public interface INotificationCatalog
     NotificationEnvelope CertIssued(int actorUserId, string commonName, int? serverId = null);
     NotificationEnvelope ServerDown(int serverId, string serverName);
     NotificationEnvelope ServerUp(int serverId, string serverName);
+
+    NotificationEnvelope UserRegistered(int userId, string displayName, string? login, string? email);
+
+    NotificationEnvelope UserPasswordChanged(int userId, string displayName, string login, string reason);
 }

--- a/DataGateMonitor/Services/Others/Notifications/NotificationCatalog.cs
+++ b/DataGateMonitor/Services/Others/Notifications/NotificationCatalog.cs
@@ -83,4 +83,37 @@ public class NotificationCatalog : INotificationCatalog
         };
         return new NotificationEnvelope(req, WebAndTelegram);
     }
+
+    public NotificationEnvelope UserRegistered(int userId, string displayName, string? login, string? email)
+    {
+        var loginPart = string.IsNullOrWhiteSpace(login) ? "" : $" Login: {login}.";
+        var emailPart = string.IsNullOrWhiteSpace(email) ? "" : $" Email: {email}.";
+        var req = new NotificationRequest
+        {
+            Type = NotificationTypes.UserRegistered,
+            Title = "New user registered",
+            Message = $"User #{userId} ({displayName}) registered.{loginPart}{emailPart}",
+            Severity = NotificationSeverity.Info,
+            Source = "auth",
+            ActorUserId = userId,
+            PreferenceKind = ApplicationNotificationKind.AppUserRegistered
+        };
+        return new NotificationEnvelope(req, WebAndTelegram);
+    }
+
+    public NotificationEnvelope UserPasswordChanged(int userId, string displayName, string login, string reason)
+    {
+        var req = new NotificationRequest
+        {
+            Type = NotificationTypes.UserPasswordChanged,
+            Title = "User password changed",
+            Message =
+                $"User #{userId} ({displayName}), login \"{login}\", changed password. Source: {reason}.",
+            Severity = NotificationSeverity.Warning,
+            Source = "auth",
+            ActorUserId = userId,
+            PreferenceKind = ApplicationNotificationKind.AppUserPasswordChanged
+        };
+        return new NotificationEnvelope(req, WebAndTelegram);
+    }
 }

--- a/DataGateMonitor/Services/TelegramBot/Interfaces/ITelegramBotUserProfilePhotoService.cs
+++ b/DataGateMonitor/Services/TelegramBot/Interfaces/ITelegramBotUserProfilePhotoService.cs
@@ -1,0 +1,18 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses;
+
+namespace DataGateMonitor.Services.TelegramBot.Interfaces;
+
+public interface ITelegramBotUserProfilePhotoService
+{
+    Task<UpsertTelegramBotUserProfilePhotoResponse> UpsertAsync(
+        UpsertTelegramBotUserProfilePhotoRequest request,
+        CancellationToken cancellationToken);
+
+    Task<TelegramBotUserProfilePhotoMetaResponse?> GetMetaByTelegramIdAsync(long telegramId,
+        CancellationToken cancellationToken);
+
+    /// <summary>Returns stored image or null if none.</summary>
+    Task<(byte[] Bytes, string MimeType)?> GetImageByTelegramIdAsync(long telegramId,
+        CancellationToken cancellationToken);
+}

--- a/DataGateMonitor/Services/TelegramBot/TelegramBotUserProfilePhotoService.cs
+++ b/DataGateMonitor/Services/TelegramBot/TelegramBotUserProfilePhotoService.cs
@@ -1,0 +1,131 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.TelegramBotUserProfilePhotoTable;
+using DataGateMonitor.DataBase.Services.Query.TelegramBotUserTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.TelegramBot.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.TelegramBotUser.Responses;
+
+namespace DataGateMonitor.Services.TelegramBot;
+
+public sealed class TelegramBotUserProfilePhotoService(
+    ITelegramBotUserQueryService telegramBotUserQueryService,
+    ITelegramBotUserProfilePhotoQueryService profilePhotoQuery,
+    ICommandService<TelegramBotUserProfilePhoto, int> photoCommand,
+    ILogger<TelegramBotUserProfilePhotoService> logger) : ITelegramBotUserProfilePhotoService
+{
+    private const int MaxDecodedPhotoBytes = 5 * 1024 * 1024;
+
+    public async Task<UpsertTelegramBotUserProfilePhotoResponse> UpsertAsync(
+        UpsertTelegramBotUserProfilePhotoRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.ProfilePhotoBase64))
+            return new UpsertTelegramBotUserProfilePhotoResponse { Updated = false };
+
+        byte[] bytes;
+        try
+        {
+            bytes = Convert.FromBase64String(request.ProfilePhotoBase64);
+        }
+        catch (FormatException ex)
+        {
+            logger.LogWarning(ex, "Invalid base64 profile photo for TelegramId {TelegramId}", request.TelegramId);
+            return new UpsertTelegramBotUserProfilePhotoResponse { Updated = false };
+        }
+
+        if (bytes.Length == 0 || bytes.Length > MaxDecodedPhotoBytes)
+        {
+            logger.LogWarning("Profile photo size invalid for TelegramId {TelegramId}: {Len}", request.TelegramId,
+                bytes.Length);
+            return new UpsertTelegramBotUserProfilePhotoResponse { Updated = false };
+        }
+
+        var tgUser = await telegramBotUserQueryService.GetByTelegramId(request.TelegramId, cancellationToken);
+        if (tgUser is null)
+        {
+            logger.LogWarning("Upsert profile photo: TelegramBotUser not found for {TelegramId}", request.TelegramId);
+            return new UpsertTelegramBotUserProfilePhotoResponse { Updated = false };
+        }
+
+        var mime = string.IsNullOrWhiteSpace(request.ProfilePhotoMimeType)
+            ? "image/jpeg"
+            : request.ProfilePhotoMimeType.Trim();
+        if (mime.Length > 64)
+            mime = mime[..64];
+
+        var unique = string.IsNullOrWhiteSpace(request.ProfilePhotoFileUniqueId)
+            ? null
+            : request.ProfilePhotoFileUniqueId.Trim();
+        if (unique is { Length: > 128 })
+            unique = unique[..128];
+
+        var existingMeta =
+            await profilePhotoQuery.GetIdAndFileUniqueIdNoTrackingAsync(tgUser.Id, cancellationToken);
+
+        if (existingMeta is not null
+            && !string.IsNullOrEmpty(unique)
+            && !string.IsNullOrEmpty(existingMeta.TelegramFileUniqueId)
+            && string.Equals(existingMeta.TelegramFileUniqueId, unique, StringComparison.Ordinal))
+        {
+            return new UpsertTelegramBotUserProfilePhotoResponse { Updated = false };
+        }
+
+        if (existingMeta is null)
+        {
+            var row = new TelegramBotUserProfilePhoto
+            {
+                TelegramBotUserId = tgUser.Id,
+                ImageBytes = bytes,
+                MimeType = mime,
+                TelegramFileUniqueId = unique
+            };
+            await photoCommand.Add(row, saveChanges: true, cancellationToken);
+            logger.LogInformation("Stored Telegram profile photo for TelegramId {TelegramId}", request.TelegramId);
+            return new UpsertTelegramBotUserProfilePhotoResponse { Updated = true };
+        }
+
+        var tracked = await profilePhotoQuery.GetByTelegramBotUserIdForUpdateAsync(tgUser.Id, cancellationToken);
+        if (tracked is null)
+            return new UpsertTelegramBotUserProfilePhotoResponse { Updated = false };
+
+        tracked.ImageBytes = bytes;
+        tracked.MimeType = mime;
+        tracked.TelegramFileUniqueId = unique;
+        await photoCommand.Update(tracked, saveChanges: true, cancellationToken);
+        logger.LogInformation("Updated Telegram profile photo for TelegramId {TelegramId}", request.TelegramId);
+        return new UpsertTelegramBotUserProfilePhotoResponse { Updated = true };
+    }
+
+    public async Task<TelegramBotUserProfilePhotoMetaResponse?> GetMetaByTelegramIdAsync(long telegramId,
+        CancellationToken cancellationToken)
+    {
+        var tgUser = await telegramBotUserQueryService.GetByTelegramId(telegramId, cancellationToken);
+        if (tgUser is null)
+            return null;
+
+        var summary = await profilePhotoQuery.GetSummaryNoTrackingAsync(tgUser.Id, cancellationToken);
+        return new TelegramBotUserProfilePhotoMetaResponse
+        {
+            TelegramId = telegramId,
+            HasPhoto = summary is not null,
+            TelegramFileUniqueId = summary?.TelegramFileUniqueId,
+            MimeType = summary?.MimeType,
+            LastUpdate = summary?.LastUpdate
+        };
+    }
+
+    public async Task<(byte[] Bytes, string MimeType)?> GetImageByTelegramIdAsync(long telegramId,
+        CancellationToken cancellationToken)
+    {
+        var tgUser = await telegramBotUserQueryService.GetByTelegramId(telegramId, cancellationToken);
+        if (tgUser is null)
+            return null;
+
+        var row = await profilePhotoQuery.GetByTelegramBotUserIdNoTrackingAsync(tgUser.Id, cancellationToken);
+        if (row is null || row.ImageBytes.Length == 0)
+            return null;
+
+        return (row.ImageBytes, row.MimeType);
+    }
+}

--- a/DataGateMonitor/Services/Users/Interfaces/IUserService.cs
+++ b/DataGateMonitor/Services/Users/Interfaces/IUserService.cs
@@ -17,4 +17,8 @@ public interface IUserService
     Task<GetAllUsersResponse> GetUsersPage(GetAllUsersRequest request, CancellationToken cancellationToken);
     Task<UsersResponse> GetUserById(GetUserByIdRequest request, CancellationToken cancellationToken);
     Task<UsersResponse> GetUserByExternalId(GetUserByExternalIdRequest request, CancellationToken cancellationToken);
+    Task<GetUserEmailConfirmationStatusResponse> GetEmailConfirmationStatus(
+        GetUserEmailConfirmationStatusRequest request,
+        CancellationToken cancellationToken);
+    Task<ConfirmUserEmailResponse> ConfirmEmailManually(ConfirmUserEmailRequest request, CancellationToken cancellationToken);
 }

--- a/DataGateMonitor/Services/Users/UserService.cs
+++ b/DataGateMonitor/Services/Users/UserService.cs
@@ -259,6 +259,34 @@ public class UserService(
         return new UsersResponse { User = dto };
     }
 
+    public async Task<GetUserEmailConfirmationStatusResponse> GetEmailConfirmationStatus(
+        GetUserEmailConfirmationStatusRequest request,
+        CancellationToken cancellationToken)
+    {
+        var user = await userQueryService.GetById(request.Id, cancellationToken)
+                   ?? throw new KeyNotFoundException($"User {request.Id} not found");
+        return new GetUserEmailConfirmationStatusResponse { IsEmailConfirmed = user.IsEmailConfirmed };
+    }
+
+    public async Task<ConfirmUserEmailResponse> ConfirmEmailManually(
+        ConfirmUserEmailRequest request,
+        CancellationToken cancellationToken)
+    {
+        var user = await userQueryService.GetById(request.Id, cancellationToken)
+                   ?? throw new KeyNotFoundException($"User {request.Id} not found");
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+            throw new InvalidOperationException("User has no email.");
+
+        if (user.IsEmailConfirmed)
+            return new ConfirmUserEmailResponse { IsEmailConfirmed = true };
+
+        user.IsEmailConfirmed = true;
+        user.LastUpdate = DateTimeOffset.UtcNow;
+        await userCommandService.Update(user, saveChanges: true, cancellationToken);
+        return new ConfirmUserEmailResponse { IsEmailConfirmed = true };
+    }
+
     // === Helpers ===
 
     private async Task<UserDto> BuildUserDtoAsync(User user, CancellationToken ct)

--- a/DataGateMonitor/example.appsettings.json
+++ b/DataGateMonitor/example.appsettings.json
@@ -27,14 +27,6 @@
     "Username": "smtp_user",
     "Password": "smtp_password"
   },
-  "CrashIngest": {
-    "MaxPayloadBytes": 1048576,
-    "RateLimitMaxRequests": 20,
-    "RateLimitWindowSeconds": 60,
-    "RequireHttps": true,
-    "RecentMaxLimit": 200,
-    "AuthToken": ""
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/DataGateMonitor/example.appsettings.json
+++ b/DataGateMonitor/example.appsettings.json
@@ -27,6 +27,14 @@
     "Username": "smtp_user",
     "Password": "smtp_password"
   },
+  "CrashIngest": {
+    "MaxPayloadBytes": 1048576,
+    "RateLimitMaxRequests": 20,
+    "RateLimitWindowSeconds": 60,
+    "RequireHttps": true,
+    "RecentMaxLimit": 200,
+    "AuthToken": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/README.md
+++ b/README.md
@@ -112,6 +112,55 @@ curl -X POST http://localhost:5581/api/certificates -d '{"clientName": "GateMoni
 curl -X DELETE http://localhost:5581/api/certificates/GateMonitor1
 ```
 
+### Mobile Crash Ingest
+`POST /api/v1/mobile/crash-ingest`
+
+Request requirements:
+- Content-Type: `text/plain; charset=utf-8`
+- Headers:
+  - `X-Crash-Filename`
+  - `X-Crash-Process`
+  - `X-Crash-Token` (optional, when configured)
+
+Response codes:
+- `204` success
+- `400` invalid/empty body or invalid headers/content-type
+- `413` payload too large
+- `429` rate-limited
+- `500` server error
+
+Backend crash-ingest settings (env-compatible):
+- `CrashIngest__MaxPayloadBytes` (default `1048576`)
+- `CrashIngest__RateLimitMaxRequests` (default `20`)
+- `CrashIngest__RateLimitWindowSeconds` (default `60`)
+- `CrashIngest__RequireHttps` (default `true`)
+- `CrashIngest__RecentMaxLimit` (default `200`)
+- `CrashIngest__AuthToken` (optional)
+- `X_CRASH_TOKEN` (optional env override for token)
+
+Android client:
+- `CRASH_REPORT_URL=https://<host>/api/v1/mobile/crash-ingest`
+- If token mode enabled, send `X-Crash-Token` with the same secret.
+
+Example:
+```bash
+curl -X POST "https://<host>/api/v1/mobile/crash-ingest" \
+  -H "Content-Type: text/plain; charset=utf-8" \
+  -H "X-Crash-Filename: fatal_2026-05-01T00-00-00.000Z.txt" \
+  -H "X-Crash-Process: com.imkolganov.datagate.dev" \
+  --data-binary @sample_crash.txt
+```
+
+With token:
+```bash
+curl -X POST "https://<host>/api/v1/mobile/crash-ingest" \
+  -H "Content-Type: text/plain; charset=utf-8" \
+  -H "X-Crash-Filename: fatal_2026-05-01T00-00-00.000Z.txt" \
+  -H "X-Crash-Process: com.imkolganov.datagate.dev" \
+  -H "X-Crash-Token: <your-token>" \
+  --data-binary @sample_crash.txt
+```
+
 ## Debugging
 
 ### Attach to a Running Container

--- a/Schems/swagger.json
+++ b/Schems/swagger.json
@@ -10536,6 +10536,10 @@
           "isNewUser": {
             "type": "boolean"
           },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          },
           "token": {
             "type": "string",
             "nullable": true
@@ -13076,6 +13080,10 @@
           },
           "isConnected": {
             "type": "boolean"
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Summary

- Fixed conflog payload mapping to support both payload shapes:
  - legacy plain `RootOpenVpnInfoResponse`,
  - new wrapped diagnostics payload with nested `openVpn` (introduced with Xray support).
- Updated `DataGateOpenVpnManagerMapping` deserialization logic to extract and parse `openVpn` when present.
- Added regression tests for both formats in `DataGateOpenVpnManagerMappingTests`.
- Bumped backend version: `1.0.3.27` → `1.0.3.28`.

## Why

After Xray integration, conflog payload began storing diagnostics wrapper JSON.  
Existing mapping still expected legacy flat OpenVPN payload, which caused empty fields
(`Version`, `Application`, `Environment`, `VPN Subnet`, `Mgmt host:port`) in recent conflog rows.

## Test plan

- Run targeted mapping tests:
  - `dotnet test DataGateMonitor.Tests/DataGateMonitor.Tests.csproj --filter "FullyQualifiedName~DataGateOpenVpnManagerMappingTests"`
- Run conflog-related tests:
  - `dotnet test DataGateMonitor.Tests/DataGateMonitor.Tests.csproj --filter "FullyQualifiedName~Conflog"`
- Manually verify Conflog History UI shows populated values for newly fetched rows after the fix.

## Notes

- Change is backward-compatible with existing historical rows.
- No API contract changes; this is mapping/deserialization compatibility only.