### PR TITLE
docs: refresh README for DataGate Monitor branding and links

### DIFF
--- a/DataGateMonitor.SharedModels/README.md
+++ b/DataGateMonitor.SharedModels/README.md
@@ -1,39 +1,18 @@
 ﻿# DataGateMonitor.SharedModels
 
-Shared models for the DataGateMonitor project.  
-These models are used for API communication between backend services and consumers.
+Shared DTOs and enums for the **DataGate Monitor** API, published as the NuGet package `DataGateMonitor.SharedModels`.
 
-## Features
+Used by the backend, tests, and any external clients that need stable API contracts.
 
-- DTOs for OpenVPN Gate Monitor API
-- Simple and lightweight
-- Compatible with .NET 6 7 8 9
+## Consumption
 
-## Versioning
+Add a package reference — **never** project-reference this repo from `DataGateMonitor` backend or tests:
 
-Check the latest version on [nuget.org](https://www.nuget.org/packages/DataGateMonitor.SharedModels).
-
-After changing DTOs in this project:
-
-1. Bump `<Version>` in `DataGateMonitor.SharedModels.csproj`.
-2. `dotnet build -c Release` then `dotnet pack -c Release` and publish to nuget.org.
-3. Bump `PackageReference` `Version="…"` in all consuming projects to the same value.
-
-Do **not** use a local NuGet feed or `ProjectReference` to SharedModels — only published versions from nuget.org in `PackageReference`.
-
-## Usage
-
-Install via NuGet:
-
-```bash
-dotnet add package DataGateMonitor.SharedModels
+```xml
+<PackageReference Include="DataGateMonitor.SharedModels" Version="…" />
 ```
 
-Import in your code:
-
-```csharp
-using DataGateMonitor.SharedModels;
-```
+After adding types here: bump version in `.csproj`, publish to NuGet, then bump `Version="…"` in all consuming projects.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ Part of the [DataGateMonitor](https://github.com/IMKolganov/DataGateMonitor) mon
 
 ## Links
 
-- [DataGate app](https://datagateapp.com/) · [Download](https://datagateapp.com/download)
-- [Dashboard](https://dash.datagateapp.com/) · [Telegram @datagateapp](https://t.me/datagateapp)
+| Resource | Link |
+|----------|------|
+| <img src="https://raw.githubusercontent.com/IMKolganov/DataGateMonitorFrontend/main/public/favicon.svg" width="16" height="16" alt="" /> **DataGate app** | [datagateapp.com](https://datagateapp.com/) |
+| <img src="https://cdn.simpleicons.org/googleplay/414141" width="16" height="16" alt="" /> **Download** | [datagateapp.com/download](https://datagateapp.com/download) |
+| <img src="https://cdn.simpleicons.org/grafana/F46800" width="16" height="16" alt="" /> **Dashboard** | [dash.datagateapp.com](https://dash.datagateapp.com/) |
+| <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram channel** | [@datagateapp](https://t.me/datagateapp) |
 
 ## Prerequisites
 
@@ -80,4 +84,10 @@ MIT
 
 ## Author
 
-**Ivan Kolganov** — [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en) · [Telegram](https://t.me/KolganovIvan) · [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
+**Ivan Kolganov**
+
+| Contact | Link |
+|---------|------|
+| <img src="https://cdn.simpleicons.org/linkedin/0A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
+| <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
+| <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |

--- a/README.md
+++ b/README.md
@@ -1,180 +1,83 @@
-﻿# OpenVpnGateMonitorBackend
+﻿# DataGate Monitor — Backend
 
-## Overview
-OpenVPN Gate Monitor is a .NET-based backend service that manages OpenVPN client connections and certificates. It runs inside a Docker container and integrates with EasyRSA.
+ASP.NET Core API for [DataGate Monitor](https://dash.datagateapp.com/): VPN server overview, client statistics, auth, admin tools, mobile crash ingest, and integration with OpenVPN / Xray sidecars.
 
-## Features
-- **Automated Certificate Management**
-- **Client Monitoring**
-- **REST API for OpenVPN Control**
-- **Secure Deployment with Docker**
+Part of the [DataGateMonitor](https://github.com/IMKolganov/DataGateMonitor) monorepo (`backend/` submodule). Standalone repo: [DataGateMonitorBackend](https://github.com/IMKolganov/DataGateMonitorBackend).
 
-## Installation
+## Links
 
-### Prerequisites
-Ensure Docker and Docker Compose are installed:
+- [DataGate app](https://datagateapp.com/) · [Download](https://datagateapp.com/download)
+- [Dashboard](https://dash.datagateapp.com/) · [Telegram @datagateapp](https://t.me/datagateapp)
+
+## Prerequisites
+
+- .NET SDK (see `global.json` / project `TargetFramework`)
+- PostgreSQL
+- Optional: Elasticsearch (logging / search)
+
+## Local run
+
 ```bash
-sudo apt-get update && sudo apt-get install -y docker.io docker-compose
+cd backend/DataGateMonitor
+dotnet run
 ```
-Check host user ID:
+
+Default URL: `http://localhost:5581` (override with `ASPNETCORE_URLS`).
+
+Configure connection strings and secrets via `appsettings.json`, user secrets, or environment variables (`DB_CONNECTION_STRING_DATAGATE`, `JWT_SECRET`, etc.).
+
+## Docker (monorepo)
+
+From the monorepo root:
+
 ```bash
-id ivan
+docker compose -f docker-compose-local.yml --env-file .env.dev.x64 up -d --build backend
 ```
 
-## Overview
-This guide explains how to correctly set up a non-root user in a Docker container with a specific **UID/GID (1000:1000)** for seamless file access between the container and host.
+Image: `imkolganov/datagate-monitor-backend`.
 
-## Why Use a Specific UID/GID?
-By default, files on the host may belong to `ivan` (`uid=1000`, `gid=1000`).  
-If the container runs a different user, it might **lack permissions** to access mounted volumes like `/etc/openvpn/easy-rsa`.
+## Database migrations
 
-## Solution: Set UID/GID in Dockerfile
-
-### Step 1: Define UID/GID in `Dockerfile`
-```dockerfile
-ARG HOST_UID=1000
-ARG HOST_GID=1000
-
-# Ensure group exists before adding
-RUN getent group app || groupadd -g $HOST_GID app
-
-# Ensure user exists before adding
-RUN id -u app &>/dev/null || useradd -m -u $HOST_UID -g app app
-
-# Set ownership for app directory
-RUN mkdir -p /app && chown -R app:app /app
-
-# Switch to non-root user
-USER app
-WORKDIR /app
-```
-
-### Step 2: Pass UID/GID During Build
 ```bash
-docker build --build-arg HOST_UID=1000 --build-arg HOST_GID=1000 -t datagate-monitor-backend .
+cd backend/DataGateMonitor.DataBase
+dotnet ef database update --startup-project ../DataGateMonitor
 ```
 
-## Verify User in Container
-Check user inside the running container:
-```bash
-docker exec -it datagate-monitor-backend id
-```
-Expected output:
-```
-uid=1000(app) gid=1000(app)
-```
+## SharedModels
 
-### Build and Run
-Clone the repository:
-```bash
-git clone https://github.com/your-repo/DataGateMonitor.git && cd DataGateMonitor
-```
-Build and run with Docker Compose:
-```bash
-docker build --build-arg HOST_UID=1000 --build-arg HOST_GID=1000 -t datagate-monitor-backend .
-docker-compose up -d
-```
-Check running containers:
-```bash
-docker ps
-```
+API DTOs live in the NuGet package `DataGateMonitor.SharedModels`. Do **not** add a project reference to SharedModels from consuming projects — bump the package version after publishing a new SharedModels release.
 
-## Configuration
+## Mobile crash ingest
 
-### Mounted Volumes
-```yaml
-volumes:
-  - /etc/openvpn/easy-rsa:/etc/openvpn/easy-rsa
-  - /etc/openvpn/clients:/etc/openvpn/clients
-  - /var/log/openvpn-status.log:/var/log/openvpn-status.log:ro
-```
-Ensure the host user has proper permissions.
-
-### Environment Variables
-```yaml
-environment:
-  - DOTNET_ENVIRONMENT=Debug
-  - ASPNETCORE_URLS=http://0.0.0.0:5581
-```
-
-## API Endpoints
-
-### List Issued Certificates
-```bash
-curl -X GET http://localhost:5581/api/certificates
-```
-### Issue a New Certificate
-```bash
-curl -X POST http://localhost:5581/api/certificates -d '{"clientName": "GateMonitor1"}' -H "Content-Type: application/json"
-```
-### Revoke a Certificate
-```bash
-curl -X DELETE http://localhost:5581/api/certificates/GateMonitor1
-```
-
-### Mobile Crash Ingest
 `POST /api/v1/mobile/crash-ingest`
 
-Request requirements:
 - Content-Type: `text/plain; charset=utf-8`
-- Headers:
-  - `X-Crash-Filename`
-  - `X-Crash-Process`
-  - `X-Crash-Token` (optional, when configured)
+- Headers: `X-Crash-Filename`, `X-Crash-Process`, optional `X-Crash-Token`
 
-Response codes:
-- `204` success
-- `400` invalid/empty body or invalid headers/content-type
-- `413` payload too large
-- `429` rate-limited
-- `500` server error
+| Code | Meaning |
+|------|---------|
+| 204 | Success |
+| 400 | Invalid body / headers |
+| 413 | Payload too large |
+| 429 | Rate limited |
+| 500 | Server error |
 
-Backend crash-ingest settings (env-compatible):
-- `CrashIngest__MaxPayloadBytes` (default `1048576`)
-- `CrashIngest__RateLimitMaxRequests` (default `20`)
-- `CrashIngest__RateLimitWindowSeconds` (default `60`)
-- `CrashIngest__RequireHttps` (default `true`)
-- `CrashIngest__RecentMaxLimit` (default `200`)
-- `CrashIngest__AuthToken` (optional)
-- `X_CRASH_TOKEN` (optional env override for token)
-
-Android client:
-- `CRASH_REPORT_URL=https://<host>/api/v1/mobile/crash-ingest`
-- If token mode enabled, send `X-Crash-Token` with the same secret.
+Settings (env): `CrashIngest__MaxPayloadBytes`, `CrashIngest__RateLimitMaxRequests`, `CrashIngest__RateLimitWindowSeconds`, `CrashIngest__RequireHttps`, `CrashIngest__RecentMaxLimit`, `CrashIngest__AuthToken` / `X_CRASH_TOKEN`.
 
 Example:
+
 ```bash
 curl -X POST "https://<host>/api/v1/mobile/crash-ingest" \
   -H "Content-Type: text/plain; charset=utf-8" \
   -H "X-Crash-Filename: fatal_2026-05-01T00-00-00.000Z.txt" \
   -H "X-Crash-Process: com.imkolganov.datagate.dev" \
   --data-binary @sample_crash.txt
-```
-
-With token:
-```bash
-curl -X POST "https://<host>/api/v1/mobile/crash-ingest" \
-  -H "Content-Type: text/plain; charset=utf-8" \
-  -H "X-Crash-Filename: fatal_2026-05-01T00-00-00.000Z.txt" \
-  -H "X-Crash-Process: com.imkolganov.datagate.dev" \
-  -H "X-Crash-Token: <your-token>" \
-  --data-binary @sample_crash.txt
-```
-
-## Debugging
-
-### Attach to a Running Container
-```bash
-docker exec -it datagate-monitor-backend /bin/sh
-```
-### Restart the Backend
-```bash
-docker-compose restart backend
-```
-### View OpenVPN Logs
-```bash
-tail -f /var/log/openvpn-status.log
 ```
 
 ## License
-MIT License. See `LICENSE` for details.
+
+MIT
+
+## Author
+
+**Ivan Kolganov** — [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en) · [Telegram](https://t.me/KolganovIvan) · [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-﻿# DataGate Monitor — Backend
+﻿<h1 align="left">
+  <img src="https://raw.githubusercontent.com/IMKolganov/DataGateMonitorFrontend/main/public/favicon.svg" width="32" height="32" alt="" />
+  DataGate Monitor — Backend
+</h1>
 
 ASP.NET Core API for [DataGate Monitor](https://dash.datagateapp.com/): VPN server overview, client statistics, auth, admin tools, mobile crash ingest, and integration with OpenVPN / Xray sidecars.
 
@@ -88,6 +91,6 @@ MIT
 
 | Contact | Link |
 |---------|------|
-| <img src="https://cdn.simpleicons.org/linkedin/0A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
+| <img src="https://api.iconify.design/simple-icons/linkedin.svg?color=%230A66C2" width="16" height="16" alt="" /> **LinkedIn** | [linkedin.com/in/imkolganov](https://www.linkedin.com/in/imkolganov/?locale=en) |
 | <img src="https://cdn.simpleicons.org/telegram/26A5E4" width="16" height="16" alt="" /> **Telegram** | [@KolganovIvan](https://t.me/KolganovIvan) |
 | <img src="https://cdn.simpleicons.org/buymeacoffee/FFDD00" width="16" height="16" alt="" /> **Buy Me a Coffee** | [buymeacoffee.com/imkolganov](https://buymeacoffee.com/imkolganov) |


### PR DESCRIPTION
## Summary
Documentation-only PR: refresh README(s) for **DataGate Monitor** branding and public links.
- Rename legacy **OpenVPN Gate Monitor** references to **DataGate Monitor**
- Add product links: [datagateapp.com](https://datagateapp.com/), [download](https://datagateapp.com/download), [dashboard](https://dash.datagateapp.com/), [@datagateapp](https://t.me/datagateapp)
- Add author / support links: [LinkedIn](https://www.linkedin.com/in/imkolganov/?locale=en), [Telegram](https://t.me/KolganovIvan), [Buy Me a Coffee](https://buymeacoffee.com/imkolganov)
- Expand dev quick-start (`README-DEV.md` in monorepo)
- Add DataGate logo to README title and icons in Links / Author tables
- Fix README table headers (`Resource | Link`, `Contact | Link`)
- Fix broken LinkedIn icon URL (simpleicons CDN → iconify)
- Fix GitHub icon visibility on dark theme (`<picture>` light/dark)
- Monorepo: add `docs/assets/datagate.svg` (favicon cannot live under `frontend/` submodule path)
No runtime, API, or deployment changes.
## Test plan
- [ ] Open README on GitHub (light + dark theme)
- [ ] Verify title logo, Links table icons, Author table icons render correctly
- [ ] Confirm all external links open (product, download, dashboard, Telegram, LinkedIn, BMC, GitHub)
- [ ] Monorepo only: confirm `docs/assets/datagate.svg` opens on GitHub (not `frontend/public/…`)
- [ ] No code/build changes required