### PR TITLE
Fix VpnServerClients duplicate insert race with PostgreSQL upsert

### DIFF
--- a/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/IVpnServerClientUpsertService.cs
+++ b/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/IVpnServerClientUpsertService.cs
@@ -1,0 +1,11 @@
+namespace DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+
+/// <summary>
+/// Inserts or updates a VPN client row keyed by (<see cref="VpnServerClientUpsertPayload.VpnServerId"/>,
+/// <see cref="VpnServerClientUpsertPayload.SessionId"/>).
+/// Production uses PostgreSQL <c>INSERT ... ON CONFLICT ... DO UPDATE</c> (atomic, race-safe).
+/// </summary>
+public interface IVpnServerClientUpsertService
+{
+    Task<int> UpsertAsync(VpnServerClientUpsertPayload payload, CancellationToken ct = default);
+}

--- a/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPayload.cs
+++ b/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPayload.cs
@@ -1,3 +1,5 @@
+using DataGateMonitor.Models;
+
 namespace DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 
 public sealed record VpnServerClientUpsertPayload(
@@ -19,4 +21,41 @@ public sealed record VpnServerClientUpsertPayload(
     string? City,
     double? Latitude,
     double? Longitude,
-    bool IsConnected);
+    bool IsConnected)
+{
+    /// <summary>
+    /// Builds an upsert snapshot from a <see cref="VpnServerClient"/> row or in-memory client state.
+    /// </summary>
+    public static VpnServerClientUpsertPayload FromClient(
+        VpnServerClient client,
+        bool persistProxyEnrichment = true,
+        int? vpnServerId = null,
+        int? userId = null,
+        string? externalId = null,
+        Guid? sessionId = null,
+        bool? isConnected = null)
+    {
+        var connected = isConnected ?? client.IsConnected;
+
+        return new VpnServerClientUpsertPayload(
+            VpnServerId: vpnServerId ?? client.VpnServerId,
+            UserId: userId ?? client.UserId,
+            ExternalId: externalId ?? client.ExternalId,
+            SessionId: sessionId ?? client.SessionId,
+            CommonName: client.CommonName,
+            RemoteIp: client.RemoteIp,
+            ProxyRealIp: persistProxyEnrichment ? client.ProxyRealIp : null,
+            LocalIp: client.LocalIp,
+            BytesReceived: client.BytesReceived,
+            BytesSent: client.BytesSent,
+            ConnectedSince: client.ConnectedSince,
+            DisconnectedAt: connected ? null : client.DisconnectedAt,
+            Username: client.Username,
+            Country: persistProxyEnrichment ? client.Country : null,
+            Region: persistProxyEnrichment ? client.Region : null,
+            City: persistProxyEnrichment ? client.City : null,
+            Latitude: persistProxyEnrichment ? client.Latitude : null,
+            Longitude: persistProxyEnrichment ? client.Longitude : null,
+            IsConnected: connected);
+    }
+}

--- a/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPayload.cs
+++ b/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPayload.cs
@@ -1,0 +1,22 @@
+namespace DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+
+public sealed record VpnServerClientUpsertPayload(
+    int VpnServerId,
+    int? UserId,
+    string ExternalId,
+    Guid SessionId,
+    string CommonName,
+    string RemoteIp,
+    string? ProxyRealIp,
+    string LocalIp,
+    long BytesReceived,
+    long BytesSent,
+    DateTimeOffset ConnectedSince,
+    DateTimeOffset? DisconnectedAt,
+    string Username,
+    string? Country,
+    string? Region,
+    string? City,
+    double? Latitude,
+    double? Longitude,
+    bool IsConnected);

