### PR TITLE
Release SharedModels 1.0.25

### DIFF
--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.24</Version>
-        <AssemblyVersion>1.0.24.0</AssemblyVersion>
-        <FileVersion>1.0.24.0</FileVersion>
+        <Version>1.0.25</Version>
+        <AssemblyVersion>1.0.25.0</AssemblyVersion>
+        <FileVersion>1.0.25.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Hubs/StatusStreamPayload.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Hubs/StatusStreamPayload.cs
@@ -1,0 +1,13 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Responses;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Hubs;
+
+/// <summary>
+/// SignalR payload broadcast on <c>OpenVpnStatusHub</c> (<c>StatusUpdated</c> event).
+/// </summary>
+public sealed class StatusStreamPayload
+{
+    public List<ServiceStatusResponse> Statuses { get; set; } = new();
+
+    public DateTimeOffset TimestampUtc { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Responses/LegacyVpnServerWithStatusesEnvelope.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServers/Responses/LegacyVpnServerWithStatusesEnvelope.cs
@@ -1,0 +1,41 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Responses;
+
+/// <summary>
+/// Legacy JSON envelope for <c>GET api/open-vpn-servers/get-all-with-status</c>.
+/// Serialized with camelCase (<c>openVpn*</c> keys) for older mobile clients.
+/// </summary>
+public sealed class LegacyVpnServerWithStatusesEnvelope
+{
+    public bool Success { get; set; } = true;
+
+    public string Message { get; set; } = "Success";
+
+    public LegacyVpnServerWithStatusesData Data { get; set; } = new();
+}
+
+public sealed class LegacyVpnServerWithStatusesData
+{
+    public List<LegacyVpnServerWithStatusItem> OpenVpnServerWithStatuses { get; set; } = new();
+}
+
+public sealed class LegacyVpnServerWithStatusItem
+{
+    public LegacyVpnServerResponses OpenVpnServerResponses { get; set; } = new();
+
+    public VpnServerStatusLogResponse? OpenVpnServerStatusLogResponse { get; set; }
+
+    public int CountConnectedClients { get; set; }
+
+    public int CountSessions { get; set; }
+
+    public long TotalBytesIn { get; set; }
+
+    public long TotalBytesOut { get; set; }
+}
+
+public sealed class LegacyVpnServerResponses
+{
+    public VpnServerDto OpenVpnServer { get; set; } = new();
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/XrayNode/Responses/XrayNodeUserActionResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/XrayNode/Responses/XrayNodeUserActionResponse.cs
@@ -1,0 +1,9 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.XrayNode.Responses;
+
+/// <summary>
+/// Response for <c>POST api/vpn-servers/{vpnServerId}/xray/kick-user</c> and <c>disable-user</c>.
+/// </summary>
+public sealed class XrayNodeUserActionResponse
+{
+    public bool Ok { get; set; } = true;
+}

--- a/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/DnsProbeResult.cs
+++ b/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/DnsProbeResult.cs
@@ -1,0 +1,17 @@
+namespace DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
+
+/// <summary>
+/// Result of a UDP DNS probe performed during proxy session diagnostics.
+/// </summary>
+public sealed class DnsProbeResult
+{
+    public string Host { get; set; } = string.Empty;
+
+    public int Port { get; set; }
+
+    public bool Responded { get; set; }
+
+    public int ResponseBytes { get; set; }
+
+    public string? Error { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxyAuditDiagnosticsResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxyAuditDiagnosticsResponse.cs
@@ -1,0 +1,13 @@
+namespace DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
+
+/// <summary>
+/// Response payload for <c>GET api/diagnostics/proxy-audit</c>.
+/// </summary>
+public sealed class ProxyAuditDiagnosticsResponse
+{
+    public DateTime CheckedAtUtc { get; set; }
+
+    public int Count { get; set; }
+
+    public IReadOnlyList<ProxySessionAuditEntryDto> Entries { get; set; } = Array.Empty<ProxySessionAuditEntryDto>();
+}

--- a/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxySessionAuditEntryDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxySessionAuditEntryDto.cs
@@ -1,0 +1,19 @@
+namespace DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
+
+/// <summary>
+/// One proxy-session audit record returned by <c>GET api/diagnostics/proxy-audit</c>.
+/// </summary>
+public sealed class ProxySessionAuditEntryDto
+{
+    public DateTime AtUtc { get; set; }
+
+    public string Event { get; set; } = string.Empty;
+
+    public string? ConnectionId { get; set; }
+
+    public string? Decision { get; set; }
+
+    public string? Reason { get; set; }
+
+    public IReadOnlyDictionary<string, string>? Details { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxySessionDiagnosticItem.cs
+++ b/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxySessionDiagnosticItem.cs
@@ -1,0 +1,35 @@
+namespace DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
+
+/// <summary>
+/// One active proxy session row in <c>GET api/diagnostics/proxy-sessions</c>.
+/// </summary>
+public sealed class ProxySessionDiagnosticItem
+{
+    public string ConnectionId { get; set; } = string.Empty;
+
+    public string Protocol { get; set; } = string.Empty;
+
+    public string RealClient { get; set; } = string.Empty;
+
+    public string LocalProxy { get; set; } = string.Empty;
+
+    public DateTime ConnectedAtUtc { get; set; }
+
+    public long ProxyClientToServerBytes { get; set; }
+
+    public long ProxyServerToClientBytes { get; set; }
+
+    public bool InOpenVpnManagement { get; set; }
+
+    public bool MissingFromManagement { get; set; }
+
+    public bool IsZombie { get; set; }
+
+    public string? OpenVpnCommonName { get; set; }
+
+    public string? OpenVpnVirtualAddress { get; set; }
+
+    public long? ManagementBytesReceived { get; set; }
+
+    public long? ManagementBytesSent { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxySessionDiagnosticsResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Diagnostics/Responses/ProxySessionDiagnosticsResponse.cs
@@ -1,0 +1,33 @@
+namespace DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
+
+/// <summary>
+/// Response payload for <c>GET api/diagnostics/proxy-sessions</c>.
+/// </summary>
+public sealed class ProxySessionDiagnosticsResponse
+{
+    public DateTime CheckedAtUtc { get; set; }
+
+    public bool ManagementStatusAvailable { get; set; }
+
+    public double? ManagementStatusAgeSeconds { get; set; }
+
+    public int ManagementClientCount { get; set; }
+
+    public bool PeerEvaluationAvailable { get; set; }
+
+    public string? PeerEvaluationSkipReason { get; set; }
+
+    public int ActiveProxySessionCount { get; set; }
+
+    public int ZombieSessionCount { get; set; }
+
+    public string DnsProbeTarget { get; set; } = string.Empty;
+
+    public string DnsProbeScope { get; set; } = string.Empty;
+
+    public string DnsProbeNote { get; set; } = string.Empty;
+
+    public DnsProbeResult DnsProbe { get; set; } = new();
+
+    public IReadOnlyList<ProxySessionDiagnosticItem> Sessions { get; set; } = Array.Empty<ProxySessionDiagnosticItem>();
+}

--- a/DataGateMonitor.SharedModels/Notifications/Requests/NotifyAdminsRequest.cs
+++ b/DataGateMonitor.SharedModels/Notifications/Requests/NotifyAdminsRequest.cs
@@ -1,0 +1,32 @@
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.SharedModels.Notifications.Requests;
+
+/// <summary>
+/// Body for <c>POST api/notifications/notify-admins</c>.
+/// </summary>
+public class NotifyAdminsRequest
+{
+    public string Type { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Message { get; set; } = string.Empty;
+
+    public NotificationSeverity Severity { get; set; } = NotificationSeverity.Info;
+
+    public string Source { get; set; } = "backend";
+
+    public int? ServerId { get; set; }
+
+    public int? ActorUserId { get; set; }
+
+    public int? RelatedClientId { get; set; }
+
+    public string? CorrelationId { get; set; }
+
+    public string? DedupKey { get; set; }
+
+    /// <summary>When set, delivery is skipped if this kind is disabled in admin notification preferences.</summary>
+    public ApplicationNotificationKind? PreferenceKind { get; set; }
+}


### PR DESCRIPTION
## Summary
- Bump `DataGateMonitor.SharedModels` to **1.0.25** (Version, AssemblyVersion, FileVersion).
- Add missing API contract types so all endpoints can consume models from NuGet instead of local DTOs:
  - `NotifyAdminsRequest` for admin notification creation
  - OpenVPN diagnostics responses (`ProxySessionDiagnosticsResponse`, `ProxyAuditDiagnosticsResponse`, etc.)
  - `XrayNodeUserActionResponse` for Xray node proxy actions
  - `LegacyVpnServerWithStatusesEnvelope` for v1 mobile `get-all-with-status`
  - `StatusStreamPayload` for SignalR status stream

## Test plan
- [ ] `dotnet build DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj -c Release`
- [ ] Verify generated package `DataGateMonitor.SharedModels.1.0.25.nupkg`
- [ ] Publish package to NuGet
- [ ] Follow-up PR: update consuming projects to `PackageReference` 1.0.25 and replace local DTOs