--- a/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertService.cs
+++ b/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertService.cs
@@ -84,7 +84,7 @@ public sealed class VpnServerClientUpsertService(
             BytesReceived = payload.BytesReceived,
             BytesSent = payload.BytesSent,
             ConnectedSince = payload.ConnectedSince,
-            DisconnectedAt = payload.DisconnectedAt,
+            DisconnectedAt = disconnectedAt,
             Username = payload.Username,
             Country = payload.Country,
             Region = payload.Region,

--- a/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertService.cs
+++ b/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertService.cs
@@ -1,0 +1,138 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using NpgsqlTypes;
+using DataGateMonitor.DataBase.Contexts;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+
+public sealed class VpnServerClientUpsertService(
+    ApplicationDbContext dbContext,
+    ICommandService<VpnServerClient, int> commandService,
+    ILogger<VpnServerClientUpsertService> logger) : IVpnServerClientUpsertService
+{
+    public async Task<int> UpsertAsync(VpnServerClientUpsertPayload payload, CancellationToken ct = default)
+    {
+        if (dbContext.Database.IsNpgsql())
+            return await UpsertPostgresAsync(payload, ct);
+
+        logger.LogWarning(
+            "VpnServerClient upsert using in-memory fallback (non-PostgreSQL provider). " +
+            "Production must use Npgsql so INSERT ... ON CONFLICT runs atomically.");
+        return await UpsertFallbackAsync(payload, ct);
+    }
+
+    private async Task<int> UpsertPostgresAsync(VpnServerClientUpsertPayload payload, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var qualifiedTable = ResolveTable(dbContext);
+        var sql = VpnServerClientUpsertSql.BuildUpsertSql(qualifiedTable);
+
+        return await dbContext.Database.ExecuteSqlRawAsync(
+            sql,
+            BuildParameters(payload, now),
+            ct);
+    }
+
+    /// <summary>
+    /// Check-then-insert fallback for EF in-memory integration tests only.
+    /// Not race-safe; production always takes the Npgsql path above.
+    /// </summary>
+    private async Task<int> UpsertFallbackAsync(VpnServerClientUpsertPayload payload, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var disconnectedAt = payload.IsConnected ? null : payload.DisconnectedAt;
+
+        var rows = await commandService.UpdateWhere(
+            x => x.VpnServerId == payload.VpnServerId && x.SessionId == payload.SessionId,
+            s => s
+                .SetProperty(c => c.UserId, c => payload.UserId ?? c.UserId)
+                .SetProperty(c => c.ExternalId, c => string.IsNullOrEmpty(payload.ExternalId) ? c.ExternalId : payload.ExternalId)
+                .SetProperty(c => c.CommonName, payload.CommonName)
+                .SetProperty(c => c.RemoteIp, c => string.IsNullOrEmpty(payload.RemoteIp) ? c.RemoteIp : payload.RemoteIp)
+                .SetProperty(c => c.ProxyRealIp, c => payload.ProxyRealIp ?? c.ProxyRealIp)
+                .SetProperty(c => c.LocalIp, c => string.IsNullOrEmpty(payload.LocalIp) ? c.LocalIp : payload.LocalIp)
+                .SetProperty(c => c.BytesReceived, payload.BytesReceived)
+                .SetProperty(c => c.BytesSent, payload.BytesSent)
+                .SetProperty(c => c.ConnectedSince, payload.ConnectedSince)
+                .SetProperty(c => c.DisconnectedAt, disconnectedAt)
+                .SetProperty(c => c.Username, c => string.IsNullOrEmpty(payload.Username) ? c.Username : payload.Username)
+                .SetProperty(c => c.Country, c => payload.Country ?? c.Country)
+                .SetProperty(c => c.Region, c => payload.Region ?? c.Region)
+                .SetProperty(c => c.City, c => payload.City ?? c.City)
+                .SetProperty(c => c.Latitude, c => payload.Latitude ?? c.Latitude)
+                .SetProperty(c => c.Longitude, c => payload.Longitude ?? c.Longitude)
+                .SetProperty(c => c.IsConnected, payload.IsConnected)
+                .SetProperty(c => c.LastUpdate, now),
+            ct);
+
+        if (rows > 0)
+            return rows;
+
+        var entity = new VpnServerClient
+        {
+            VpnServerId = payload.VpnServerId,
+            UserId = payload.UserId,
+            ExternalId = payload.ExternalId,
+            SessionId = payload.SessionId,
+            CommonName = payload.CommonName,
+            RemoteIp = payload.RemoteIp,
+            ProxyRealIp = payload.ProxyRealIp,
+            LocalIp = payload.LocalIp,
+            BytesReceived = payload.BytesReceived,
+            BytesSent = payload.BytesSent,
+            ConnectedSince = payload.ConnectedSince,
+            DisconnectedAt = payload.DisconnectedAt,
+            Username = payload.Username,
+            Country = payload.Country,
+            Region = payload.Region,
+            City = payload.City,
+            Latitude = payload.Latitude,
+            Longitude = payload.Longitude,
+            IsConnected = payload.IsConnected,
+            CreateDate = now,
+            LastUpdate = now,
+        };
+
+        await commandService.Add(entity, saveChanges: true, ct);
+        return 1;
+    }
+
+    private static NpgsqlParameter[] BuildParameters(VpnServerClientUpsertPayload payload, DateTimeOffset now) =>
+    [
+        new NpgsqlParameter("vpnServerId", NpgsqlDbType.Integer) { Value = payload.VpnServerId },
+        new NpgsqlParameter("userId", NpgsqlDbType.Integer) { Value = (object?)payload.UserId ?? DBNull.Value },
+        new NpgsqlParameter("externalId", NpgsqlDbType.Varchar) { Value = payload.ExternalId },
+        new NpgsqlParameter("sessionId", NpgsqlDbType.Uuid) { Value = payload.SessionId },
+        new NpgsqlParameter("commonName", NpgsqlDbType.Varchar) { Value = payload.CommonName },
+        new NpgsqlParameter("remoteIp", NpgsqlDbType.Varchar) { Value = payload.RemoteIp },
+        new NpgsqlParameter("proxyRealIp", NpgsqlDbType.Varchar) { Value = (object?)payload.ProxyRealIp ?? DBNull.Value },
+        new NpgsqlParameter("localIp", NpgsqlDbType.Varchar) { Value = payload.LocalIp },
+        new NpgsqlParameter("bytesReceived", NpgsqlDbType.Bigint) { Value = payload.BytesReceived },
+        new NpgsqlParameter("bytesSent", NpgsqlDbType.Bigint) { Value = payload.BytesSent },
+        new NpgsqlParameter("connectedSince", NpgsqlDbType.TimestampTz) { Value = payload.ConnectedSince.UtcDateTime },
+        new NpgsqlParameter("disconnectedAt", NpgsqlDbType.TimestampTz)
+        {
+            Value = payload.DisconnectedAt.HasValue ? payload.DisconnectedAt.Value.UtcDateTime : DBNull.Value
+        },
+        new NpgsqlParameter("username", NpgsqlDbType.Varchar) { Value = payload.Username },
+        new NpgsqlParameter("country", NpgsqlDbType.Varchar) { Value = (object?)payload.Country ?? DBNull.Value },
+        new NpgsqlParameter("region", NpgsqlDbType.Varchar) { Value = (object?)payload.Region ?? DBNull.Value },
+        new NpgsqlParameter("city", NpgsqlDbType.Varchar) { Value = (object?)payload.City ?? DBNull.Value },
+        new NpgsqlParameter("latitude", NpgsqlDbType.Double) { Value = (object?)payload.Latitude ?? DBNull.Value },
+        new NpgsqlParameter("longitude", NpgsqlDbType.Double) { Value = (object?)payload.Longitude ?? DBNull.Value },
+        new NpgsqlParameter("isConnected", NpgsqlDbType.Boolean) { Value = payload.IsConnected },
+        new NpgsqlParameter("now", NpgsqlDbType.TimestampTz) { Value = now.UtcDateTime },
+    ];
+
+    private static string ResolveTable(ApplicationDbContext ctx)
+    {
+        var entity = ctx.Model.FindEntityType(typeof(VpnServerClient))
+                     ?? throw new InvalidOperationException($"{nameof(VpnServerClient)} is not mapped.");
+        var schema = entity.GetSchema() ?? "public";
+        var table = entity.GetTableName() ?? throw new InvalidOperationException("Table name missing.");
+        return $"\"{schema}\".\"{table}\"";
+    }
+}

--- a/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertSql.cs
+++ b/DataGateMonitor.DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertSql.cs
@@ -1,0 +1,47 @@
+namespace DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+
+/// <summary>
+/// PostgreSQL upsert for <c>VpnServerClients</c> on <c>UX_VpnServerClients_Server_Session</c>.
+/// </summary>
+internal static class VpnServerClientUpsertSql
+{
+    internal const string TargetAlias = "target";
+
+    internal static string BuildUpsertSql(string qualifiedTable) =>
+        $"""
+         INSERT INTO {qualifiedTable} AS {TargetAlias}
+             ("VpnServerId", "UserId", "ExternalId", "SessionId", "CommonName", "RemoteIp", "ProxyRealIp",
+              "LocalIp", "BytesReceived", "BytesSent", "ConnectedSince", "DisconnectedAt", "Username",
+              "Country", "Region", "City", "Latitude", "Longitude", "IsConnected", "CreateDate", "LastUpdate")
+         VALUES
+             (@vpnServerId, @userId, @externalId, @sessionId, @commonName, @remoteIp, @proxyRealIp,
+              @localIp, @bytesReceived, @bytesSent, @connectedSince, @disconnectedAt, @username,
+              @country, @region, @city, @latitude, @longitude, @isConnected, @now, @now)
+         ON CONFLICT ("VpnServerId", "SessionId")
+         DO UPDATE SET
+             -- overwrite only when incoming value is present (nullable / enriched fields)
+             "UserId" = COALESCE(EXCLUDED."UserId", {TargetAlias}."UserId"),
+             "ExternalId" = COALESCE(NULLIF(EXCLUDED."ExternalId", ''), {TargetAlias}."ExternalId"),
+             "RemoteIp" = COALESCE(NULLIF(EXCLUDED."RemoteIp", ''), {TargetAlias}."RemoteIp"),
+             "ProxyRealIp" = COALESCE(EXCLUDED."ProxyRealIp", {TargetAlias}."ProxyRealIp"),
+             "LocalIp" = COALESCE(NULLIF(EXCLUDED."LocalIp", ''), {TargetAlias}."LocalIp"),
+             "Username" = COALESCE(NULLIF(EXCLUDED."Username", ''), {TargetAlias}."Username"),
+             "Country" = COALESCE(EXCLUDED."Country", {TargetAlias}."Country"),
+             "Region" = COALESCE(EXCLUDED."Region", {TargetAlias}."Region"),
+             "City" = COALESCE(EXCLUDED."City", {TargetAlias}."City"),
+             "Latitude" = COALESCE(EXCLUDED."Latitude", {TargetAlias}."Latitude"),
+             "Longitude" = COALESCE(EXCLUDED."Longitude", {TargetAlias}."Longitude"),
+             -- always overwrite (session identity + live counters)
+             "CommonName" = EXCLUDED."CommonName",
+             "BytesReceived" = EXCLUDED."BytesReceived",
+             "BytesSent" = EXCLUDED."BytesSent",
+             "ConnectedSince" = EXCLUDED."ConnectedSince",
+             -- special logic (connection lifecycle)
+             "IsConnected" = EXCLUDED."IsConnected",
+             "DisconnectedAt" = CASE
+                 WHEN EXCLUDED."IsConnected" = true THEN NULL
+                 ELSE COALESCE(EXCLUDED."DisconnectedAt", {TargetAlias}."DisconnectedAt")
+             END,
+             "LastUpdate" = EXCLUDED."LastUpdate"
+         """;
+}

--- a/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPayloadTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPayloadTests.cs
@@ -1,0 +1,58 @@
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.Tests.DataBase.Services.Command.VpnServerClientTable;
+
+public class VpnServerClientUpsertPayloadTests
+{
+    [Fact]
+    public void FromClient_connected_snapshot_clears_disconnected_at()
+    {
+        var payload = VpnServerClientUpsertPayload.FromClient(
+            new VpnServerClient
+            {
+                VpnServerId = 1,
+                SessionId = Guid.NewGuid(),
+                CommonName = "cn",
+                RemoteIp = "1.1.1.1",
+                LocalIp = "10.0.0.2",
+                Username = "cn",
+                ExternalId = "ext",
+                ConnectedSince = DateTimeOffset.UtcNow,
+                DisconnectedAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                IsConnected = false,
+            },
+            isConnected: true);
+
+        Assert.True(payload.IsConnected);
+        Assert.Null(payload.DisconnectedAt);
+    }
+
+    [Fact]
+    public void FromClient_without_proxy_enrichment_omits_geo_and_proxy_fields()
+    {
+        var payload = VpnServerClientUpsertPayload.FromClient(
+            new VpnServerClient
+            {
+                VpnServerId = 1,
+                SessionId = Guid.NewGuid(),
+                CommonName = "cn",
+                RemoteIp = "1.1.1.1",
+                LocalIp = "10.0.0.2",
+                Username = "cn",
+                ExternalId = "ext",
+                ConnectedSince = DateTimeOffset.UtcNow,
+                ProxyRealIp = "203.0.113.1:443",
+                Country = "DE",
+                IsConnected = true,
+            },
+            persistProxyEnrichment: false,
+            userId: 42,
+            externalId: "resolved-ext");
+
+        Assert.Null(payload.ProxyRealIp);
+        Assert.Null(payload.Country);
+        Assert.Equal(42, payload.UserId);
+        Assert.Equal("resolved-ext", payload.ExternalId);
+    }
+}

--- a/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPostgresIntegrationTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPostgresIntegrationTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+using DataGateMonitor.DataBase.Contexts;
+using DataGateMonitor.DataBase.Repositories;
+using DataGateMonitor.DataBase.Repositories.Queries;
+using DataGateMonitor.DataBase.Services.Command;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+using DataGateMonitor.DataBase.UnitOfWork;
+using DataGateMonitor.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DataGateMonitor.Tests.DataBase.Services.Command.VpnServerClientTable;
+
+/// <summary>
+/// PostgreSQL integration tests for atomic upsert and concurrent writers.
+/// Skipped when <c>DATAGATE_TEST_PG_CONNECTION</c> is unset or the server is unreachable.
+/// Example: DATAGATE_TEST_PG_CONNECTION="Host=localhost;Port=5432;Database=datagate_local;Username=postgres;Password=dgh@14f!"
+/// </summary>
+public sealed class VpnServerClientUpsertPostgresIntegrationTests : IAsyncLifetime
+{
+    private ApplicationDbContext? _context;
+    private IVpnServerClientUpsertService? _sut;
+    private bool _postgresAvailable;
+
+    public async Task InitializeAsync()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("DATAGATE_TEST_PG_CONNECTION");
+        if (string.IsNullOrWhiteSpace(connectionString))
+            return;
+
+        try
+        {
+            await using var probe = new NpgsqlConnection(connectionString);
+            await probe.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseNpgsql(connectionString)
+                .Options;
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["DataBaseSettings:DefaultSchema"] = "xgb_dashopnvpn",
+                })
+                .Build();
+
+            _context = new ApplicationDbContext(options, configuration);
+            await _context.Database.MigrateAsync();
+
+            var repositoryFactory = new RepositoryFactory(_context);
+            var queryFactory = new QueryFactory(_context);
+            var dbContextFactory = new Moq.Mock<IDbContextFactory<ApplicationDbContext>>();
+            var unitOfWork = new UnitOfWork(_context, dbContextFactory.Object, repositoryFactory, queryFactory);
+            var commandService = new EfCommandService<VpnServerClient, int>(unitOfWork);
+            _sut = new VpnServerClientUpsertService(_context, commandService, NullLogger<VpnServerClientUpsertService>.Instance);
+            _postgresAvailable = true;
+        }
+        catch
+        {
+            _postgresAvailable = false;
+            if (_context is not null)
+                await _context.DisposeAsync();
+            _context = null;
+            _sut = null;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context is not null)
+            await _context.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_on_postgres_uses_on_conflict_not_duplicate_insert()
+    {
+        if (!_postgresAvailable || _context is null || _sut is null)
+            return;
+
+        var sessionId = Guid.NewGuid();
+        var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-7);
+        var payload = VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId, externalId: "pg-ext", connectedSince: connectedSince, bytesReceived: 10);
+
+        try
+        {
+            await _sut.UpsertAsync(payload);
+            await _sut.UpsertAsync(payload with { BytesReceived = 20, ExternalId = "" });
+
+            var rows = await _context.VpnServerClients
+                .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
+                .ToListAsync();
+
+            Assert.Single(rows);
+            Assert.Equal("pg-ext", rows[0].ExternalId);
+            Assert.Equal(20, rows[0].BytesReceived);
+        }
+        finally
+        {
+            await _context.VpnServerClients
+                .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
+                .ExecuteDeleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task UpsertAsync_concurrent_writers_same_session_produce_single_row()
+    {
+        if (!_postgresAvailable || _context is null || _sut is null)
+            return;
+
+        var sessionId = Guid.NewGuid();
+        var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-4);
+        var payload = VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId, externalId: "race-ext", connectedSince: connectedSince);
+
+        try
+        {
+            var tasks = Enumerable.Range(0, 32)
+                .Select(i => _sut.UpsertAsync(payload with { BytesReceived = i * 100L }))
+                .ToArray();
+
+            await Task.WhenAll(tasks);
+
+            var count = await _context.VpnServerClients.CountAsync(c =>
+                c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId);
+
+            Assert.Equal(1, count);
+        }
+        finally
+        {
+            await _context.VpnServerClients
+                .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
+                .ExecuteDeleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task UpsertAsync_on_postgres_clears_disconnected_at_when_connected()
+    {
+        if (!_postgresAvailable || _context is null || _sut is null)
+            return;
+
+        var sessionId = Guid.NewGuid();
+        var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-6);
+
+        try
+        {
+            await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+                sessionId,
+                externalId: "pg-dc",
+                connectedSince: connectedSince,
+                isConnected: false,
+                disconnectedAt: DateTimeOffset.UtcNow.AddMinutes(-1)));
+
+            await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+                sessionId,
+                externalId: "pg-dc",
+                connectedSince: connectedSince,
+                isConnected: true,
+                disconnectedAt: DateTimeOffset.UtcNow.AddMinutes(-1)));
+
+            var row = await _context.VpnServerClients.SingleAsync(c =>
+                c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId);
+
+            Assert.True(row.IsConnected);
+            Assert.Null(row.DisconnectedAt);
+        }
+        finally
+        {
+            await _context.VpnServerClients
+                .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
+                .ExecuteDeleteAsync();
+        }
+    }
+}

--- a/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPostgresIntegrationTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPostgresIntegrationTests.cs
@@ -7,88 +7,91 @@ using DataGateMonitor.DataBase.Repositories.Queries;
 using DataGateMonitor.DataBase.Services.Command;
 using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 using DataGateMonitor.DataBase.UnitOfWork;
-using DataGateMonitor.Models;
 using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
 
 namespace DataGateMonitor.Tests.DataBase.Services.Command.VpnServerClientTable;
 
 /// <summary>
 /// PostgreSQL integration tests for atomic upsert and concurrent writers.
-/// Skipped when <c>DATAGATE_TEST_PG_CONNECTION</c> is unset or the server is unreachable.
-/// Example: DATAGATE_TEST_PG_CONNECTION="Host=localhost;Port=5432;Database=datagate_local;Username=postgres;Password=dgh@14f!"
+/// Skipped unless <c>DATAGATE_TEST_PG_CONNECTION</c> is set and the server is reachable.
+/// Example: DATAGATE_TEST_PG_CONNECTION="Host=localhost;Port=5433;Database=datagate_backend;Username=backend_user;Password=..."
 /// </summary>
 public sealed class VpnServerClientUpsertPostgresIntegrationTests : IAsyncLifetime
 {
-    private ApplicationDbContext? _context;
-    private IVpnServerClientUpsertService? _sut;
+    private string? _connectionString;
+    private IConfiguration? _configuration;
+    private ApplicationDbContext? _probeContext;
     private bool _postgresAvailable;
+    private string _skipReason =
+        "Set DATAGATE_TEST_PG_CONNECTION to run PostgreSQL upsert integration tests.";
 
     public async Task InitializeAsync()
     {
-        var connectionString = Environment.GetEnvironmentVariable("DATAGATE_TEST_PG_CONNECTION");
-        if (string.IsNullOrWhiteSpace(connectionString))
+        _connectionString = Environment.GetEnvironmentVariable("DATAGATE_TEST_PG_CONNECTION");
+        if (string.IsNullOrWhiteSpace(_connectionString))
             return;
 
         try
         {
-            await using var probe = new NpgsqlConnection(connectionString);
+            await using var probe = new NpgsqlConnection(_connectionString);
             await probe.OpenAsync();
 
-            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
-                .UseNpgsql(connectionString)
-                .Options;
-
-            var configuration = new ConfigurationBuilder()
+            _configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
                     ["DataBaseSettings:DefaultSchema"] = "xgb_dashopnvpn",
                 })
                 .Build();
 
-            _context = new ApplicationDbContext(options, configuration);
-            await _context.Database.MigrateAsync();
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseNpgsql(_connectionString)
+                .Options;
 
-            var repositoryFactory = new RepositoryFactory(_context);
-            var queryFactory = new QueryFactory(_context);
-            var dbContextFactory = new Moq.Mock<IDbContextFactory<ApplicationDbContext>>();
-            var unitOfWork = new UnitOfWork(_context, dbContextFactory.Object, repositoryFactory, queryFactory);
-            var commandService = new EfCommandService<VpnServerClient, int>(unitOfWork);
-            _sut = new VpnServerClientUpsertService(_context, commandService, NullLogger<VpnServerClientUpsertService>.Instance);
+            _probeContext = new ApplicationDbContext(options, _configuration);
+
+            var schemaExists = await _probeContext.VpnServerClients.AsNoTracking().AnyAsync();
+            if (!schemaExists)
+                await _probeContext.Database.MigrateAsync();
+
             _postgresAvailable = true;
         }
-        catch
+        catch (Exception ex)
         {
             _postgresAvailable = false;
-            if (_context is not null)
-                await _context.DisposeAsync();
-            _context = null;
-            _sut = null;
+            _skipReason = $"PostgreSQL integration tests unavailable: {ex.Message}";
+            if (_probeContext is not null)
+                await _probeContext.DisposeAsync();
+            _probeContext = null;
         }
     }
 
     public async Task DisposeAsync()
     {
-        if (_context is not null)
-            await _context.DisposeAsync();
+        if (_probeContext is not null)
+            await _probeContext.DisposeAsync();
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task UpsertAsync_on_postgres_uses_on_conflict_not_duplicate_insert()
     {
-        if (!_postgresAvailable || _context is null || _sut is null)
-            return;
+        RequirePostgres();
 
         var sessionId = Guid.NewGuid();
         var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-7);
         var payload = VpnServerClientUpsertTestHarness.CreatePayload(
             sessionId, externalId: "pg-ext", connectedSince: connectedSince, bytesReceived: 10);
 
+        await using var ctx = CreateContext();
+        var sut = CreateUpsertService(ctx);
+
         try
         {
-            await _sut.UpsertAsync(payload);
-            await _sut.UpsertAsync(payload with { BytesReceived = 20, ExternalId = "" });
+            await sut.UpsertAsync(payload);
+            await sut.UpsertAsync(payload with { BytesReceived = 20, ExternalId = "" });
 
-            var rows = await _context.VpnServerClients
+            var rows = await ctx.VpnServerClients
+                .AsNoTracking()
                 .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
                 .ToListAsync();
 
@@ -98,70 +101,78 @@ public sealed class VpnServerClientUpsertPostgresIntegrationTests : IAsyncLifeti
         }
         finally
         {
-            await _context.VpnServerClients
+            await ctx.VpnServerClients
                 .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
                 .ExecuteDeleteAsync();
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task UpsertAsync_concurrent_writers_same_session_produce_single_row()
     {
-        if (!_postgresAvailable || _context is null || _sut is null)
-            return;
+        RequirePostgres();
 
         var sessionId = Guid.NewGuid();
         var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-4);
         var payload = VpnServerClientUpsertTestHarness.CreatePayload(
             sessionId, externalId: "race-ext", connectedSince: connectedSince);
 
+        await using var verifyContext = CreateContext();
+
         try
         {
             var tasks = Enumerable.Range(0, 32)
-                .Select(i => _sut.UpsertAsync(payload with { BytesReceived = i * 100L }))
+                .Select(async i =>
+                {
+                    await using var ctx = CreateContext();
+                    var sut = CreateUpsertService(ctx);
+                    await sut.UpsertAsync(payload with { BytesReceived = i * 100L });
+                })
                 .ToArray();
 
             await Task.WhenAll(tasks);
 
-            var count = await _context.VpnServerClients.CountAsync(c =>
+            var count = await verifyContext.VpnServerClients.AsNoTracking().CountAsync(c =>
                 c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId);
 
             Assert.Equal(1, count);
         }
         finally
         {
-            await _context.VpnServerClients
+            await verifyContext.VpnServerClients
                 .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
                 .ExecuteDeleteAsync();
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task UpsertAsync_on_postgres_clears_disconnected_at_when_connected()
     {
-        if (!_postgresAvailable || _context is null || _sut is null)
-            return;
+        RequirePostgres();
 
         var sessionId = Guid.NewGuid();
         var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-6);
 
+        await using var ctx = CreateContext();
+        var sut = CreateUpsertService(ctx);
+
         try
         {
-            await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            await sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
                 sessionId,
                 externalId: "pg-dc",
                 connectedSince: connectedSince,
                 isConnected: false,
                 disconnectedAt: DateTimeOffset.UtcNow.AddMinutes(-1)));
 
-            await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            await sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
                 sessionId,
                 externalId: "pg-dc",
                 connectedSince: connectedSince,
                 isConnected: true,
                 disconnectedAt: DateTimeOffset.UtcNow.AddMinutes(-1)));
 
-            var row = await _context.VpnServerClients.SingleAsync(c =>
+            var row = await ctx.VpnServerClients.AsNoTracking().SingleAsync(c =>
                 c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId);
 
             Assert.True(row.IsConnected);
@@ -169,9 +180,34 @@ public sealed class VpnServerClientUpsertPostgresIntegrationTests : IAsyncLifeti
         }
         finally
         {
-            await _context.VpnServerClients
+            await ctx.VpnServerClients
                 .Where(c => c.VpnServerId == VpnServerClientUpsertTestHarness.TestVpnServerId && c.SessionId == sessionId)
                 .ExecuteDeleteAsync();
         }
+    }
+
+    private ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(_connectionString!)
+            .Options;
+        return new ApplicationDbContext(options, _configuration!);
+    }
+
+    private static IVpnServerClientUpsertService CreateUpsertService(ApplicationDbContext context)
+    {
+        var repositoryFactory = new RepositoryFactory(context);
+        var queryFactory = new QueryFactory(context);
+        var dbContextFactory = new Moq.Mock<IDbContextFactory<ApplicationDbContext>>();
+        var unitOfWork = new UnitOfWork(context, dbContextFactory.Object, repositoryFactory, queryFactory);
+        var commandService = new EfCommandService<Models.VpnServerClient, int>(unitOfWork);
+        return new VpnServerClientUpsertService(context, commandService, NullLogger<VpnServerClientUpsertService>.Instance);
+    }
+
+    private void RequirePostgres()
+    {
+        Skip.IfNot(_postgresAvailable, _skipReason);
+        Assert.NotNull(_connectionString);
+        Assert.NotNull(_configuration);
     }
 }

--- a/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPostgresSqlTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertPostgresSqlTests.cs
@@ -1,0 +1,61 @@
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+
+namespace DataGateMonitor.Tests.DataBase.Services.Command.VpnServerClientTable;
+
+public class VpnServerClientUpsertPostgresSqlTests
+{
+    [Fact]
+    public void BuildUpsertSql_UsesTargetAliasAndOnConflictOnServerAndSession()
+    {
+        var sql = VpnServerClientUpsertSql.BuildUpsertSql(@"""xgb"".""VpnServerClients""");
+
+        Assert.Contains(@"""xgb"".""VpnServerClients"" AS target", sql, StringComparison.Ordinal);
+        Assert.Contains(@"ON CONFLICT (""VpnServerId"", ""SessionId"")", sql, StringComparison.Ordinal);
+        Assert.Contains("DO UPDATE SET", sql, StringComparison.Ordinal);
+        Assert.Contains(@"target.""UserId""", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"""VpnServerClients"".""UserId""", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildUpsertSql_PreservesCreateDateOnConflict()
+    {
+        var sql = VpnServerClientUpsertSql.BuildUpsertSql(@"""public"".""VpnServerClients""");
+
+        Assert.Contains(@"""CreateDate""", sql, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"""CreateDate"" = EXCLUDED.""CreateDate""", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildUpsertSql_MergesEnrichedAndNullableFieldsWithoutWiping()
+    {
+        var sql = VpnServerClientUpsertSql.BuildUpsertSql(@"""public"".""VpnServerClients""");
+
+        Assert.Contains(@"COALESCE(EXCLUDED.""ProxyRealIp"", target.""ProxyRealIp"")", sql, StringComparison.Ordinal);
+        Assert.Contains(@"COALESCE(EXCLUDED.""Country"", target.""Country"")", sql, StringComparison.Ordinal);
+        Assert.Contains(@"COALESCE(EXCLUDED.""UserId"", target.""UserId"")", sql, StringComparison.Ordinal);
+        Assert.Contains(@"COALESCE(NULLIF(EXCLUDED.""ExternalId"", ''), target.""ExternalId"")", sql, StringComparison.Ordinal);
+        Assert.Contains(@"COALESCE(NULLIF(EXCLUDED.""RemoteIp"", ''), target.""RemoteIp"")", sql, StringComparison.Ordinal);
+        Assert.Contains(@"COALESCE(NULLIF(EXCLUDED.""LocalIp"", ''), target.""LocalIp"")", sql, StringComparison.Ordinal);
+        Assert.Contains(@"COALESCE(NULLIF(EXCLUDED.""Username"", ''), target.""Username"")", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildUpsertSql_ClearsDisconnectedAtWhenClientIsConnected()
+    {
+        var sql = VpnServerClientUpsertSql.BuildUpsertSql(@"""public"".""VpnServerClients""");
+
+        Assert.Contains(@"WHEN EXCLUDED.""IsConnected"" = true THEN NULL", sql, StringComparison.Ordinal);
+        Assert.Contains(@"COALESCE(EXCLUDED.""DisconnectedAt"", target.""DisconnectedAt"")", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildUpsertSql_AlwaysOverwritesLiveCountersAndConnectionState()
+    {
+        var sql = VpnServerClientUpsertSql.BuildUpsertSql(@"""public"".""VpnServerClients""");
+
+        Assert.Contains(@"""BytesReceived"" = EXCLUDED.""BytesReceived""", sql, StringComparison.Ordinal);
+        Assert.Contains(@"""BytesSent"" = EXCLUDED.""BytesSent""", sql, StringComparison.Ordinal);
+        Assert.Contains(@"""IsConnected"" = EXCLUDED.""IsConnected""", sql, StringComparison.Ordinal);
+        Assert.Contains(@"""LastUpdate"" = EXCLUDED.""LastUpdate""", sql, StringComparison.Ordinal);
+    }
+}

--- a/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertServiceSqliteTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertServiceSqliteTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DataGateMonitor.DataBase.Contexts;
+using DataGateMonitor.DataBase.Repositories;
+using DataGateMonitor.DataBase.Repositories.Queries;
+using DataGateMonitor.DataBase.Services.Command;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+using DataGateMonitor.DataBase.UnitOfWork;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.Tests.DataBase.Services.Command.VpnServerClientTable;
+
+/// <summary>
+/// Exercises <see cref="VpnServerClientUpsertService"/> merge semantics via the SQLite fallback path
+/// (non-Npgsql). Production uses PostgreSQL <c>INSERT ... ON CONFLICT</c> instead.
+/// </summary>
+public sealed class VpnServerClientUpsertServiceSqliteTests : IAsyncLifetime
+{
+    private SqliteConnection _connection = null!;
+    private ApplicationDbContext _context = null!;
+    private IVpnServerClientUpsertService _sut = null!;
+
+    public async Task InitializeAsync()
+    {
+        (_connection, _context, _sut) = await VpnServerClientUpsertTestHarness.CreateSqliteAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _context.DisposeAsync();
+        await _connection.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task UpsertAsync_inserts_when_row_missing()
+    {
+        var sessionId = Guid.NewGuid();
+        var payload = VpnServerClientUpsertTestHarness.CreatePayload(sessionId, externalId: "ext-1");
+
+        var affected = await _sut.UpsertAsync(payload);
+
+        Assert.Equal(1, affected);
+        var row = await _context.VpnServerClients.AsNoTracking().SingleAsync(c => c.SessionId == sessionId);
+        Assert.Equal("ext-1", row.ExternalId);
+        Assert.True(row.IsConnected);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_updates_existing_row_without_duplicate()
+    {
+        var sessionId = Guid.NewGuid();
+        var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-5);
+
+        await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId, externalId: "ext-known", bytesReceived: 100, connectedSince: connectedSince));
+
+        await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId, externalId: "", bytesReceived: 500, connectedSince: connectedSince));
+
+        var rows = await _context.VpnServerClients.AsNoTracking()
+            .Where(c => c.SessionId == sessionId).ToListAsync();
+        Assert.Single(rows);
+        Assert.Equal("ext-known", rows[0].ExternalId);
+        Assert.Equal(500, rows[0].BytesReceived);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_does_not_wipe_enriched_fields_when_incoming_null()
+    {
+        var sessionId = Guid.NewGuid();
+        var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-3);
+
+        await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId,
+            externalId: "ext-geo",
+            connectedSince: connectedSince,
+            country: "DE",
+            proxyRealIp: "203.0.113.1:443"));
+
+        await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId,
+            externalId: "ext-geo",
+            connectedSince: connectedSince,
+            country: null,
+            proxyRealIp: null,
+            bytesReceived: 999));
+
+        var row = await _context.VpnServerClients.AsNoTracking().SingleAsync(c => c.SessionId == sessionId);
+        Assert.Equal("DE", row.Country);
+        Assert.Equal("203.0.113.1:443", row.ProxyRealIp);
+        Assert.Equal(999, row.BytesReceived);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_clears_disconnected_at_when_client_is_connected()
+    {
+        var sessionId = Guid.NewGuid();
+        var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-2);
+        var disconnectedAt = DateTimeOffset.UtcNow.AddMinutes(-1);
+
+        _context.VpnServerClients.Add(new VpnServerClient
+        {
+            VpnServerId = VpnServerClientUpsertTestHarness.TestVpnServerId,
+            SessionId = sessionId,
+            ExternalId = "ext-dc",
+            CommonName = "cn",
+            RemoteIp = "1.2.3.4",
+            LocalIp = "10.8.0.2",
+            BytesReceived = 0,
+            BytesSent = 0,
+            ConnectedSince = connectedSince,
+            DisconnectedAt = disconnectedAt,
+            Username = "cn",
+            IsConnected = false,
+            CreateDate = DateTimeOffset.UtcNow,
+            LastUpdate = DateTimeOffset.UtcNow,
+        });
+        await _context.SaveChangesAsync();
+
+        await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId, externalId: "ext-dc", connectedSince: connectedSince, isConnected: true));
+
+        var row = await _context.VpnServerClients.AsNoTracking().SingleAsync(c => c.SessionId == sessionId);
+        Assert.True(row.IsConnected);
+        Assert.Null(row.DisconnectedAt);
+    }
+
+    [Fact]
+    public async Task UpsertAsync_preserves_create_date_on_update()
+    {
+        var sessionId = Guid.NewGuid();
+        var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-10);
+
+        await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId, externalId: "ext-cd", connectedSince: connectedSince));
+
+        var createDate = (await _context.VpnServerClients.AsNoTracking().SingleAsync(c => c.SessionId == sessionId)).CreateDate;
+
+        await Task.Delay(15);
+        await _sut.UpsertAsync(VpnServerClientUpsertTestHarness.CreatePayload(
+            sessionId, externalId: "ext-cd", connectedSince: connectedSince, bytesReceived: 42));
+
+        var row = await _context.VpnServerClients.AsNoTracking().SingleAsync(c => c.SessionId == sessionId);
+        Assert.Equal(createDate, row.CreateDate);
+        Assert.True(row.LastUpdate >= createDate);
+    }
+}

--- a/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertTestHarness.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Command/VpnServerClientTable/VpnServerClientUpsertTestHarness.cs
@@ -1,0 +1,80 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DataGateMonitor.DataBase.Contexts;
+using DataGateMonitor.DataBase.Repositories;
+using DataGateMonitor.DataBase.Repositories.Queries;
+using DataGateMonitor.DataBase.Services.Command;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+using DataGateMonitor.DataBase.UnitOfWork;
+
+namespace DataGateMonitor.Tests.DataBase.Services.Command.VpnServerClientTable;
+
+internal static class VpnServerClientUpsertTestHarness
+{
+    internal const int TestVpnServerId = 9_999_001;
+
+    internal static VpnServerClientUpsertPayload CreatePayload(
+        Guid sessionId,
+        string externalId = "ext-default",
+        DateTimeOffset? connectedSince = null,
+        long bytesReceived = 0,
+        bool isConnected = true,
+        DateTimeOffset? disconnectedAt = null,
+        string? country = null,
+        string? proxyRealIp = null) =>
+        new(
+            VpnServerId: TestVpnServerId,
+            UserId: null,
+            ExternalId: externalId,
+            SessionId: sessionId,
+            CommonName: "test-cn",
+            RemoteIp: "198.51.100.10",
+            ProxyRealIp: proxyRealIp,
+            LocalIp: "10.8.0.5",
+            BytesReceived: bytesReceived,
+            BytesSent: 0,
+            ConnectedSince: connectedSince ?? DateTimeOffset.UtcNow,
+            DisconnectedAt: disconnectedAt,
+            Username: "test-cn",
+            Country: country,
+            Region: null,
+            City: null,
+            Latitude: null,
+            Longitude: null,
+            IsConnected: isConnected);
+
+    internal static async Task<(SqliteConnection Connection, ApplicationDbContext Context, IVpnServerClientUpsertService Sut)>
+        CreateSqliteAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .ConfigureWarnings(b => b.Ignore(RelationalEventId.AmbientTransactionWarning))
+            .Options;
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DataBaseSettings:DefaultSchema"] = "test_schema",
+            })
+            .Build();
+
+        var context = new ApplicationDbContext(options, configuration);
+        await context.Database.EnsureCreatedAsync();
+
+        var repositoryFactory = new RepositoryFactory(context);
+        var queryFactory = new QueryFactory(context);
+        var dbContextFactory = new Mock<IDbContextFactory<ApplicationDbContext>>();
+        var unitOfWork = new UnitOfWork(context, dbContextFactory.Object, repositoryFactory, queryFactory);
+        var commandService = new EfCommandService<Models.VpnServerClient, int>(unitOfWork);
+        var sut = new VpnServerClientUpsertService(context, commandService, NullLogger<VpnServerClientUpsertService>.Instance);
+
+        return (connection, context, sut);
+    }
+}

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -28,6 +28,7 @@
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
         <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.24" />
         <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DataGateMonitor.Tests/Services/OpenVpnManagementInterfaces/OpenVpnClientServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/OpenVpnManagementInterfaces/OpenVpnClientServiceTests.cs
@@ -327,30 +327,6 @@ public class OpenVpnClientServiceTests
     }
 
     [Fact]
-    public void GenerateSessionId_Deterministic_And_SensitiveToInputs()
-    {
-        var svc = CreateService(out _, out _, out _, out _);
-        var mi = typeof(OpenVpnClientService).GetMethod("GenerateSessionId", BindingFlags.Instance | BindingFlags.NonPublic)!;
-
-        var cn = "client-a";
-        var ip = "203.0.113.5:40884";
-        var t = new DateTimeOffset(2025, 12, 3, 8, 55, 35, TimeSpan.Zero);
-
-        var a1 = (Guid)mi.Invoke(svc, new object[] { cn, ip, t })!;
-        var a2 = (Guid)mi.Invoke(svc, new object[] { cn, ip, t })!;
-        Assert.Equal(a1, a2);
-
-        var b = (Guid)mi.Invoke(svc, new object[] { cn, ip, t.AddSeconds(1) })!;
-        Assert.NotEqual(a1, b);
-
-        var c = (Guid)mi.Invoke(svc, new object[] { cn, "198.51.100.23:2093", t })!;
-        Assert.NotEqual(a1, c);
-
-        var d = (Guid)mi.Invoke(svc, new object[] { "client-b", ip, t })!;
-        Assert.NotEqual(a1, d);
-    }
-
-    [Fact]
     public async Task GetClientsFromManagementAsync_HappyPath_ParsesViaClient_And_Logs()
     {
         // Arrange

--- a/DataGateMonitor/Configurations/QueryCommandConfiguration.cs
+++ b/DataGateMonitor/Configurations/QueryCommandConfiguration.cs
@@ -1,5 +1,6 @@
 using DataGateMonitor.DataBase.Services.Command;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 using DataGateMonitor.DataBase.Services.Query;
 using DataGateMonitor.DataBase.Services.Query.ClientApplicationTable;
 using DataGateMonitor.DataBase.Services.Query.DeviceTable;
@@ -41,6 +42,7 @@ public static class QueryCommandConfiguration
         services.AddScoped(typeof(IQueryService<,>), typeof(EfQueryService<,>));
         services.AddScoped(typeof(ICommandService<,>), typeof(EfCommandService<,>));
         services.AddScoped<ITransactionRunner, EfTransactionRunner>();
+        services.AddScoped<IVpnServerClientUpsertService, VpnServerClientUpsertService>();
         
         services.AddScoped<IClientApplicationQueryService, ClientApplicationQueryService>();
         services.AddScoped<IIncomingMessageLogQueryService, IncomingMessageLogQueryService>();

--- a/DataGateMonitor/Services/Api/VpnDataService.cs
+++ b/DataGateMonitor/Services/Api/VpnDataService.cs
@@ -114,9 +114,8 @@ public class VpnDataService(
             await SyncQuotaPlanLinksAsync(server.Id, quotaPlanIds, ct);
             await SyncTagLinksAsync(server.Id, tagIds, ct);
 
-            // Additional writes in the same transaction
-            if (!await CheckAndPutDefaultExpiredSettings(server, ct))
-                logger.LogWarning("Failed to add/update default settings for OpenVPN server.");
+            // Backfill export config for servers created before post-setup ran (no-op when config already exists).
+            await EnsureDefaultExportConfigIfMissingAsync(server, ct);
 
             // Return fresh snapshot
             return await openVpnServerQueryService.GetById(server.Id, ct)
@@ -152,7 +151,7 @@ public class VpnDataService(
         var server = await openVpnServerQueryService.GetById(vpnServerId, ct)
                      ?? throw new InvalidOperationException("VpnServer not found");
 
-        var createdDefaultConfig = await CheckAndPutDefaultExpiredSettings(server, ct);
+        var createdDefaultConfig = await TryCreateDefaultExportConfigIfMissingAsync(server, ct);
         return new VpnServerPostSetupExecutionResult
         {
             VpnServerId = vpnServerId,
@@ -193,18 +192,23 @@ public class VpnDataService(
         </tls-crypt>
         """;
 
-    private async Task<bool> CheckAndPutDefaultExpiredSettings(VpnServer openVpnServer, CancellationToken ct)
+    private async Task EnsureDefaultExportConfigIfMissingAsync(VpnServer server, CancellationToken ct)
     {
-        if (openVpnServer.ServerType == VpnServerType.OpenVpn)
-            return await EnsureOpenVpnDefaultExportConfigAsync(openVpnServer, ct);
+        _ = await TryCreateDefaultExportConfigIfMissingAsync(server, ct);
+    }
 
-        if (openVpnServer.ServerType == VpnServerType.Xray)
-            return await EnsureXrayDefaultExportConfigAsync(openVpnServer, ct);
+    private async Task<bool> TryCreateDefaultExportConfigIfMissingAsync(VpnServer server, CancellationToken ct)
+    {
+        if (server.ServerType == VpnServerType.OpenVpn)
+            return await TryCreateOpenVpnDefaultExportConfigAsync(server, ct);
+
+        if (server.ServerType == VpnServerType.Xray)
+            return await TryCreateXrayDefaultExportConfigAsync(server, ct);
 
         return false;
     }
 
-    private async Task<bool> EnsureOpenVpnDefaultExportConfigAsync(VpnServer server, CancellationToken ct)
+    private async Task<bool> TryCreateOpenVpnDefaultExportConfigAsync(VpnServer server, CancellationToken ct)
     {
         if (await openVpnServerOvpnFileConfigQueryService.AnyByVpnServerId(server.Id, ct))
             return false;
@@ -221,7 +225,7 @@ public class VpnDataService(
         return true;
     }
 
-    private async Task<bool> EnsureXrayDefaultExportConfigAsync(VpnServer server, CancellationToken ct)
+    private async Task<bool> TryCreateXrayDefaultExportConfigAsync(VpnServer server, CancellationToken ct)
     {
         if (await openVpnServerOvpnFileConfigQueryService.AnyByVpnServerId(server.Id, ct))
             return false;

--- a/DataGateMonitor/Services/BackgroundServices/VpnServerService.cs
+++ b/DataGateMonitor/Services/BackgroundServices/VpnServerService.cs
@@ -1,6 +1,6 @@
-using Mapster;
 using DataGateMonitor.DataBase.Services.Command;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerStatusLogTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -31,6 +31,7 @@ public class VpnServerService(
     ICommandService<VpnServerClient, int> openVpnServerClientCommandService,
     ICommandService<VpnServerStatusLog, int> openVpnServerStatusLogCommandService,
     ICommandService<VpnServerClientTraffic, int> openVpnClientTrafficCommandService,
+    IVpnServerClientUpsertService vpnServerClientUpsertService,
     IConnectedClientsCounterStore connectedClientsCounterStore) : IVpnServerService
 {
     public async Task SaveConnectedClientsAsync(VpnServer openVpnServer, CancellationToken ct)
@@ -80,68 +81,30 @@ public class VpnServerService(
                     m.CommonName, openVpnServer.Id, ct) ?? string.Empty;
                 user = await userQueryService.GetByExternalId(externalId, ct) ?? null;
                 
-                // ---- Upsert main client row ----
                 var persistProxyEnrichment = ProxyClientLookupService.ShouldPersistProxyEnrichmentFromPoll(m);
-                var rows = persistProxyEnrichment
-                    ? await openVpnServerClientCommandService.UpdateWhere(
-                        x => x.VpnServerId == openVpnServer.Id && x.SessionId == sessionId,
-                        s => s
-                            .SetProperty(c => c.UserId, user?.Id)
-                            .SetProperty(c => c.CommonName, m.CommonName)
-                            .SetProperty(c => c.RemoteIp, m.RemoteIp)
-                            .SetProperty(c => c.ProxyRealIp, m.ProxyRealIp)
-                            .SetProperty(c => c.LocalIp, m.LocalIp)
-                            .SetProperty(c => c.BytesReceived, m.BytesReceived)
-                            .SetProperty(c => c.BytesSent, m.BytesSent)
-                            .SetProperty(c => c.ConnectedSince, m.ConnectedSince) // idempotent
-                            .SetProperty(c => c.Username, m.Username)
-                            .SetProperty(c => c.Country, m.Country)
-                            .SetProperty(c => c.Region, m.Region)
-                            .SetProperty(c => c.City, m.City)
-                            .SetProperty(c => c.Latitude, m.Latitude)
-                            .SetProperty(c => c.Longitude, m.Longitude)
-                            .SetProperty(c => c.ExternalId, externalId)
-                            .SetProperty(c => c.IsConnected, true)
-                            .SetProperty(c => c.DisconnectedAt, _ => (DateTimeOffset?)null)
-                            .SetProperty(c => c.LastUpdate, nowUtc),
-                        ct)
-                    : await openVpnServerClientCommandService.UpdateWhere(
-                        x => x.VpnServerId == openVpnServer.Id && x.SessionId == sessionId,
-                        s => s
-                            .SetProperty(c => c.UserId, user?.Id)
-                            .SetProperty(c => c.CommonName, m.CommonName)
-                            .SetProperty(c => c.RemoteIp, m.RemoteIp)
-                            .SetProperty(c => c.LocalIp, m.LocalIp)
-                            .SetProperty(c => c.BytesReceived, m.BytesReceived)
-                            .SetProperty(c => c.BytesSent, m.BytesSent)
-                            .SetProperty(c => c.ConnectedSince, m.ConnectedSince) // idempotent
-                            .SetProperty(c => c.Username, m.Username)
-                            .SetProperty(c => c.ExternalId, externalId)
-                            .SetProperty(c => c.IsConnected, true)
-                            .SetProperty(c => c.DisconnectedAt, _ => (DateTimeOffset?)null)
-                            .SetProperty(c => c.LastUpdate, nowUtc),
-                        ct);
-
-                if (rows == 0)
-                {
-                    var newClient = m.Adapt<VpnServerClient>();
-                    newClient.VpnServerId = openVpnServer.Id;
-                    newClient.UserId = user?.Id;
-                    newClient.SessionId = sessionId;
-                    newClient.ExternalId = externalId;
-                    newClient.IsConnected = true;
-                    newClient.DisconnectedAt = null;
-                    newClient.LastUpdate = nowUtc;
-                    newClient.CreateDate = nowUtc;
-
-                    await openVpnServerClientCommandService.Add(newClient, saveChanges: false, ct);
-                    logger.LogInformation("VpnServerId: {Id}. Added new client session {SessionId}.",
-                        openVpnServer.Id, sessionId);
-                }
-                else
-                {
-                    logger.LogDebug("Updated client session {SessionId}.", sessionId);
-                }
+                await vpnServerClientUpsertService.UpsertAsync(
+                    new VpnServerClientUpsertPayload(
+                        VpnServerId: openVpnServer.Id,
+                        UserId: user?.Id,
+                        ExternalId: externalId,
+                        SessionId: sessionId,
+                        CommonName: m.CommonName,
+                        RemoteIp: m.RemoteIp,
+                        ProxyRealIp: persistProxyEnrichment ? m.ProxyRealIp : null,
+                        LocalIp: m.LocalIp,
+                        BytesReceived: m.BytesReceived,
+                        BytesSent: m.BytesSent,
+                        ConnectedSince: m.ConnectedSince,
+                        DisconnectedAt: null,
+                        Username: m.Username,
+                        Country: persistProxyEnrichment ? m.Country : null,
+                        Region: persistProxyEnrichment ? m.Region : null,
+                        City: persistProxyEnrichment ? m.City : null,
+                        Latitude: persistProxyEnrichment ? m.Latitude : null,
+                        Longitude: persistProxyEnrichment ? m.Longitude : null,
+                        IsConnected: true),
+                    ct);
+                logger.LogDebug("Upserted client session {SessionId}.", sessionId);
 
                 // ---- Write traffic sample on every call (exact MeasuredAt)
                 var measuredAt = DateTimeOffset.UtcNow; // exact timestamp of this poll

--- a/DataGateMonitor/Services/BackgroundServices/VpnServerService.cs
+++ b/DataGateMonitor/Services/BackgroundServices/VpnServerService.cs
@@ -83,26 +83,14 @@ public class VpnServerService(
                 
                 var persistProxyEnrichment = ProxyClientLookupService.ShouldPersistProxyEnrichmentFromPoll(m);
                 await vpnServerClientUpsertService.UpsertAsync(
-                    new VpnServerClientUpsertPayload(
-                        VpnServerId: openVpnServer.Id,
-                        UserId: user?.Id,
-                        ExternalId: externalId,
-                        SessionId: sessionId,
-                        CommonName: m.CommonName,
-                        RemoteIp: m.RemoteIp,
-                        ProxyRealIp: persistProxyEnrichment ? m.ProxyRealIp : null,
-                        LocalIp: m.LocalIp,
-                        BytesReceived: m.BytesReceived,
-                        BytesSent: m.BytesSent,
-                        ConnectedSince: m.ConnectedSince,
-                        DisconnectedAt: null,
-                        Username: m.Username,
-                        Country: persistProxyEnrichment ? m.Country : null,
-                        Region: persistProxyEnrichment ? m.Region : null,
-                        City: persistProxyEnrichment ? m.City : null,
-                        Latitude: persistProxyEnrichment ? m.Latitude : null,
-                        Longitude: persistProxyEnrichment ? m.Longitude : null,
-                        IsConnected: true),
+                    VpnServerClientUpsertPayload.FromClient(
+                        m,
+                        persistProxyEnrichment: persistProxyEnrichment,
+                        vpnServerId: openVpnServer.Id,
+                        userId: user?.Id,
+                        externalId: externalId,
+                        sessionId: sessionId,
+                        isConnected: true),
                     ct);
                 logger.LogDebug("Upserted client session {SessionId}.", sessionId);
 

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
@@ -1,16 +1,16 @@
 using System.Diagnostics;
-using System.Security.Cryptography;
-using System.Text;
 using Mapster;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.SignalR.Client;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Serialization;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.VpnEvent.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Dto;
@@ -274,6 +274,7 @@ public class OpenVpnEventClient(
             var logService = scope.ServiceProvider.GetRequiredService<IVpnEventLogService>();
             var fileQuery = scope.ServiceProvider.GetRequiredService<IIssuedOvpnFileQueryService>();
             var proxyLookup = scope.ServiceProvider.GetRequiredService<IProxyClientLookupService>();
+            var clientUpsert = scope.ServiceProvider.GetRequiredService<IVpnServerClientUpsertService>();
             var clientCmd = scope.ServiceProvider.GetRequiredService<ICommandService<VpnServerClient, int>>();
 
             var req = data.Adapt<VpnEventRequest>();
@@ -305,11 +306,32 @@ public class OpenVpnEventClient(
                 await proxyLookup.EnrichFromManagementRealAddressAsync(_openVpnServer, openVpnServerClient,
                     CancellationToken.None);
 
-                openVpnServerClient.SessionId = GenerateSessionId(
+                openVpnServerClient.SessionId = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(
                     openVpnServerClient.CommonName, openVpnServerClient.RemoteIp, openVpnServerClient.ConnectedSince);
 
-                await clientCmd.Add(openVpnServerClient, saveChanges: false, CancellationToken.None);
-                logger.LogInformation("VpnServerId: {Id}. Added new client session {SessionId}.",
+                await clientUpsert.UpsertAsync(
+                    new VpnServerClientUpsertPayload(
+                        VpnServerId: openVpnServerClient.VpnServerId,
+                        UserId: openVpnServerClient.UserId,
+                        ExternalId: openVpnServerClient.ExternalId,
+                        SessionId: openVpnServerClient.SessionId,
+                        CommonName: openVpnServerClient.CommonName,
+                        RemoteIp: openVpnServerClient.RemoteIp,
+                        ProxyRealIp: openVpnServerClient.ProxyRealIp,
+                        LocalIp: openVpnServerClient.LocalIp,
+                        BytesReceived: openVpnServerClient.BytesReceived,
+                        BytesSent: openVpnServerClient.BytesSent,
+                        ConnectedSince: openVpnServerClient.ConnectedSince,
+                        DisconnectedAt: openVpnServerClient.DisconnectedAt,
+                        Username: openVpnServerClient.Username,
+                        Country: openVpnServerClient.Country,
+                        Region: openVpnServerClient.Region,
+                        City: openVpnServerClient.City,
+                        Latitude: openVpnServerClient.Latitude,
+                        Longitude: openVpnServerClient.Longitude,
+                        IsConnected: openVpnServerClient.IsConnected),
+                    CancellationToken.None);
+                logger.LogInformation("VpnServerId: {Id}. Upserted client session {SessionId}.",
                     _openVpnServer.Id, openVpnServerClient.SessionId);
             }
             else if (eventType.Equals("ClientDisconnected", StringComparison.OrdinalIgnoreCase)
@@ -355,13 +377,5 @@ public class OpenVpnEventClient(
             logger.LogDebug("HandleEvent finished for {EventType} (ServerId={ServerId}); TotalMs={ElapsedMs}",
                 eventType, _openVpnServer.Id, swTotal.ElapsedMilliseconds);
         }
-    }
-
-    private Guid GenerateSessionId(string commonName, string realAddress, DateTimeOffset connectedSince)
-    {
-        var sessionString = $"{commonName}-{realAddress}-{connectedSince:o}";
-        using var sha256 = SHA256.Create();
-        var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sessionString));
-        return new Guid(hashBytes.Take(16).ToArray());
     }
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
@@ -310,26 +310,7 @@ public class OpenVpnEventClient(
                     openVpnServerClient.CommonName, openVpnServerClient.RemoteIp, openVpnServerClient.ConnectedSince);
 
                 await clientUpsert.UpsertAsync(
-                    new VpnServerClientUpsertPayload(
-                        VpnServerId: openVpnServerClient.VpnServerId,
-                        UserId: openVpnServerClient.UserId,
-                        ExternalId: openVpnServerClient.ExternalId,
-                        SessionId: openVpnServerClient.SessionId,
-                        CommonName: openVpnServerClient.CommonName,
-                        RemoteIp: openVpnServerClient.RemoteIp,
-                        ProxyRealIp: openVpnServerClient.ProxyRealIp,
-                        LocalIp: openVpnServerClient.LocalIp,
-                        BytesReceived: openVpnServerClient.BytesReceived,
-                        BytesSent: openVpnServerClient.BytesSent,
-                        ConnectedSince: openVpnServerClient.ConnectedSince,
-                        DisconnectedAt: openVpnServerClient.DisconnectedAt,
-                        Username: openVpnServerClient.Username,
-                        Country: openVpnServerClient.Country,
-                        Region: openVpnServerClient.Region,
-                        City: openVpnServerClient.City,
-                        Latitude: openVpnServerClient.Latitude,
-                        Longitude: openVpnServerClient.Longitude,
-                        IsConnected: openVpnServerClient.IsConnected),
+                    VpnServerClientUpsertPayload.FromClient(openVpnServerClient, isConnected: true),
                     CancellationToken.None);
                 logger.LogInformation("VpnServerId: {Id}. Upserted client session {SessionId}.",
                     _openVpnServer.Id, openVpnServerClient.SessionId);

--- a/DataGateMonitor/Services/OpenVpnManagementInterfaces/OpenVpnClientService.cs
+++ b/DataGateMonitor/Services/OpenVpnManagementInterfaces/OpenVpnClientService.cs
@@ -1,9 +1,8 @@
 using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
 
 namespace DataGateMonitor.Services.OpenVpnManagementInterfaces;
@@ -58,7 +57,8 @@ public class OpenVpnClientService(
 
             await proxyClientLookupService.EnrichFromManagementRealAddressAsync(server, client, cancellationToken);
 
-            client.SessionId = GenerateSessionId(client.CommonName, client.RemoteIp, client.ConnectedSince);
+            client.SessionId = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(
+                client.CommonName, client.RemoteIp, client.ConnectedSince);
             result.Clients.Add(client);
         }
 
@@ -149,15 +149,5 @@ public class OpenVpnClientService(
 
         logger.LogError("Failed to parse {FieldName}. Value: '{Value}'", fieldName, value);
         throw new FormatException($"Invalid instant format in field {fieldName}: '{value}'");
-    }
-
-
-
-    private Guid GenerateSessionId(string commonName, string realAddress, DateTimeOffset connectedSince)
-    {
-        var sessionString = $"{commonName}-{realAddress}-{connectedSince:o}";
-        using var sha256 = SHA256.Create();
-        var hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(sessionString));
-        return new Guid(hashBytes.Take(16).ToArray());
     }
 }

--- a/DataGateMonitor/Services/XrayNode/XrayVpnClientSyncService.cs
+++ b/DataGateMonitor/Services/XrayNode/XrayVpnClientSyncService.cs
@@ -70,26 +70,28 @@ public sealed class XrayVpnClientSyncService(
                 var (country, region, city, lat, lon) = await ResolveGeoAsync(c.RemoteAddress, cancellationToken);
 
                 await vpnServerClientUpsertService.UpsertAsync(
-                    new VpnServerClientUpsertPayload(
-                        VpnServerId: server.Id,
-                        UserId: user?.Id,
-                        ExternalId: externalId,
-                        SessionId: sessionId,
-                        CommonName: commonName,
-                        RemoteIp: c.RemoteAddress,
-                        ProxyRealIp: null,
-                        LocalIp: UnknownLocalIpPlaceholder,
-                        BytesReceived: c.BytesReceived,
-                        BytesSent: c.BytesSent,
-                        ConnectedSince: c.ConnectedSince,
-                        DisconnectedAt: null,
-                        Username: username,
-                        Country: country,
-                        Region: region,
-                        City: city,
-                        Latitude: lat,
-                        Longitude: lon,
-                        IsConnected: true),
+                    VpnServerClientUpsertPayload.FromClient(
+                        new VpnServerClient
+                        {
+                            VpnServerId = server.Id,
+                            UserId = user?.Id,
+                            SessionId = sessionId,
+                            CommonName = commonName,
+                            RemoteIp = c.RemoteAddress,
+                            LocalIp = UnknownLocalIpPlaceholder,
+                            BytesReceived = c.BytesReceived,
+                            BytesSent = c.BytesSent,
+                            ConnectedSince = c.ConnectedSince,
+                            Username = username,
+                            Country = country,
+                            Region = region,
+                            City = city,
+                            Latitude = lat,
+                            Longitude = lon,
+                            ExternalId = externalId,
+                            IsConnected = true,
+                        },
+                        isConnected: true),
                     cancellationToken);
 
                 var measuredAt = DateTimeOffset.UtcNow;

--- a/DataGateMonitor/Services/XrayNode/XrayVpnClientSyncService.cs
+++ b/DataGateMonitor/Services/XrayNode/XrayVpnClientSyncService.cs
@@ -1,4 +1,5 @@
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedXrayClientLinkTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -20,6 +21,7 @@ public sealed class XrayVpnClientSyncService(
     ITransactionRunner transactionRunner,
     ICommandService<VpnServerClient, int> vpnServerClientCommandService,
     ICommandService<VpnServerClientTraffic, int> vpnClientTrafficCommandService,
+    IVpnServerClientUpsertService vpnServerClientUpsertService,
     IConnectedClientsCounterStore connectedClientsCounterStore)
     : IXrayVpnClientSyncService
 {
@@ -67,58 +69,28 @@ public sealed class XrayVpnClientSyncService(
 
                 var (country, region, city, lat, lon) = await ResolveGeoAsync(c.RemoteAddress, cancellationToken);
 
-                var rows = await vpnServerClientCommandService.UpdateWhere(
-                    x => x.VpnServerId == server.Id && x.SessionId == sessionId,
-                    s => s
-                        .SetProperty(x => x.UserId, user?.Id)
-                        .SetProperty(x => x.CommonName, commonName)
-                        .SetProperty(x => x.RemoteIp, c.RemoteAddress)
-                        .SetProperty(x => x.ProxyRealIp, (string?)null)
-                        .SetProperty(x => x.LocalIp, UnknownLocalIpPlaceholder)
-                        .SetProperty(x => x.BytesReceived, c.BytesReceived)
-                        .SetProperty(x => x.BytesSent, c.BytesSent)
-                        .SetProperty(x => x.ConnectedSince, c.ConnectedSince)
-                        .SetProperty(x => x.Username, username)
-                        .SetProperty(x => x.Country, country)
-                        .SetProperty(x => x.Region, region)
-                        .SetProperty(x => x.City, city)
-                        .SetProperty(x => x.Latitude, lat)
-                        .SetProperty(x => x.Longitude, lon)
-                        .SetProperty(x => x.ExternalId, externalId)
-                        .SetProperty(x => x.IsConnected, true)
-                        .SetProperty(x => x.DisconnectedAt, _ => (DateTimeOffset?)null)
-                        .SetProperty(x => x.LastUpdate, nowUtc),
+                await vpnServerClientUpsertService.UpsertAsync(
+                    new VpnServerClientUpsertPayload(
+                        VpnServerId: server.Id,
+                        UserId: user?.Id,
+                        ExternalId: externalId,
+                        SessionId: sessionId,
+                        CommonName: commonName,
+                        RemoteIp: c.RemoteAddress,
+                        ProxyRealIp: null,
+                        LocalIp: UnknownLocalIpPlaceholder,
+                        BytesReceived: c.BytesReceived,
+                        BytesSent: c.BytesSent,
+                        ConnectedSince: c.ConnectedSince,
+                        DisconnectedAt: null,
+                        Username: username,
+                        Country: country,
+                        Region: region,
+                        City: city,
+                        Latitude: lat,
+                        Longitude: lon,
+                        IsConnected: true),
                     cancellationToken);
-
-                if (rows == 0)
-                {
-                    var newClient = new VpnServerClient
-                    {
-                        VpnServerId = server.Id,
-                        UserId = user?.Id,
-                        SessionId = sessionId,
-                        CommonName = commonName,
-                        RemoteIp = c.RemoteAddress,
-                        ProxyRealIp = null,
-                        LocalIp = UnknownLocalIpPlaceholder,
-                        BytesReceived = c.BytesReceived,
-                        BytesSent = c.BytesSent,
-                        ConnectedSince = c.ConnectedSince,
-                        Username = username,
-                        Country = country,
-                        Region = region,
-                        City = city,
-                        Latitude = lat,
-                        Longitude = lon,
-                        ExternalId = externalId,
-                        IsConnected = true,
-                        DisconnectedAt = null,
-                        LastUpdate = nowUtc,
-                        CreateDate = nowUtc,
-                    };
-
-                    await vpnServerClientCommandService.Add(newClient, saveChanges: false, cancellationToken);
-                }
 
                 var measuredAt = DateTimeOffset.UtcNow;
 


### PR DESCRIPTION
## Summary

- Replace check-then-insert client persistence with atomic PostgreSQL `INSERT ... ON CONFLICT` upsert to eliminate `23505` races between status polling and connect events on `(VpnServerId, SessionId)`.
- Harden upsert merge semantics (`CreateDate`, `DisconnectedAt`, nullable fields via `COALESCE`/`NULLIF`) and add SQLite + optional Postgres integration tests.
- Stop logging a false warning when OpenVPN export config already exists during VPN server update.

## Test plan

- [x] `dotnet test` — SQLite upsert unit tests (13+ cases)
- [x] Optional Postgres integration tests with `DATAGATE_TEST_PG_CONNECTION` (concurrent upsert, merge, `DisconnectedAt` clear)
- [x] Verified manually against prod backup Docker (`datagate_postgres_backend_local`, schema `xgb_dashopnvpn`)