### PR TITLE
Cert expiry monitoring, Pi-hole health alerts, and DNS search by VPN profiles

### DIFF
--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.29" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
       <PackageReference Include="Mapster" Version="10.0.8" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.31" />
       <PackageReference Include="Mapster" Version="10.0.8" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
@@ -31,5 +31,9 @@ public interface IIssuedOvpnFileQueryService
     
     Task<bool> ExistsActiveByVpnServerIdAndCommonName(int vpnServerId, string commonName, CancellationToken ct);
 
+    Task<List<IssuedOvpnFile>> GetAllActive(CancellationToken ct);
+
+    Task<List<IssuedOvpnFile>> GetAllActiveByVpnServerIds(IReadOnlyCollection<int> vpnServerIds, CancellationToken ct);
+
     Task<IPagedResult<IssuedOvpnFile>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
@@ -91,6 +91,18 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
                 x.VpnServerId == vpnServerId
                 && x.CommonName == commonName
                 && !x.IsRevoked, ct);
+
+    public Task<List<IssuedOvpnFile>> GetAllActive(CancellationToken ct)
+        => q.Where(x => !x.IsRevoked, ct: ct);
+
+    public Task<List<IssuedOvpnFile>> GetAllActiveByVpnServerIds(IReadOnlyCollection<int> vpnServerIds, CancellationToken ct)
+    {
+        if (vpnServerIds.Count == 0)
+            return Task.FromResult(new List<IssuedOvpnFile>());
+
+        var ids = vpnServerIds.Distinct().ToList();
+        return q.Where(x => !x.IsRevoked && ids.Contains(x.VpnServerId), ct: ct);
+    }
     
     public Task<IPagedResult<IssuedOvpnFile>> GetPage(int page, int pageSize, CancellationToken ct)
         => q.Page(page, pageSize, ct: ct);

--- a/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/IVpnDnsQueryLogQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/IVpnDnsQueryLogQueryService.cs
@@ -7,7 +7,18 @@ namespace DataGateMonitor.DataBase.Services.Query.VpnDnsQueryLogTable;
 
 public interface IVpnDnsQueryLogQueryService
 {
-    Task<IPagedResult<VpnDnsQueryLog>> SearchAsync(GetVpnDnsQueryRequest request, CancellationToken ct);
+    Task<IPagedResult<VpnDnsQueryLog>> SearchAsync(
+        GetVpnDnsQueryRequest request,
+        CancellationToken ct,
+        IReadOnlyList<string>? profileCommonNames = null);
+
+    Task<IReadOnlyList<VpnDnsProfileSummaryItem>> GetProfileSummaryAsync(
+        string externalId,
+        IReadOnlyList<string> profileCommonNames,
+        int vpnServerId,
+        DateTimeOffset? fromUtc,
+        DateTimeOffset? toUtc,
+        CancellationToken ct);
 
     Task<(int TotalCount, DateTimeOffset? LastQueriedAtUtc)> GetServerSummaryAsync(int vpnServerId, CancellationToken ct);
 

--- a/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryService.cs
@@ -8,7 +8,10 @@ namespace DataGateMonitor.DataBase.Services.Query.VpnDnsQueryLogTable;
 
 public class VpnDnsQueryLogQueryService(IQueryService<VpnDnsQueryLog, int> q) : IVpnDnsQueryLogQueryService
 {
-    public async Task<IPagedResult<VpnDnsQueryLog>> SearchAsync(GetVpnDnsQueryRequest request, CancellationToken ct)
+    public async Task<IPagedResult<VpnDnsQueryLog>> SearchAsync(
+        GetVpnDnsQueryRequest request,
+        CancellationToken ct,
+        IReadOnlyList<string>? profileCommonNames = null)
     {
         var page = request.Page < 1 ? 1 : request.Page;
         var pageSize = request.PageSize < 1 ? 50 : Math.Min(request.PageSize, 500);
@@ -18,11 +21,7 @@ public class VpnDnsQueryLogQueryService(IQueryService<VpnDnsQueryLog, int> q) : 
         if (request.VpnServerId > 0)
             query = query.Where(x => x.VpnServerId == request.VpnServerId);
 
-        if (!string.IsNullOrWhiteSpace(request.ExternalId))
-            query = query.Where(x => x.ExternalId == request.ExternalId);
-
-        if (!string.IsNullOrWhiteSpace(request.CommonName))
-            query = query.Where(x => x.CommonName == request.CommonName);
+        query = ApplyIdentityFilter(query, request.ExternalId, request.CommonName, profileCommonNames);
 
         if (!string.IsNullOrWhiteSpace(request.ClientIp))
             query = query.Where(x => x.ClientIp == request.ClientIp);
@@ -55,6 +54,48 @@ public class VpnDnsQueryLogQueryService(IQueryService<VpnDnsQueryLog, int> q) : 
             TotalCount = totalCount,
             Items = items
         };
+    }
+
+    public async Task<IReadOnlyList<VpnDnsProfileSummaryItem>> GetProfileSummaryAsync(
+        string externalId,
+        IReadOnlyList<string> profileCommonNames,
+        int vpnServerId,
+        DateTimeOffset? fromUtc,
+        DateTimeOffset? toUtc,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(externalId) && profileCommonNames.Count == 0)
+            return Array.Empty<VpnDnsProfileSummaryItem>();
+
+        var query = q.Query();
+        if (vpnServerId > 0)
+            query = query.Where(x => x.VpnServerId == vpnServerId);
+
+        if (fromUtc.HasValue)
+            query = query.Where(x => x.QueriedAtUtc >= fromUtc.Value);
+
+        if (toUtc.HasValue)
+            query = query.Where(x => x.QueriedAtUtc <= toUtc.Value);
+
+        query = ApplyIdentityFilter(query, externalId, commonName: null, profileCommonNames);
+
+        var grouped = await query
+            .GroupBy(x => new { x.CommonName, x.VpnServerId })
+            .Select(g => new VpnDnsProfileSummaryItem
+            {
+                CommonName = g.Key.CommonName ?? string.Empty,
+                VpnServerId = g.Key.VpnServerId,
+                QueryCount = g.Count(),
+                LastQueriedAtUtc = g.Max(x => x.QueriedAtUtc)
+            })
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        return grouped
+            .Where(x => !string.IsNullOrWhiteSpace(x.CommonName))
+            .OrderByDescending(x => x.QueryCount)
+            .ThenBy(x => x.CommonName, StringComparer.Ordinal)
+            .ToList();
     }
 
     public async Task<(int TotalCount, DateTimeOffset? LastQueriedAtUtc)> GetServerSummaryAsync(
@@ -106,5 +147,37 @@ public class VpnDnsQueryLogQueryService(IQueryService<VpnDnsQueryLog, int> q) : 
             .Take(limit)
             .AsNoTracking()
             .ToListAsync(ct);
+    }
+
+    internal static IQueryable<VpnDnsQueryLog> ApplyIdentityFilter(
+        IQueryable<VpnDnsQueryLog> query,
+        string? externalId,
+        string? commonName,
+        IReadOnlyList<string>? profileCommonNames)
+    {
+        if (!string.IsNullOrWhiteSpace(commonName))
+            return query.Where(x => x.CommonName == commonName);
+
+        var ext = string.IsNullOrWhiteSpace(externalId) ? null : externalId.Trim();
+        var cns = profileCommonNames?
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(ext) && cns is { Count: > 0 })
+        {
+            return query.Where(x =>
+                x.ExternalId == ext
+                || (x.CommonName != null && cns.Contains(x.CommonName)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(ext))
+            return query.Where(x => x.ExternalId == ext);
+
+        if (cns is { Count: > 0 })
+            return query.Where(x => x.CommonName != null && cns.Contains(x.CommonName));
+
+        return query;
     }
 }

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.31" />
       <PackageReference Include="Mapster" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.29" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
       <PackageReference Include="Mapster" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.29" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.31" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/Helpers/NotificationTypes.cs
+++ b/DataGateMonitor.Models/Helpers/NotificationTypes.cs
@@ -19,4 +19,7 @@ public static class NotificationTypes
 
     public const string OvpnCertExpiryWarning = "ovpn.cert.expiry.warning";
     public const string OvpnCertExpired       = "ovpn.cert.expired";
+
+    public const string PiHoleCollectorUnhealthy = "pihole.collector.unhealthy";
+    public const string PiHoleCollectorRecovered = "pihole.collector.recovered";
 }

--- a/DataGateMonitor.Models/Helpers/NotificationTypes.cs
+++ b/DataGateMonitor.Models/Helpers/NotificationTypes.cs
@@ -16,4 +16,7 @@ public static class NotificationTypes
 
     public const string TrafficDailyRollupSucceeded = "traffic.daily-rollup.succeeded";
     public const string TrafficDailyRollupFailed      = "traffic.daily-rollup.failed";
+
+    public const string OvpnCertExpiryWarning = "ovpn.cert.expiry.warning";
+    public const string OvpnCertExpired       = "ovpn.cert.expired";
 }

--- a/DataGateMonitor.Models/VpnDnsProfileSummaryItem.cs
+++ b/DataGateMonitor.Models/VpnDnsProfileSummaryItem.cs
@@ -1,0 +1,14 @@
+namespace DataGateMonitor.Models;
+
+public sealed class VpnDnsProfileSummaryItem
+{
+    public string CommonName { get; set; } = string.Empty;
+
+    public int VpnServerId { get; set; }
+
+    public bool IsRevoked { get; set; }
+
+    public int QueryCount { get; set; }
+
+    public DateTimeOffset? LastQueriedAtUtc { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.30</Version>
-        <AssemblyVersion>1.0.30.0</AssemblyVersion>
-        <FileVersion>1.0.30.0</FileVersion>
+        <Version>1.0.31</Version>
+        <AssemblyVersion>1.0.31.0</AssemblyVersion>
+        <FileVersion>1.0.31.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.29</Version>
-        <AssemblyVersion>1.0.29.0</AssemblyVersion>
-        <FileVersion>1.0.29.0</FileVersion>
+        <Version>1.0.30</Version>
+        <AssemblyVersion>1.0.30.0</AssemblyVersion>
+        <FileVersion>1.0.30.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Dto/CertExpiryCheckSummaryDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Dto/CertExpiryCheckSummaryDto.cs
@@ -1,0 +1,12 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+
+public class CertExpiryCheckSummaryDto
+{
+    public int ServersChecked { get; set; }
+    public int ProfilesChecked { get; set; }
+    public int Healthy { get; set; }
+    public int ExpiringSoon { get; set; }
+    public int Expired { get; set; }
+    public int MissingOnNode { get; set; }
+    public int ServerFailures { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Dto/CertExpiryProfileResultDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Dto/CertExpiryProfileResultDto.cs
@@ -1,0 +1,15 @@
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+
+public class CertExpiryProfileResultDto
+{
+    public int IssuedOvpnFileId { get; set; }
+    public string CommonName { get; set; } = string.Empty;
+    public CertExpiryProfileOutcome Outcome { get; set; }
+    public DateTimeOffset? ExpiryUtc { get; set; }
+    public int? DaysLeft { get; set; }
+    public string? SerialNumber { get; set; }
+    public bool PathsMatch { get; set; }
+    public bool NotificationSent { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Dto/CertExpiryServerResultDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Dto/CertExpiryServerResultDto.cs
@@ -1,0 +1,13 @@
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+
+public class CertExpiryServerResultDto
+{
+    public int VpnServerId { get; set; }
+    public string ServerName { get; set; } = string.Empty;
+    public CertExpiryServerFetchStatus FetchStatus { get; set; }
+    public string? FetchError { get; set; }
+    public long DurationMs { get; set; }
+    public List<CertExpiryProfileResultDto> Profiles { get; set; } = [];
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Requests/RunCertExpiryCheckRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Requests/RunCertExpiryCheckRequest.cs
@@ -1,0 +1,10 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Requests;
+
+public class RunCertExpiryCheckRequest
+{
+    /// <summary>When set, only this OpenVPN server is checked. When null, all eligible servers are checked.</summary>
+    public int? VpnServerId { get; set; }
+
+    /// <summary>When true, admin notifications are sent for findings (scheduled runs always notify).</summary>
+    public bool SendNotifications { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Responses/CertExpiryCheckRunResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Responses/CertExpiryCheckRunResponse.cs
@@ -1,0 +1,21 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+
+public class CertExpiryCheckRunResponse
+{
+    public Guid RunId { get; set; }
+    public DateTimeOffset StartedAtUtc { get; set; }
+    public DateTimeOffset? FinishedAtUtc { get; set; }
+    public long? DurationMs { get; set; }
+    public CertExpiryRunStatus Status { get; set; }
+    public int? VpnServerId { get; set; }
+    public string ScopeLabel { get; set; } = string.Empty;
+    public int WarningDays { get; set; }
+    public bool SendNotifications { get; set; }
+    public bool IsScheduled { get; set; }
+    public CertExpiryCheckSummaryDto Summary { get; set; } = new();
+    public List<CertExpiryServerResultDto> Servers { get; set; } = [];
+    public string? ErrorMessage { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Responses/CertExpiryRunSummaryDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Responses/CertExpiryRunSummaryDto.cs
@@ -1,0 +1,23 @@
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+
+public class CertExpiryRunSummaryDto
+{
+    public Guid RunId { get; set; }
+    public DateTimeOffset StartedAtUtc { get; set; }
+    public DateTimeOffset? FinishedAtUtc { get; set; }
+    public long? DurationMs { get; set; }
+    public CertExpiryRunStatus Status { get; set; }
+    public int? VpnServerId { get; set; }
+    public string ScopeLabel { get; set; } = string.Empty;
+    public bool SendNotifications { get; set; }
+    public bool IsScheduled { get; set; }
+    public int ServersChecked { get; set; }
+    public int ProfilesChecked { get; set; }
+    public int Expired { get; set; }
+    public int ExpiringSoon { get; set; }
+    public int MissingOnNode { get; set; }
+    public int ServerFailures { get; set; }
+    public string? ErrorMessage { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Responses/GetCertExpiryRunsResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/CertExpiry/Responses/GetCertExpiryRunsResponse.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+
+public class GetCertExpiryRunsResponse
+{
+    public List<CertExpiryRunSummaryDto> Runs { get; set; } = [];
+}

--- a/DataGateMonitor.SharedModels/Enums/ApplicationNotificationKind.cs
+++ b/DataGateMonitor.SharedModels/Enums/ApplicationNotificationKind.cs
@@ -57,4 +57,10 @@ public enum ApplicationNotificationKind
 
     /// <summary>Daily traffic rollup failed.</summary>
     TrafficDailyRollupFailed = 30,
+
+    /// <summary>Issued OpenVPN client certificate expires within the configured warning window.</summary>
+    OvpnCertExpiryWarning = 31,
+
+    /// <summary>Issued OpenVPN client certificate has expired on the node PKI.</summary>
+    OvpnCertExpired = 32,
 }

--- a/DataGateMonitor.SharedModels/Enums/CertExpiryProfileOutcome.cs
+++ b/DataGateMonitor.SharedModels/Enums/CertExpiryProfileOutcome.cs
@@ -1,0 +1,9 @@
+namespace DataGateMonitor.SharedModels.Enums;
+
+public enum CertExpiryProfileOutcome
+{
+    Healthy = 0,
+    ExpiringSoon = 1,
+    Expired = 2,
+    MissingOnNode = 3
+}

--- a/DataGateMonitor.SharedModels/Enums/CertExpiryRunStatus.cs
+++ b/DataGateMonitor.SharedModels/Enums/CertExpiryRunStatus.cs
@@ -1,0 +1,9 @@
+namespace DataGateMonitor.SharedModels.Enums;
+
+public enum CertExpiryRunStatus
+{
+    Running = 0,
+    Completed = 1,
+    Failed = 2,
+    SkippedAlreadyRunning = 3
+}

--- a/DataGateMonitor.SharedModels/Enums/CertExpiryServerFetchStatus.cs
+++ b/DataGateMonitor.SharedModels/Enums/CertExpiryServerFetchStatus.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.SharedModels.Enums;
+
+public enum CertExpiryServerFetchStatus
+{
+    Success = 0,
+    Failed = 1,
+    Skipped = 2
+}

--- a/DataGateMonitor.Tests/Controllers/CertExpiryControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/CertExpiryControllerTests.cs
@@ -1,0 +1,99 @@
+using System.Security.Claims;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Api.Auth.Handlers.Interfaces;
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class CertExpiryControllerTests
+{
+    [Fact]
+    public async Task RunCheck_ReturnsSuccessResponse()
+    {
+        var runId = Guid.NewGuid();
+        var runner = new Mock<ICertExpiryScheduledCheckRunner>();
+        runner.Setup(r => r.RunCheckAsync(It.IsAny<RunCertExpiryCheckRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CertExpiryCheckRunResponse
+            {
+                RunId = runId,
+                Status = CertExpiryRunStatus.Completed,
+                ScopeLabel = "All eligible servers",
+                Summary = new()
+            });
+
+        var store = new CertExpiryRunHistoryStore();
+        var access = new Mock<IVpnServerAccessQueryService>();
+
+        var controller = CreateController(runner.Object, store, access.Object);
+
+        var result = await controller.RunCheck(new RunCertExpiryCheckRequest(), CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<CertExpiryCheckRunResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal(runId, payload.Data!.RunId);
+    }
+
+    [Fact]
+    public void GetRuns_ReturnsStoredSummaries()
+    {
+        var runId = Guid.NewGuid();
+        var store = new CertExpiryRunHistoryStore();
+        store.Save(new CertExpiryCheckRunResponse
+        {
+            RunId = runId,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            Status = CertExpiryRunStatus.Completed,
+            ScopeLabel = "Server #10",
+            VpnServerId = 10,
+            Summary = new() { ProfilesChecked = 3 }
+        });
+
+        var controller = CreateController(Mock.Of<ICertExpiryScheduledCheckRunner>(), store, Mock.Of<IVpnServerAccessQueryService>());
+
+        var result = controller.GetRuns(limit: 10, vpnServerId: null);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<GetCertExpiryRunsResponse>>(ok.Value);
+        Assert.Single(payload.Data!.Runs);
+        Assert.Equal(runId, payload.Data.Runs[0].RunId);
+    }
+
+    [Fact]
+    public void GetRun_WhenMissing_ReturnsNotFound()
+    {
+        var controller = CreateController(
+            Mock.Of<ICertExpiryScheduledCheckRunner>(),
+            new CertExpiryRunHistoryStore(),
+            Mock.Of<IVpnServerAccessQueryService>());
+
+        var result = controller.GetRun(Guid.NewGuid());
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    private static CertExpiryController CreateController(
+        ICertExpiryScheduledCheckRunner runner,
+        ICertExpiryRunHistoryStore store,
+        IVpnServerAccessQueryService access)
+    {
+        var controller = new CertExpiryController(runner, store, access);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Role, "Admin")],
+                    "mock"))
+            }
+        };
+        return controller;
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/VpnDnsQueryControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnDnsQueryControllerTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using DataGateMonitor.Controllers;
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.VpnDnsQueryLogTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnDnsQuery.Requests;
@@ -17,7 +18,10 @@ public class VpnDnsQueryControllerTests
     public async Task Search_ReturnsPagedResponse()
     {
         var queryService = new Mock<IVpnDnsQueryLogQueryService>();
-        queryService.Setup(x => x.SearchAsync(It.IsAny<GetVpnDnsQueryRequest>(), It.IsAny<CancellationToken>()))
+        queryService.Setup(x => x.SearchAsync(
+                It.IsAny<GetVpnDnsQueryRequest>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyList<string>>()))
             .ReturnsAsync(new PagedResponse<VpnDnsQueryLog>
             {
                 Page = 1,
@@ -40,19 +44,13 @@ public class VpnDnsQueryControllerTests
                 ]
             });
 
-        var controller = new VpnDnsQueryController(queryService.Object);
-        controller.ControllerContext = new ControllerContext
-        {
-            HttpContext = new DefaultHttpContext
-            {
-                User = new ClaimsPrincipal(new ClaimsIdentity(
-                    [new Claim(ClaimTypes.Role, "Admin")],
-                    "mock"))
-            }
-        };
+        var issued = new Mock<IIssuedOvpnFileQueryService>();
+        var controller = new VpnDnsQueryController(queryService.Object, issued.Object);
+        controller.ControllerContext = AdminContext();
 
         var result = await controller.Search(
             new GetVpnDnsQueryRequest { VpnServerId = 2, DomainContains = "example" },
+            matchUserProfiles: false,
             CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
@@ -60,6 +58,34 @@ public class VpnDnsQueryControllerTests
         Assert.True(envelope.Success);
         Assert.Single(envelope.Data!.Items);
         Assert.Equal("example.com", envelope.Data.Items[0].Domain);
+    }
+
+    [Fact]
+    public async Task Search_WithMatchUserProfiles_ResolvesCommonNames()
+    {
+        var queryService = new Mock<IVpnDnsQueryLogQueryService>();
+        queryService.Setup(x => x.SearchAsync(
+                It.IsAny<GetVpnDnsQueryRequest>(),
+                It.IsAny<CancellationToken>(),
+                It.Is<IReadOnlyList<string>?>(cns => cns != null && cns.Contains("cn-1"))))
+            .ReturnsAsync(new PagedResponse<VpnDnsQueryLog> { Page = 1, PageSize = 50, TotalCount = 0, Items = [] });
+
+        var issued = new Mock<IIssuedOvpnFileQueryService>();
+        issued.Setup(x => x.GetAllByExternalId("ext-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new IssuedOvpnFile { CommonName = "cn-1", VpnServerId = 75, ExternalId = "ext-1" }]);
+
+        var controller = new VpnDnsQueryController(queryService.Object, issued.Object);
+        controller.ControllerContext = AdminContext();
+
+        await controller.Search(
+            new GetVpnDnsQueryRequest { ExternalId = "ext-1" },
+            matchUserProfiles: true,
+            CancellationToken.None);
+
+        queryService.Verify(x => x.SearchAsync(
+            It.IsAny<GetVpnDnsQueryRequest>(),
+            It.IsAny<CancellationToken>(),
+            It.Is<IReadOnlyList<string>?>(cns => cns != null && cns.Contains("cn-1"))), Times.Once);
     }
 
     [Fact]
@@ -77,16 +103,9 @@ public class VpnDnsQueryControllerTests
                 }
             });
 
-        var controller = new VpnDnsQueryController(queryService.Object);
-        controller.ControllerContext = new ControllerContext
-        {
-            HttpContext = new DefaultHttpContext
-            {
-                User = new ClaimsPrincipal(new ClaimsIdentity(
-                    [new Claim(ClaimTypes.Role, "Admin")],
-                    "mock"))
-            }
-        };
+        var issued = new Mock<IIssuedOvpnFileQueryService>();
+        var controller = new VpnDnsQueryController(queryService.Object, issued.Object);
+        controller.ControllerContext = AdminContext();
 
         var result = await controller.TopDomains(
             new GetVpnDnsTopDomainsRequest { Limit = 100 },
@@ -98,4 +117,14 @@ public class VpnDnsQueryControllerTests
         Assert.Single(envelope.Data!.Items);
         Assert.Equal(12, envelope.Data.Items[0].UniqueUsersCount);
     }
+
+    private static ControllerContext AdminContext() => new()
+    {
+        HttpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Role, "Admin")],
+                "mock"))
+        }
+    };
 }

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryServiceTests.cs
@@ -61,6 +61,123 @@ public class VpnDnsQueryLogQueryServiceTests
     }
 
     [Fact]
+    public async Task SearchAsync_WithProfileCommonNames_MatchesExternalIdOrCommonName()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await using var context = CreateContext();
+        context.VpnDnsQueryLogs.AddRange(
+            new VpnDnsQueryLog
+            {
+                VpnServerId = 1,
+                PiHoleQueryId = 1,
+                ExternalId = "ext-a",
+                CommonName = "cn-a",
+                ClientIp = "10.51.30.1",
+                Domain = "mapped.example",
+                Status = "FORWARDED",
+                QueriedAtUtc = now,
+                CreateDate = now,
+                LastUpdate = now
+            },
+            new VpnDnsQueryLog
+            {
+                VpnServerId = 1,
+                PiHoleQueryId = 2,
+                ExternalId = null,
+                CommonName = "cn-b",
+                ClientIp = "10.51.30.2",
+                Domain = "unmapped.example",
+                Status = "FORWARDED",
+                QueriedAtUtc = now,
+                CreateDate = now,
+                LastUpdate = now
+            },
+            new VpnDnsQueryLog
+            {
+                VpnServerId = 1,
+                PiHoleQueryId = 3,
+                ExternalId = "ext-other",
+                CommonName = "cn-other",
+                ClientIp = "10.51.30.3",
+                Domain = "other.example",
+                Status = "FORWARDED",
+                QueriedAtUtc = now,
+                CreateDate = now,
+                LastUpdate = now
+            });
+        await context.SaveChangesAsync();
+
+        var queries = new Dictionary<Type, object>
+        {
+            [typeof(VpnDnsQueryLog)] = new TestQuery<VpnDnsQueryLog>(context.VpnDnsQueryLogs)
+        };
+        var sut = new VpnDnsQueryLogQueryService(new EfQueryService<VpnDnsQueryLog, int>(new TestUnitOfWork(queries)));
+
+        var page = await sut.SearchAsync(new GetVpnDnsQueryRequest
+        {
+            ExternalId = "ext-a",
+            VpnServerId = 1
+        }, CancellationToken.None, ["cn-b"]);
+
+        Assert.Equal(2, page.TotalCount);
+        Assert.Contains(page.Items, x => x.Domain == "mapped.example");
+        Assert.Contains(page.Items, x => x.Domain == "unmapped.example");
+    }
+
+    [Fact]
+    public async Task GetProfileSummaryAsync_GroupsByCommonName()
+    {
+        var now = DateTimeOffset.UtcNow;
+        await using var context = CreateContext();
+        context.VpnDnsQueryLogs.AddRange(
+            new VpnDnsQueryLog
+            {
+                VpnServerId = 75,
+                PiHoleQueryId = 1,
+                ExternalId = "ext-a",
+                CommonName = "cn-a",
+                ClientIp = "10.51.15.1",
+                Domain = "one.example",
+                Status = "FORWARDED",
+                QueriedAtUtc = now,
+                CreateDate = now,
+                LastUpdate = now
+            },
+            new VpnDnsQueryLog
+            {
+                VpnServerId = 75,
+                PiHoleQueryId = 2,
+                ExternalId = "ext-a",
+                CommonName = "cn-a",
+                ClientIp = "10.51.15.1",
+                Domain = "two.example",
+                Status = "FORWARDED",
+                QueriedAtUtc = now.AddMinutes(1),
+                CreateDate = now,
+                LastUpdate = now
+            });
+        await context.SaveChangesAsync();
+
+        var queries = new Dictionary<Type, object>
+        {
+            [typeof(VpnDnsQueryLog)] = new TestQuery<VpnDnsQueryLog>(context.VpnDnsQueryLogs)
+        };
+        var sut = new VpnDnsQueryLogQueryService(new EfQueryService<VpnDnsQueryLog, int>(new TestUnitOfWork(queries)));
+
+        var rows = await sut.GetProfileSummaryAsync(
+            "ext-a",
+            ["cn-a"],
+            vpnServerId: 75,
+            fromUtc: null,
+            toUtc: null,
+            CancellationToken.None);
+
+        Assert.Single(rows);
+        Assert.Equal("cn-a", rows[0].CommonName);
+        Assert.Equal(2, rows[0].QueryCount);
+    }
+
+    [Fact]
     public async Task SearchAsync_WithoutVpnServerId_ReturnsAcrossServers()
     {
         var now = DateTimeOffset.UtcNow;

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.31" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.29" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryBackgroundServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryBackgroundServiceTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DataGateMonitor.Services.CertExpiry;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryBackgroundServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_Invokes_ScheduledRunner_At_Least_Once()
+    {
+        var previous = Environment.GetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, null);
+
+            var runner = new Mock<ICertExpiryScheduledCheckRunner>();
+            runner.Setup(r => r.RunAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+            var sut = new CertExpiryBackgroundService(
+                NullLogger<CertExpiryBackgroundService>.Instance,
+                runner.Object);
+
+            using var cts = new CancellationTokenSource();
+            await sut.StartAsync(cts.Token);
+            await Task.Delay(1200, CancellationToken.None);
+            cts.Cancel();
+
+            try
+            {
+                await sut.StopAsync(CancellationToken.None);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+
+            runner.Verify(r => r.RunAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, previous);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDisabled_DoesNotInvokeRunner()
+    {
+        var key = CertExpiryEnvironment.DisabledVariable;
+        var previous = Environment.GetEnvironmentVariable(key);
+        var runner = new Mock<ICertExpiryScheduledCheckRunner>();
+
+        try
+        {
+            Environment.SetEnvironmentVariable(key, "true");
+            var sut = new CertExpiryBackgroundService(
+                NullLogger<CertExpiryBackgroundService>.Instance,
+                runner.Object);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            await sut.StartAsync(cts.Token);
+            await Task.Delay(80);
+            await sut.StopAsync(CancellationToken.None);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, previous);
+        }
+
+        runner.Verify(r => r.RunAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryClassifierTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryClassifierTests.cs
@@ -1,0 +1,73 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryClassifierTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 30, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Classify_WhenCertNull_ReturnsMissingOnNode()
+    {
+        var outcome = CertExpiryClassifier.Classify(null, Now, Now.AddDays(30));
+        Assert.Equal(CertExpiryCheckOutcome.MissingOnNode, outcome);
+    }
+
+    [Fact]
+    public void Classify_WhenExpiryPast_ReturnsExpired()
+    {
+        var cert = new ServerCertificate
+        {
+            ExpiryDate = Now.AddDays(-1),
+            Status = CertificateStatus.Active
+        };
+
+        Assert.Equal(CertExpiryCheckOutcome.Expired, CertExpiryClassifier.Classify(cert, Now, Now.AddDays(30)));
+    }
+
+    [Fact]
+    public void Classify_WhenStatusRevoked_ReturnsExpiredEvenIfFutureExpiry()
+    {
+        var cert = new ServerCertificate
+        {
+            ExpiryDate = Now.AddDays(100),
+            Status = CertificateStatus.Revoked
+        };
+
+        Assert.Equal(CertExpiryCheckOutcome.Expired, CertExpiryClassifier.Classify(cert, Now, Now.AddDays(30)));
+    }
+
+    [Fact]
+    public void Classify_WhenWithinWarningWindow_ReturnsExpiringSoon()
+    {
+        var cert = new ServerCertificate
+        {
+            ExpiryDate = Now.AddDays(10),
+            Status = CertificateStatus.Active
+        };
+
+        Assert.Equal(CertExpiryCheckOutcome.ExpiringSoon, CertExpiryClassifier.Classify(cert, Now, Now.AddDays(30)));
+    }
+
+    [Fact]
+    public void Classify_WhenOutsideWarningWindow_ReturnsNone()
+    {
+        var cert = new ServerCertificate
+        {
+            ExpiryDate = Now.AddDays(120),
+            Status = CertificateStatus.Active
+        };
+
+        Assert.Equal(CertExpiryCheckOutcome.None, CertExpiryClassifier.Classify(cert, Now, Now.AddDays(30)));
+    }
+
+    [Fact]
+    public void EstimateDaysLeft_RoundsUpPartialDays()
+    {
+        var expiry = Now.AddHours(25);
+        Assert.Equal(2, CertExpiryClassifier.EstimateDaysLeft(expiry, Now));
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryEnvironmentTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryEnvironmentTests.cs
@@ -1,0 +1,28 @@
+using DataGateMonitor.Services.CertExpiry;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryEnvironmentTests
+{
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("false", true)]
+    [InlineData("FALSE", true)]
+    [InlineData("0", true)]
+    [InlineData("true", false)]
+    [InlineData("TRUE", false)]
+    [InlineData("1", false)]
+    public void IsEnabled_RespectsDisableFlag(string? envValue, bool expected)
+    {
+        var previous = Environment.GetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, envValue);
+            Assert.Equal(expected, CertExpiryEnvironment.IsEnabled());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, previous);
+        }
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryManualCheckTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryManualCheckTests.cs
@@ -1,0 +1,187 @@
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.Others.Notifications.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Requests;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public sealed class CertExpiryManualCheckTests : IDisposable
+{
+    private readonly string? _previousDisabledEnv;
+    private readonly Mock<IIssuedOvpnFileQueryService> _issuedFiles = new();
+    private readonly Mock<IVpnServerQueryService> _servers = new();
+    private readonly Mock<ICertApiClient> _certApi = new();
+    private readonly Mock<ICertExpiryNotificationService> _notifier = new();
+    private readonly Mock<ISettingsService> _settings = new();
+    private readonly CertExpiryNotificationTracker _tracker = new();
+    private readonly CertExpiryRunHistoryStore _history = new();
+
+    public CertExpiryManualCheckTests()
+    {
+        _previousDisabledEnv = Environment.GetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable);
+        Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, null);
+        _settings.Setup(s => s.GetValueAsync<int>(CertExpiryScheduledCheckRunner.WarningDaysSetting, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(30);
+    }
+
+    public void Dispose() =>
+        Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, _previousDisabledEnv);
+
+    [Fact]
+    public async Task RunCheckAsync_ManualRun_DoesNotSendNotificationsByDefault()
+    {
+        const int serverId = 10;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client-expiring");
+        SetupNodeCert(serverId, "client-expiring", DateTimeOffset.UtcNow.AddDays(7));
+
+        var result = await CreateRunner().RunCheckAsync(
+            new RunCertExpiryCheckRequest { VpnServerId = serverId, SendNotifications = false },
+            CancellationToken.None);
+
+        Assert.Equal(CertExpiryRunStatus.Completed, result.Status);
+        Assert.Equal(1, result.Summary.ExpiringSoon);
+        _notifier.Verify(
+            n => n.NotifyExpiringSoonAsync(
+                It.IsAny<IssuedOvpnFile>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunCheckAsync_StoresDetailedServerAndProfileResults()
+    {
+        const int serverId = 10;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client-expired");
+        SetupNodeCert(serverId, "client-expired", DateTimeOffset.UtcNow.AddDays(-1));
+
+        var runner = CreateRunner();
+        var result = await runner.RunCheckAsync(
+            new RunCertExpiryCheckRequest { VpnServerId = serverId },
+            CancellationToken.None);
+
+        Assert.Single(result.Servers);
+        Assert.Equal(CertExpiryServerFetchStatus.Success, result.Servers[0].FetchStatus);
+        Assert.Single(result.Servers[0].Profiles);
+        Assert.Equal(CertExpiryProfileOutcome.Expired, result.Servers[0].Profiles[0].Outcome);
+        Assert.Equal("client-expired", result.Servers[0].Profiles[0].CommonName);
+
+        var fromHistory = _history.Get(result.RunId);
+        Assert.NotNull(fromHistory);
+        Assert.Equal(result.RunId, fromHistory!.RunId);
+    }
+
+    [Fact]
+    public async Task RunCheckAsync_WhenServerFetchFails_RecordsFetchError()
+    {
+        const int serverId = 10;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client-1");
+        _certApi.Setup(c => c.GetAllCertificatesAsync(serverId, It.IsAny<CancellationToken>(), false))
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        var result = await CreateRunner().RunCheckAsync(
+            new RunCertExpiryCheckRequest { VpnServerId = serverId },
+            CancellationToken.None);
+
+        Assert.Equal(CertExpiryRunStatus.Completed, result.Status);
+        Assert.Equal(1, result.Summary.ServerFailures);
+        Assert.Equal("Connection refused", result.Servers[0].FetchError);
+        Assert.Empty(result.Servers[0].Profiles);
+    }
+
+    [Fact]
+    public async Task RunCheckAsync_WhenAlreadyRunning_ReturnsSkipped()
+    {
+        var runner = CreateRunner();
+        var tcs = new TaskCompletionSource<List<VpnServer>>();
+        _servers.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .Returns(tcs.Task);
+
+        var first = runner.RunCheckAsync(new RunCertExpiryCheckRequest(), CancellationToken.None);
+        await Task.Delay(100);
+        var second = await runner.RunCheckAsync(new RunCertExpiryCheckRequest(), CancellationToken.None);
+
+        Assert.Equal(CertExpiryRunStatus.SkippedAlreadyRunning, second.Status);
+        tcs.SetResult([]);
+        await first;
+    }
+
+    private CertExpiryScheduledCheckRunner CreateRunner()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _issuedFiles.Object);
+        services.AddScoped(_ => _servers.Object);
+        services.AddScoped(_ => _certApi.Object);
+        services.AddScoped(_ => _notifier.Object);
+        services.AddScoped(_ => _settings.Object);
+
+        var provider = services.BuildServiceProvider();
+        return new CertExpiryScheduledCheckRunner(
+            NullLogger<CertExpiryScheduledCheckRunner>.Instance,
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            _tracker,
+            _history);
+    }
+
+    private void SetupServer(int serverId)
+    {
+        _servers.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new VpnServer
+                {
+                    Id = serverId,
+                    ServerName = $"Server-{serverId}",
+                    ServerType = VpnServerType.OpenVpn,
+                    ApiUrl = $"http://server-{serverId}"
+                }
+            ]);
+    }
+
+    private void SetupIssuedFile(int serverId, string commonName)
+    {
+        _issuedFiles.Setup(q => q.GetAllActiveByVpnServerIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new IssuedOvpnFile
+                {
+                    Id = commonName.GetHashCode(),
+                    VpnServerId = serverId,
+                    CommonName = commonName,
+                    ExternalId = "ext",
+                    IssuedAt = DateTimeOffset.UtcNow.AddMonths(-1),
+                    IsRevoked = false
+                }
+            ]);
+    }
+
+    private void SetupNodeCert(int serverId, string commonName, DateTimeOffset expiry)
+    {
+        _certApi.Setup(c => c.GetAllCertificatesAsync(serverId, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(
+            [
+                new ServerCertificate
+                {
+                    CommonName = commonName,
+                    ExpiryDate = expiry,
+                    SerialNumber = "serial-1",
+                    Status = expiry <= DateTimeOffset.UtcNow ? CertificateStatus.Expired : CertificateStatus.Active
+                }
+            ]);
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryNotificationServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryNotificationServiceTests.cs
@@ -1,0 +1,70 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.Others.Notifications.CertExpiry;
+using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.SharedModels.Notifications.Requests;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryNotificationServiceTests
+{
+    [Fact]
+    public async Task NotifyExpiredAsync_UsesOvpnCertExpiredPreference()
+    {
+        var notifications = new Mock<INotificationService>();
+        NotifyAdminsRequest? captured = null;
+        notifications
+            .Setup(n => n.NotifyAdmins(It.IsAny<NotifyAdminsRequest>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<NotifyAdminsRequest, IEnumerable<string>, CancellationToken>((req, _, _) => captured = req)
+            .ReturnsAsync(1);
+
+        var sut = new CertExpiryNotificationService(notifications.Object);
+        var issued = new IssuedOvpnFile
+        {
+            Id = 42,
+            VpnServerId = 3,
+            CommonName = "user_1",
+            ExternalId = "100"
+        };
+
+        await sut.NotifyExpiredAsync(
+            issued,
+            "TestServer",
+            DateTimeOffset.UtcNow.AddDays(-1),
+            "ABC123",
+            CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(ApplicationNotificationKind.OvpnCertExpired, captured!.PreferenceKind);
+        Assert.Equal(NotificationSeverity.Error, captured.Severity);
+        Assert.Contains("user_1", captured.Message);
+    }
+
+    [Fact]
+    public async Task NotifyExpiringSoonAsync_UsesWarningPreference()
+    {
+        var notifications = new Mock<INotificationService>();
+        NotifyAdminsRequest? captured = null;
+        notifications
+            .Setup(n => n.NotifyAdmins(It.IsAny<NotifyAdminsRequest>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<NotifyAdminsRequest, IEnumerable<string>, CancellationToken>((req, _, _) => captured = req)
+            .ReturnsAsync(1);
+
+        var sut = new CertExpiryNotificationService(notifications.Object);
+        var issued = new IssuedOvpnFile { Id = 1, VpnServerId = 2, CommonName = "cn", ExternalId = "ext" };
+
+        await sut.NotifyExpiringSoonAsync(
+            issued,
+            "Srv",
+            DateTimeOffset.UtcNow.AddDays(5),
+            5,
+            null,
+            CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(ApplicationNotificationKind.OvpnCertExpiryWarning, captured!.PreferenceKind);
+        Assert.Equal(NotificationSeverity.Warning, captured.Severity);
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryNotificationTrackerTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryNotificationTrackerTests.cs
@@ -1,0 +1,48 @@
+using DataGateMonitor.Services.CertExpiry;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryNotificationTrackerTests
+{
+    [Fact]
+    public void TryMarkNotified_ReturnsFalse_OnDuplicateKey()
+    {
+        var tracker = new CertExpiryNotificationTracker();
+        var expiry = new DateTimeOffset(2026, 6, 30, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.True(tracker.TryMarkNotified(1, "client-a", expiry, "expiring-soon"));
+        Assert.False(tracker.TryMarkNotified(1, "client-a", expiry, "expiring-soon"));
+    }
+
+    [Fact]
+    public void TryMarkNotified_AllowsDifferentAlertKinds()
+    {
+        var tracker = new CertExpiryNotificationTracker();
+        var expiry = new DateTimeOffset(2026, 6, 30, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.True(tracker.TryMarkNotified(1, "client-a", expiry, "expiring-soon"));
+        Assert.True(tracker.TryMarkNotified(1, "client-a", expiry, "expired"));
+    }
+
+    [Fact]
+    public void TryMarkServerCheckFailureNotified_DeduplicatesPerServer()
+    {
+        var tracker = new CertExpiryNotificationTracker();
+
+        Assert.True(tracker.TryMarkServerCheckFailureNotified(7));
+        Assert.False(tracker.TryMarkServerCheckFailureNotified(7));
+        Assert.True(tracker.TryMarkServerCheckFailureNotified(8));
+    }
+
+    [Fact]
+    public void BuildKey_IsStableForUtcAndLocalSameInstant()
+    {
+        var utc = new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero);
+        var local = utc.ToOffset(TimeSpan.FromHours(3));
+
+        var utcKey = CertExpiryNotificationTracker.BuildKey(1, "cn", utc, "expired");
+        var localKey = CertExpiryNotificationTracker.BuildKey(1, "cn", local, "expired");
+
+        Assert.Equal(utcKey, localKey);
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryProdBackupAnalysisTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryProdBackupAnalysisTests.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using System.Globalization;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+/// <summary>
+/// Validates first-run impact against prod backup restored in Docker (<c>datagate_prod_restore</c>).
+/// Snapshot date: backup 2026-06-29, simulation reference 2026-06-30 UTC.
+/// </summary>
+public class CertExpiryProdBackupAnalysisTests
+{
+    private const string DockerContainer = "datagate_prod_restore";
+    private const string DbUser = "datagate";
+    private const string DbName = "datagate_db_prod";
+    private static readonly DateTimeOffset SimulationNow = new(2026, 6, 30, 12, 0, 0, TimeSpan.Zero);
+
+    [SkippableFact]
+    public void ProdBackupSimulation_MatchesExpectedFirstRunImpact()
+    {
+        Skip.IfNot(CanQueryProdRestore(), "Docker container datagate_prod_restore is not available.");
+
+        var activeFiles = LoadActiveIssuedFiles();
+        var servers = LoadVpnServers();
+
+        var result = CertExpiryProdSimulation.Simulate(activeFiles, servers, SimulationNow, warningDays: 30);
+
+        Assert.Equal(1166, result.TotalActiveInDb);
+        Assert.Equal(4, result.OpenVpnServerCount);
+        Assert.Equal(293, result.ProfilesOnEligibleServers);
+        Assert.Equal(873, result.SkippedIneligible);
+        Assert.Equal(1, result.EstimatedExpired);
+        Assert.Equal(0, result.EstimatedExpiringSoon);
+        Assert.Equal(292, result.EstimatedHealthy);
+        Assert.Equal(1, result.EstimatedFirstRunNotifications);
+    }
+
+    [SkippableFact]
+    public void ProdBackupSimulation_FirstRunSqlAndHttpFootprint()
+    {
+        Skip.IfNot(CanQueryProdRestore(), "Docker container datagate_prod_restore is not available.");
+
+        var activeFiles = LoadActiveIssuedFiles();
+        var servers = LoadVpnServers();
+        var eligibleServerCount = servers.Count(CertExpiryScheduledCheckRunner.IsOpenVpnServerCandidate);
+
+        // Mirrors CertExpiryScheduledCheckRunner: Settings + VpnServers + GetAllActiveByVpnServerIds + N cert API calls.
+        const int expectedSqlQueries = 3;
+        var expectedHttpCalls = eligibleServerCount;
+
+        Assert.Equal(4, eligibleServerCount);
+        Assert.Equal(3, expectedSqlQueries);
+        Assert.Equal(4, expectedHttpCalls);
+
+        var profilesLoaded = activeFiles.Count(f =>
+            servers.Where(CertExpiryScheduledCheckRunner.IsOpenVpnServerCandidate).Select(s => s.Id).Contains(f.VpnServerId));
+
+        Assert.Equal(293, profilesLoaded);
+        Assert.True(profilesLoaded < activeFiles.Count, "Optimized query should load fewer rows than all active profiles.");
+    }
+
+    private static bool CanQueryProdRestore()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "docker",
+                Arguments = $"exec {DockerContainer} psql -U {DbUser} -d {DbName} -t -A -c \"SELECT 1\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            process!.WaitForExit(5000);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static List<IssuedOvpnFile> LoadActiveIssuedFiles()
+    {
+        const string sql = """
+            SELECT "Id","VpnServerId","CommonName","ExternalId","IssuedAt"
+            FROM xgb_dashopnvpn."IssuedOvpnFiles"
+            WHERE "IsRevoked" = false;
+            """;
+        var lines = ExecutePsql(sql);
+        return lines.Select(ParseIssuedFile).ToList();
+    }
+
+    private static List<VpnServer> LoadVpnServers()
+    {
+        const string sql = """
+            SELECT "Id","ServerName","ServerType","ApiUrl","IsDisable","IsDeleted"
+            FROM xgb_dashopnvpn."VpnServers";
+            """;
+        var lines = ExecutePsql(sql);
+        return lines.Select(ParseVpnServer).ToList();
+    }
+
+    private static IssuedOvpnFile ParseIssuedFile(string line)
+    {
+        var p = line.Split('|');
+        return new IssuedOvpnFile
+        {
+            Id = int.Parse(p[0], CultureInfo.InvariantCulture),
+            VpnServerId = int.Parse(p[1], CultureInfo.InvariantCulture),
+            CommonName = p[2],
+            ExternalId = p[3],
+            IssuedAt = DateTimeOffset.Parse(p[4], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal),
+            IsRevoked = false
+        };
+    }
+
+    private static VpnServer ParseVpnServer(string line)
+    {
+        var p = line.Split('|');
+        return new VpnServer
+        {
+            Id = int.Parse(p[0], CultureInfo.InvariantCulture),
+            ServerName = p[1],
+            ServerType = (VpnServerType)int.Parse(p[2], CultureInfo.InvariantCulture),
+            ApiUrl = p[3],
+            IsDisable = ParsePostgresBool(p[4]),
+            IsDeleted = ParsePostgresBool(p[5])
+        };
+    }
+
+    private static bool ParsePostgresBool(string value) =>
+        value.Equals("t", StringComparison.OrdinalIgnoreCase)
+        || value.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+    private static List<string> ExecutePsql(string sql)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "docker",
+            Arguments = $"exec -i {DockerContainer} psql -U {DbUser} -d {DbName} -t -A -F|",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi)!;
+        process.StandardInput.WriteLine(sql);
+        process.StandardInput.Close();
+        var output = process.StandardOutput.ReadToEnd();
+        var err = process.StandardError.ReadToEnd();
+        process.WaitForExit(60_000);
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"psql failed: {err}");
+
+        return output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .ToList();
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryProdSimulationTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryProdSimulationTests.cs
@@ -1,0 +1,38 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryProdSimulationTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 30, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Simulate_FiltersIneligibleServersAndEstimatesOutcomes()
+    {
+        var servers = new List<VpnServer>
+        {
+            new() { Id = 1, ServerName = "Open", ServerType = VpnServerType.OpenVpn, ApiUrl = "http://a" },
+            new() { Id = 2, ServerName = "Disabled", ServerType = VpnServerType.OpenVpn, ApiUrl = "http://b", IsDisable = true }
+        };
+
+        var files = new List<IssuedOvpnFile>
+        {
+            new() { Id = 1, VpnServerId = 1, CommonName = "ok", IssuedAt = Now.AddDays(-30), IsRevoked = false },
+            new() { Id = 2, VpnServerId = 1, CommonName = "old", IssuedAt = Now.AddDays(-400), IsRevoked = false },
+            new() { Id = 3, VpnServerId = 2, CommonName = "skipped", IssuedAt = Now.AddDays(-30), IsRevoked = false }
+        };
+
+        var result = CertExpiryProdSimulation.Simulate(files, servers, Now, warningDays: 30);
+
+        Assert.Equal(3, result.TotalActiveInDb);
+        Assert.Equal(1, result.OpenVpnServerCount);
+        Assert.Equal(2, result.ProfilesOnEligibleServers);
+        Assert.Equal(1, result.SkippedIneligible);
+        Assert.Equal(1, result.EstimatedExpired);
+        Assert.Equal(0, result.EstimatedExpiringSoon);
+        Assert.Equal(1, result.EstimatedHealthy);
+        Assert.Equal(1, result.EstimatedFirstRunNotifications);
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryRunHistoryStoreTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryRunHistoryStoreTests.cs
@@ -1,0 +1,94 @@
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryRunHistoryStoreTests
+{
+    [Fact]
+    public void SaveAndGet_RoundTripsRun()
+    {
+        var store = new CertExpiryRunHistoryStore();
+        var runId = Guid.NewGuid();
+        var run = SampleRun(runId, vpnServerId: null, serverIdInResults: 10);
+
+        store.Save(run);
+
+        var loaded = store.Get(runId);
+        Assert.NotNull(loaded);
+        Assert.Equal(runId, loaded!.RunId);
+        Assert.Single(loaded.Servers);
+    }
+
+    [Fact]
+    public void List_OrdersByStartedAtDescending()
+    {
+        var store = new CertExpiryRunHistoryStore();
+        var older = Guid.NewGuid();
+        var newer = Guid.NewGuid();
+
+        store.Save(SampleRun(older, startedAt: DateTimeOffset.UtcNow.AddHours(-2)));
+        store.Save(SampleRun(newer, startedAt: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var list = store.List(limit: 10);
+
+        Assert.Equal(newer, list[0].RunId);
+        Assert.Equal(older, list[1].RunId);
+    }
+
+    [Fact]
+    public void List_FiltersByVpnServerId()
+    {
+        var store = new CertExpiryRunHistoryStore();
+        var allServersRun = Guid.NewGuid();
+        var serverTenRun = Guid.NewGuid();
+
+        store.Save(SampleRun(allServersRun, vpnServerId: null, serverIdInResults: 10));
+        store.Save(SampleRun(serverTenRun, vpnServerId: 10, serverIdInResults: 10));
+        store.Save(SampleRun(Guid.NewGuid(), vpnServerId: 99, serverIdInResults: 99));
+
+        var filtered = store.List(limit: 10, vpnServerId: 10);
+
+        Assert.Equal(2, filtered.Count);
+        Assert.Contains(filtered, r => r.RunId == allServersRun);
+        Assert.Contains(filtered, r => r.RunId == serverTenRun);
+    }
+
+    [Fact]
+    public void List_ClampsLimitToMax()
+    {
+        var store = new CertExpiryRunHistoryStore();
+        for (var i = 0; i < 105; i++)
+            store.Save(SampleRun(Guid.NewGuid(), startedAt: DateTimeOffset.UtcNow.AddMinutes(-i)));
+
+        Assert.Equal(100, store.List(limit: 500).Count);
+    }
+
+    private static CertExpiryCheckRunResponse SampleRun(
+        Guid runId,
+        DateTimeOffset? startedAt = null,
+        int? vpnServerId = null,
+        int serverIdInResults = 1)
+    {
+        return new CertExpiryCheckRunResponse
+        {
+            RunId = runId,
+            StartedAtUtc = startedAt ?? DateTimeOffset.UtcNow,
+            Status = CertExpiryRunStatus.Completed,
+            VpnServerId = vpnServerId,
+            ScopeLabel = vpnServerId?.ToString() ?? "All",
+            Summary = new CertExpiryCheckSummaryDto { ServersChecked = 1, ProfilesChecked = 0 },
+            Servers =
+            [
+                new CertExpiryServerResultDto
+                {
+                    VpnServerId = serverIdInResults,
+                    ServerName = $"Server-{serverIdInResults}",
+                    FetchStatus = CertExpiryServerFetchStatus.Success
+                }
+            ]
+        };
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryRunMapperTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryRunMapperTests.cs
@@ -7,13 +7,14 @@ namespace DataGateMonitor.Tests.Services.CertExpiry;
 
 public class CertExpiryRunMapperTests
 {
-    [Theory]
-    [InlineData(CertExpiryCheckOutcome.None, CertExpiryProfileOutcome.Healthy)]
-    [InlineData(CertExpiryCheckOutcome.ExpiringSoon, CertExpiryProfileOutcome.ExpiringSoon)]
-    [InlineData(CertExpiryCheckOutcome.Expired, CertExpiryProfileOutcome.Expired)]
-    [InlineData(CertExpiryCheckOutcome.MissingOnNode, CertExpiryProfileOutcome.MissingOnNode)]
-    public void ToProfileOutcome_MapsAllOutcomes(CertExpiryCheckOutcome input, CertExpiryProfileOutcome expected) =>
-        Assert.Equal(expected, CertExpiryRunMapper.ToProfileOutcome(input));
+    [Fact]
+    public void ToProfileOutcome_MapsAllOutcomes()
+    {
+        Assert.Equal(CertExpiryProfileOutcome.Healthy, CertExpiryRunMapper.ToProfileOutcome(CertExpiryCheckOutcome.None));
+        Assert.Equal(CertExpiryProfileOutcome.ExpiringSoon, CertExpiryRunMapper.ToProfileOutcome(CertExpiryCheckOutcome.ExpiringSoon));
+        Assert.Equal(CertExpiryProfileOutcome.Expired, CertExpiryRunMapper.ToProfileOutcome(CertExpiryCheckOutcome.Expired));
+        Assert.Equal(CertExpiryProfileOutcome.MissingOnNode, CertExpiryRunMapper.ToProfileOutcome(CertExpiryCheckOutcome.MissingOnNode));
+    }
 
     [Fact]
     public void BuildSummary_CountsProfilesAndServerFailures()

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryRunMapperTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryRunMapperTests.cs
@@ -1,0 +1,72 @@
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryRunMapperTests
+{
+    [Theory]
+    [InlineData(CertExpiryCheckOutcome.None, CertExpiryProfileOutcome.Healthy)]
+    [InlineData(CertExpiryCheckOutcome.ExpiringSoon, CertExpiryProfileOutcome.ExpiringSoon)]
+    [InlineData(CertExpiryCheckOutcome.Expired, CertExpiryProfileOutcome.Expired)]
+    [InlineData(CertExpiryCheckOutcome.MissingOnNode, CertExpiryProfileOutcome.MissingOnNode)]
+    public void ToProfileOutcome_MapsAllOutcomes(CertExpiryCheckOutcome input, CertExpiryProfileOutcome expected) =>
+        Assert.Equal(expected, CertExpiryRunMapper.ToProfileOutcome(input));
+
+    [Fact]
+    public void BuildSummary_CountsProfilesAndServerFailures()
+    {
+        var summary = CertExpiryRunMapper.BuildSummary(
+        [
+            new CertExpiryServerResultDto
+            {
+                FetchStatus = CertExpiryServerFetchStatus.Success,
+                Profiles =
+                [
+                    new CertExpiryProfileResultDto { Outcome = CertExpiryProfileOutcome.Healthy },
+                    new CertExpiryProfileResultDto { Outcome = CertExpiryProfileOutcome.Expired }
+                ]
+            },
+            new CertExpiryServerResultDto
+            {
+                FetchStatus = CertExpiryServerFetchStatus.Failed,
+                Profiles = []
+            }
+        ]);
+
+        Assert.Equal(2, summary.ServersChecked);
+        Assert.Equal(2, summary.ProfilesChecked);
+        Assert.Equal(1, summary.Healthy);
+        Assert.Equal(1, summary.Expired);
+        Assert.Equal(1, summary.ServerFailures);
+    }
+
+    [Fact]
+    public void ToSummary_CopiesRunFields()
+    {
+        var runId = Guid.NewGuid();
+        var run = new CertExpiryCheckRunResponse
+        {
+            RunId = runId,
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            Status = CertExpiryRunStatus.Completed,
+            ScopeLabel = "All eligible servers",
+            Summary = new CertExpiryCheckSummaryDto
+            {
+                ServersChecked = 2,
+                ProfilesChecked = 5,
+                Expired = 1
+            }
+        };
+
+        var summary = CertExpiryRunMapper.ToSummary(run);
+
+        Assert.Equal(runId, summary.RunId);
+        Assert.Equal(CertExpiryRunStatus.Completed, summary.Status);
+        Assert.Equal("All eligible servers", summary.ScopeLabel);
+        Assert.Equal(5, summary.ProfilesChecked);
+        Assert.Equal(1, summary.Expired);
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryScheduledCheckRunnerIntegrationTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryScheduledCheckRunnerIntegrationTests.cs
@@ -22,6 +22,7 @@ public sealed class CertExpiryScheduledCheckRunnerIntegrationTests : IDisposable
     private readonly Mock<ICertExpiryNotificationService> _notifier = new();
     private readonly Mock<ISettingsService> _settings = new();
     private readonly CertExpiryNotificationTracker _tracker = new();
+    private readonly CertExpiryRunHistoryStore _history = new();
 
     public CertExpiryScheduledCheckRunnerIntegrationTests()
     {
@@ -325,7 +326,8 @@ public sealed class CertExpiryScheduledCheckRunnerIntegrationTests : IDisposable
         return new CertExpiryScheduledCheckRunner(
             NullLogger<CertExpiryScheduledCheckRunner>.Instance,
             provider.GetRequiredService<IServiceScopeFactory>(),
-            _tracker);
+            _tracker,
+            _history);
     }
 
     private void SetupServer(int serverId)

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryScheduledCheckRunnerIntegrationTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryScheduledCheckRunnerIntegrationTests.cs
@@ -1,0 +1,377 @@
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.Others.Notifications.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public sealed class CertExpiryScheduledCheckRunnerIntegrationTests : IDisposable
+{
+    private readonly string? _previousDisabledEnv;
+    private readonly Mock<IIssuedOvpnFileQueryService> _issuedFiles = new();
+    private readonly Mock<IVpnServerQueryService> _servers = new();
+    private readonly Mock<ICertApiClient> _certApi = new();
+    private readonly Mock<ICertExpiryNotificationService> _notifier = new();
+    private readonly Mock<ISettingsService> _settings = new();
+    private readonly CertExpiryNotificationTracker _tracker = new();
+
+    public CertExpiryScheduledCheckRunnerIntegrationTests()
+    {
+        _previousDisabledEnv = Environment.GetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable);
+        Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, null);
+        _settings.Setup(s => s.GetValueAsync<int>(CertExpiryScheduledCheckRunner.WarningDaysSetting, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(30);
+    }
+
+    public void Dispose() =>
+        Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, _previousDisabledEnv);
+
+    [Fact]
+    public async Task RunAsync_WhenNoEligibleServers_DoesNotQueryCertificatesOrProfiles()
+    {
+        _servers.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _issuedFiles.Verify(q => q.GetAllActiveByVpnServerIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()), Times.Never);
+        _certApi.Verify(
+            c => c.GetAllCertificatesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenEligibleServersButNoProfiles_DoesNotCallCertApi()
+    {
+        const int serverId = 99;
+        SetupServer(serverId);
+        _issuedFiles.Setup(q => q.GetAllActiveByVpnServerIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _certApi.Verify(
+            c => c.GetAllCertificatesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCertExpiringSoon_NotifiesOnce()
+    {
+        const int serverId = 10;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client-expiring");
+        SetupNodeCert(serverId, "client-expiring", DateTimeOffset.UtcNow.AddDays(7));
+
+        var runner = CreateRunner();
+        await runner.RunAsync(CancellationToken.None);
+        await runner.RunAsync(CancellationToken.None);
+
+        _notifier.Verify(
+            n => n.NotifyExpiringSoonAsync(
+                It.Is<IssuedOvpnFile>(f => f.CommonName == "client-expiring"),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCertExpired_NotifiesExpired()
+    {
+        const int serverId = 11;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client-expired");
+        SetupNodeCert(serverId, "client-expired", DateTimeOffset.UtcNow.AddDays(-2));
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _notifier.Verify(
+            n => n.NotifyExpiredAsync(
+                It.Is<IssuedOvpnFile>(f => f.CommonName == "client-expired"),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _notifier.Verify(
+            n => n.NotifyExpiringSoonAsync(
+                It.IsAny<IssuedOvpnFile>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCertMissingOnNode_NotifiesMissing()
+    {
+        const int serverId = 12;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "missing-client");
+        _certApi.Setup(c => c.GetAllCertificatesAsync(serverId, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync([]);
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _notifier.Verify(
+            n => n.NotifyCertificateMissingAsync(
+                It.Is<IssuedOvpnFile>(f => f.CommonName == "missing-client"),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenServerFetchFails_NotifiesOncePerServer()
+    {
+        const int serverId = 13;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "any");
+        _certApi.Setup(c => c.GetAllCertificatesAsync(serverId, It.IsAny<CancellationToken>(), false))
+            .ThrowsAsync(new HttpRequestException("node offline"));
+
+        var runner = CreateRunner();
+        await runner.RunAsync(CancellationToken.None);
+        await runner.RunAsync(CancellationToken.None);
+
+        _notifier.Verify(
+            n => n.NotifyServerCheckFailedAsync(serverId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_SkipsDisabledAndNonOpenVpnServers()
+    {
+        _servers.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new VpnServer
+                {
+                    Id = 1,
+                    ServerName = "Xray",
+                    ServerType = VpnServerType.Xray,
+                    ApiUrl = "http://xray"
+                },
+                new VpnServer
+                {
+                    Id = 2,
+                    ServerName = "Disabled",
+                    ServerType = VpnServerType.OpenVpn,
+                    ApiUrl = "http://ovpn",
+                    IsDisable = true
+                }
+            ]);
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _issuedFiles.Verify(
+            q => q.GetAllActiveByVpnServerIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _certApi.Verify(
+            c => c.GetAllCertificatesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCertOutsideWarningWindow_DoesNotNotify()
+    {
+        const int serverId = 14;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "healthy-client");
+        SetupNodeCert(serverId, "healthy-client", DateTimeOffset.UtcNow.AddDays(120));
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _notifier.Verify(
+            n => n.NotifyExpiringSoonAsync(
+                It.IsAny<IssuedOvpnFile>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _notifier.Verify(
+            n => n.NotifyExpiredAsync(
+                It.IsAny<IssuedOvpnFile>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesGetAllActiveByVpnServerIds_NotFullTableScan()
+    {
+        const int serverId = 16;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client");
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _issuedFiles.Verify(
+            q => q.GetAllActiveByVpnServerIds(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(serverId)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _issuedFiles.Verify(q => q.GetAllActive(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCustomWarningDays_UsesSettingValue()
+    {
+        const int serverId = 17;
+        _settings.Setup(s => s.GetValueAsync<int>(CertExpiryScheduledCheckRunner.WarningDaysSetting, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(7);
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client-warning-7d");
+        SetupNodeCert(serverId, "client-warning-7d", DateTimeOffset.UtcNow.AddDays(5));
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _notifier.Verify(
+            n => n.NotifyExpiringSoonAsync(
+                It.Is<IssuedOvpnFile>(f => f.CommonName == "client-warning-7d"),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCertRevokedOnNode_NotifiesExpired()
+    {
+        const int serverId = 18;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "revoked-on-node");
+        _certApi.Setup(c => c.GetAllCertificatesAsync(serverId, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(
+            [
+                new ServerCertificate
+                {
+                    CommonName = "revoked-on-node",
+                    ExpiryDate = DateTimeOffset.UtcNow.AddDays(90),
+                    Status = CertificateStatus.Revoked,
+                    IsRevoked = true,
+                    SerialNumber = "rev"
+                }
+            ]);
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _notifier.Verify(
+            n => n.NotifyExpiredAsync(
+                It.Is<IssuedOvpnFile>(f => f.CommonName == "revoked-on-node"),
+                It.IsAny<string>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesSilentCertificateFetch()
+    {
+        const int serverId = 15;
+        SetupServer(serverId);
+        SetupIssuedFile(serverId, "client");
+        SetupNodeCert(serverId, "client", DateTimeOffset.UtcNow.AddDays(120));
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _certApi.Verify(
+            c => c.GetAllCertificatesAsync(serverId, It.IsAny<CancellationToken>(), false),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenDisabledViaEnvironment_DoesNothing()
+    {
+        Environment.SetEnvironmentVariable(CertExpiryEnvironment.DisabledVariable, "true");
+        SetupServer(1);
+        SetupIssuedFile(1, "client");
+
+        await CreateRunner().RunAsync(CancellationToken.None);
+
+        _servers.Verify(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private CertExpiryScheduledCheckRunner CreateRunner()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _issuedFiles.Object);
+        services.AddScoped(_ => _servers.Object);
+        services.AddScoped(_ => _certApi.Object);
+        services.AddScoped(_ => _notifier.Object);
+        services.AddScoped(_ => _settings.Object);
+
+        var provider = services.BuildServiceProvider();
+        return new CertExpiryScheduledCheckRunner(
+            NullLogger<CertExpiryScheduledCheckRunner>.Instance,
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            _tracker);
+    }
+
+    private void SetupServer(int serverId)
+    {
+        _servers.Setup(s => s.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new VpnServer
+                {
+                    Id = serverId,
+                    ServerName = $"Server-{serverId}",
+                    ServerType = VpnServerType.OpenVpn,
+                    ApiUrl = $"http://server-{serverId}"
+                }
+            ]);
+    }
+
+    private void SetupIssuedFile(int serverId, string commonName)
+    {
+        _issuedFiles.Setup(q => q.GetAllActiveByVpnServerIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new IssuedOvpnFile
+                {
+                    Id = commonName.GetHashCode(),
+                    VpnServerId = serverId,
+                    CommonName = commonName,
+                    ExternalId = "ext",
+                    IssuedAt = DateTimeOffset.UtcNow.AddMonths(-1),
+                    IsRevoked = false
+                }
+            ]);
+    }
+
+    private void SetupNodeCert(int serverId, string commonName, DateTimeOffset expiry)
+    {
+        _certApi.Setup(c => c.GetAllCertificatesAsync(serverId, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(
+            [
+                new ServerCertificate
+                {
+                    CommonName = commonName,
+                    ExpiryDate = expiry,
+                    SerialNumber = "serial-1",
+                    Status = expiry <= DateTimeOffset.UtcNow ? CertificateStatus.Expired : CertificateStatus.Active
+                }
+            ]);
+    }
+}

--- a/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryScheduledCheckRunnerTests.cs
+++ b/DataGateMonitor.Tests/Services/CertExpiry/CertExpiryScheduledCheckRunnerTests.cs
@@ -1,0 +1,69 @@
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Tests.Services.CertExpiry;
+
+public class CertExpiryScheduledCheckRunnerTests
+{
+    [Fact]
+    public void BuildCertificateLookup_PrefersActiveCertOverRevoked()
+    {
+        var expiry = DateTimeOffset.UtcNow.AddDays(10);
+        var certs = new List<ServerCertificate>
+        {
+            new()
+            {
+                CommonName = "client1",
+                IsRevoked = true,
+                ExpiryDate = expiry.AddDays(5),
+                SerialNumber = "revoked"
+            },
+            new()
+            {
+                CommonName = "client1",
+                IsRevoked = false,
+                ExpiryDate = expiry,
+                SerialNumber = "active"
+            }
+        };
+
+        var lookup = CertExpiryScheduledCheckRunner.BuildCertificateLookup(certs);
+
+        Assert.Equal("active", lookup["client1"].SerialNumber);
+    }
+
+    [Fact]
+    public void BuildCertificateLookup_WhenOnlyRevoked_UsesRevokedEntry()
+    {
+        var expiry = DateTimeOffset.UtcNow.AddDays(-1);
+        var certs = new List<ServerCertificate>
+        {
+            new()
+            {
+                CommonName = "client1",
+                IsRevoked = true,
+                Status = CertificateStatus.Revoked,
+                ExpiryDate = expiry,
+                SerialNumber = "revoked-only"
+            }
+        };
+
+        var lookup = CertExpiryScheduledCheckRunner.BuildCertificateLookup(certs);
+
+        Assert.Equal("revoked-only", lookup["client1"].SerialNumber);
+    }
+
+    [Fact]
+    public void BuildCertificateLookup_IgnoresEmptyCommonNames()
+    {
+        var lookup = CertExpiryScheduledCheckRunner.BuildCertificateLookup(
+        [
+            new ServerCertificate { CommonName = "", ExpiryDate = DateTimeOffset.UtcNow.AddDays(1) },
+            new ServerCertificate { CommonName = "valid", ExpiryDate = DateTimeOffset.UtcNow.AddDays(1), SerialNumber = "ok" }
+        ]);
+
+        Assert.Single(lookup);
+        Assert.Equal("ok", lookup["valid"].SerialNumber);
+    }
+}

--- a/DataGateMonitor.Tests/Services/PiHoleHealth/PiHoleHealthCheckRunnerTests.cs
+++ b/DataGateMonitor.Tests/Services/PiHoleHealth/PiHoleHealthCheckRunnerTests.cs
@@ -1,0 +1,98 @@
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api;
+using DataGateMonitor.Services.Api.Interfaces;
+using DataGateMonitor.Services.PiHoleHealth;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Diagnostics.Responses;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.PiHoleHealth;
+
+public class PiHoleHealthCheckRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_NotifiesRecoveredAfterPriorUnhealthyAlert()
+    {
+        var server = new VpnServer
+        {
+            Id = 75,
+            ServerName = "Norway",
+            IsPiHoleEnabled = true,
+            IsDeleted = false,
+            IsDisable = false
+        };
+
+        var vpnServers = new Mock<IVpnServerQueryService>();
+        vpnServers.Setup(x => x.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VpnServer> { server });
+
+        var piHoleConfig = new Mock<IVpnServerPiHoleConfigService>();
+        piHoleConfig.SetupSequence(x => x.GetMicroserviceDiagnosticsAsync(75, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PiHoleDiagnosticsResponse
+            {
+                Health = "Disabled",
+                HealthMessage = "Collector is disabled on the VPN microservice."
+            })
+            .ReturnsAsync(new PiHoleDiagnosticsResponse { Health = "Ok" });
+
+        var notifications = new Mock<IPiHoleHealthNotificationService>();
+        var tracker = new PiHoleHealthNotificationTracker();
+        var sut = new PiHoleHealthCheckRunner(
+            Mock.Of<ILogger<PiHoleHealthCheckRunner>>(),
+            vpnServers.Object,
+            piHoleConfig.Object,
+            notifications.Object,
+            tracker);
+
+        await sut.RunAsync(CancellationToken.None);
+        await sut.RunAsync(CancellationToken.None);
+
+        notifications.Verify(
+            x => x.NotifyUnhealthyAsync(
+                75,
+                "Norway",
+                "Disabled",
+                "Collector is disabled on the VPN microservice.",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        notifications.Verify(
+            x => x.NotifyRecoveredAsync(75, "Norway", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_DoesNotNotifyRecoveredWhenServerWasAlwaysHealthy()
+    {
+        var server = new VpnServer
+        {
+            Id = 77,
+            ServerName = "Norway 2",
+            IsPiHoleEnabled = true,
+            IsDeleted = false,
+            IsDisable = false
+        };
+
+        var vpnServers = new Mock<IVpnServerQueryService>();
+        vpnServers.Setup(x => x.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VpnServer> { server });
+
+        var piHoleConfig = new Mock<IVpnServerPiHoleConfigService>();
+        piHoleConfig.Setup(x => x.GetMicroserviceDiagnosticsAsync(77, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PiHoleDiagnosticsResponse { Health = "Ok" });
+
+        var notifications = new Mock<IPiHoleHealthNotificationService>();
+        var sut = new PiHoleHealthCheckRunner(
+            Mock.Of<ILogger<PiHoleHealthCheckRunner>>(),
+            vpnServers.Object,
+            piHoleConfig.Object,
+            notifications.Object,
+            new PiHoleHealthNotificationTracker());
+
+        await sut.RunAsync(CancellationToken.None);
+
+        notifications.Verify(
+            x => x.NotifyRecoveredAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/DataGateMonitor.Tests/Services/PiHoleHealth/PiHoleHealthNotificationServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/PiHoleHealth/PiHoleHealthNotificationServiceTests.cs
@@ -1,0 +1,30 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.PiHoleHealth;
+using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.SharedModels.Notifications.Requests;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.PiHoleHealth;
+
+public class PiHoleHealthNotificationServiceTests
+{
+    [Fact]
+    public async Task NotifyUnhealthyAsync_UsesPiHoleNotificationType()
+    {
+        var notifications = new Mock<INotificationService>();
+        NotifyAdminsRequest? captured = null;
+        notifications.Setup(x => x.NotifyAdmins(It.IsAny<NotifyAdminsRequest>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<NotifyAdminsRequest, IEnumerable<string>, CancellationToken>((req, _, _) => captured = req)
+            .ReturnsAsync(1);
+
+        var sut = new PiHoleHealthNotificationService(notifications.Object);
+        await sut.NotifyUnhealthyAsync(75, "Norway", "Warning", "Collector is disabled", CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(NotificationTypes.PiHoleCollectorUnhealthy, captured!.Type);
+        Assert.Equal(ApplicationNotificationKind.OpenVpnServerSyncError, captured.PreferenceKind);
+        Assert.Equal(NotificationSeverity.Warning, captured.Severity);
+    }
+}

--- a/DataGateMonitor.Tests/Services/PiHoleHealth/PiHoleHealthNotificationServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/PiHoleHealth/PiHoleHealthNotificationServiceTests.cs
@@ -27,4 +27,21 @@ public class PiHoleHealthNotificationServiceTests
         Assert.Equal(ApplicationNotificationKind.OpenVpnServerSyncError, captured.PreferenceKind);
         Assert.Equal(NotificationSeverity.Warning, captured.Severity);
     }
+
+    [Fact]
+    public async Task NotifyRecoveredAsync_UsesPiHoleRecoveredNotificationType()
+    {
+        var notifications = new Mock<INotificationService>();
+        NotifyAdminsRequest? captured = null;
+        notifications.Setup(x => x.NotifyAdmins(It.IsAny<NotifyAdminsRequest>(), It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<NotifyAdminsRequest, IEnumerable<string>, CancellationToken>((req, _, _) => captured = req)
+            .ReturnsAsync(1);
+
+        var sut = new PiHoleHealthNotificationService(notifications.Object);
+        await sut.NotifyRecoveredAsync(75, "Norway", CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(NotificationTypes.PiHoleCollectorRecovered, captured!.Type);
+        Assert.Equal(NotificationSeverity.Info, captured.Severity);
+    }
 }

--- a/DataGateMonitor/Configurations/CertExpiryServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/CertExpiryServiceConfiguration.cs
@@ -7,6 +7,7 @@ public static class CertExpiryServiceConfiguration
     public static void ConfigureCertExpiryServices(this IServiceCollection services, DatabaseRuntimeOptions databaseRuntime)
     {
         services.AddSingleton<CertExpiryNotificationTracker>();
+        services.AddSingleton<ICertExpiryRunHistoryStore, CertExpiryRunHistoryStore>();
         services.AddScoped<ICertExpiryScheduledCheckRunner, CertExpiryScheduledCheckRunner>();
 
         if (databaseRuntime.IsConnectionConfigured)

--- a/DataGateMonitor/Configurations/CertExpiryServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/CertExpiryServiceConfiguration.cs
@@ -1,0 +1,15 @@
+using DataGateMonitor.Services.CertExpiry;
+
+namespace DataGateMonitor.Configurations;
+
+public static class CertExpiryServiceConfiguration
+{
+    public static void ConfigureCertExpiryServices(this IServiceCollection services, DatabaseRuntimeOptions databaseRuntime)
+    {
+        services.AddSingleton<CertExpiryNotificationTracker>();
+        services.AddScoped<ICertExpiryScheduledCheckRunner, CertExpiryScheduledCheckRunner>();
+
+        if (databaseRuntime.IsConnectionConfigured)
+            services.AddHostedService<CertExpiryBackgroundService>();
+    }
+}

--- a/DataGateMonitor/Configurations/NotificationConfiguration.cs
+++ b/DataGateMonitor/Configurations/NotificationConfiguration.cs
@@ -6,6 +6,7 @@ using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
 using DataGateMonitor.Services.Others.Notifications.GeoLite;
 using DataGateMonitor.Services.Others.Notifications.TrafficDaily;
+using DataGateMonitor.Services.Others.Notifications.CertExpiry;
 using DataGateMonitor.Hubs;
 
 namespace DataGateMonitor.Configurations;
@@ -29,6 +30,7 @@ public static class NotificationConfiguration
         services.AddScoped<IOpenVpnMicroserviceNotificationService, OpenVpnMicroserviceNotificationService>();
         services.AddScoped<IGeoLiteNotificationService, GeoLiteNotificationService>();
         services.AddScoped<ITrafficDailyRollupNotificationService, TrafficDailyRollupNotificationService>();
+        services.AddScoped<ICertExpiryNotificationService, CertExpiryNotificationService>();
 
         // Admin hub adapter for WebNotifier
         services.AddSingleton<IAdminNotificationHub, AdminNotificationHubService>(); // <— ADD THIS

--- a/DataGateMonitor/Controllers/CertExpiryController.cs
+++ b/DataGateMonitor/Controllers/CertExpiryController.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.Services.Api.Auth.Handlers.Interfaces;
+using DataGateMonitor.Services.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateMonitor.Controllers;
+
+[ApiController]
+[Route("api/cert-expiry")]
+[Authorize]
+[Authorize(Roles = "Admin,App")]
+public class CertExpiryController(
+    ICertExpiryScheduledCheckRunner checkRunner,
+    ICertExpiryRunHistoryStore runHistoryStore,
+    IVpnServerAccessQueryService vpnServerAccessQueryService) : BaseController
+{
+    [HttpPost("check")]
+    public async Task<ActionResult<ApiResponse<CertExpiryCheckRunResponse>>> RunCheck(
+        [FromBody] RunCertExpiryCheckRequest request,
+        CancellationToken ct)
+    {
+        if (request.VpnServerId is int serverId
+            && await VpnServerAuthorizationHelper.RequireVpnServerAccessOrForbidAsync<CertExpiryCheckRunResponse>(
+                User, vpnServerAccessQueryService, serverId, ct) is { } deny)
+        {
+            return deny;
+        }
+
+        var result = await checkRunner.RunCheckAsync(request, ct).ConfigureAwait(false);
+        return Ok(ApiResponse<CertExpiryCheckRunResponse>.SuccessResponse(result));
+    }
+
+    [HttpGet("runs")]
+    public ActionResult<ApiResponse<GetCertExpiryRunsResponse>> GetRuns(
+        [FromQuery] int limit = 20,
+        [FromQuery] int? vpnServerId = null)
+    {
+        var response = new GetCertExpiryRunsResponse
+        {
+            Runs = runHistoryStore.List(limit, vpnServerId).ToList()
+        };
+
+        return Ok(ApiResponse<GetCertExpiryRunsResponse>.SuccessResponse(response));
+    }
+
+    [HttpGet("runs/{runId:guid}")]
+    public ActionResult<ApiResponse<CertExpiryCheckRunResponse>> GetRun([FromRoute] Guid runId)
+    {
+        var run = runHistoryStore.Get(runId);
+        if (run is null)
+            return NotFound(ApiResponse<CertExpiryCheckRunResponse>.ErrorResponse("Run not found."));
+
+        return Ok(ApiResponse<CertExpiryCheckRunResponse>.SuccessResponse(run));
+    }
+}

--- a/DataGateMonitor/Controllers/VpnDnsQueryController.cs
+++ b/DataGateMonitor/Controllers/VpnDnsQueryController.cs
@@ -1,7 +1,9 @@
 using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.VpnDnsQueryLogTable;
+using DataGateMonitor.Models;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnDnsQuery.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnDnsQuery.Responses;
 using DataGateMonitor.SharedModels.Responses;
@@ -11,14 +13,18 @@ namespace DataGateMonitor.Controllers;
 [ApiController]
 [Route("api/vpn-dns-queries")]
 [Authorize(Roles = "Admin")]
-public class VpnDnsQueryController(IVpnDnsQueryLogQueryService queryService) : BaseController
+public class VpnDnsQueryController(
+    IVpnDnsQueryLogQueryService queryService,
+    IIssuedOvpnFileQueryService issuedOvpnFileQueryService) : BaseController
 {
     [HttpGet("search")]
     public async Task<ActionResult<ApiResponse<VpnDnsQueryPageResponse>>> Search(
         [FromQuery] GetVpnDnsQueryRequest request,
-        CancellationToken cancellationToken)
+        [FromQuery] bool matchUserProfiles = false,
+        CancellationToken cancellationToken = default)
     {
-        var page = await queryService.SearchAsync(request, cancellationToken);
+        var profileCommonNames = await ResolveProfileCommonNamesAsync(request.ExternalId, matchUserProfiles, cancellationToken);
+        var page = await queryService.SearchAsync(request, cancellationToken, profileCommonNames);
         var response = new VpnDnsQueryPageResponse
         {
             Page = page.Page,
@@ -28,6 +34,76 @@ public class VpnDnsQueryController(IVpnDnsQueryLogQueryService queryService) : B
         };
 
         return Ok(ApiResponse<VpnDnsQueryPageResponse>.SuccessResponse(response));
+    }
+
+    [HttpGet("profile-summary")]
+    public async Task<ActionResult<ApiResponse<IReadOnlyList<VpnDnsProfileSummaryResponseItem>>>> ProfileSummary(
+        [FromQuery] string externalId,
+        [FromQuery] int vpnServerId = 0,
+        [FromQuery] DateTimeOffset? fromUtc = null,
+        [FromQuery] DateTimeOffset? toUtc = null,
+        CancellationToken cancellationToken = default)
+    {
+        var ext = externalId?.Trim() ?? string.Empty;
+        var issuedFiles = ext.Length == 0
+            ? []
+            : await issuedOvpnFileQueryService.GetAllByExternalId(ext, cancellationToken);
+
+        var profileCommonNames = issuedFiles
+            .Select(f => f.CommonName)
+            .Where(cn => !string.IsNullOrWhiteSpace(cn))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var dnsByCn = await queryService.GetProfileSummaryAsync(
+            ext,
+            profileCommonNames,
+            vpnServerId,
+            fromUtc,
+            toUtc,
+            cancellationToken);
+
+        var dnsLookup = dnsByCn.ToDictionary(
+            x => ProfileKey(x.CommonName, x.VpnServerId),
+            x => x,
+            StringComparer.Ordinal);
+
+        var items = issuedFiles
+            .GroupBy(f => ProfileKey(f.CommonName, f.VpnServerId))
+            .Select(g =>
+            {
+                var sample = g.First();
+                dnsLookup.TryGetValue(ProfileKey(sample.CommonName, sample.VpnServerId), out var dns);
+                return new VpnDnsProfileSummaryResponseItem
+                {
+                    CommonName = sample.CommonName,
+                    VpnServerId = sample.VpnServerId,
+                    IsRevoked = sample.IsRevoked,
+                    QueryCount = dns?.QueryCount ?? 0,
+                    LastQueriedAtUtc = dns?.LastQueriedAtUtc
+                };
+            })
+            .OrderByDescending(x => x.QueryCount)
+            .ThenBy(x => x.CommonName, StringComparer.Ordinal)
+            .ToList();
+
+        foreach (var dns in dnsByCn)
+        {
+            var key = ProfileKey(dns.CommonName, dns.VpnServerId);
+            if (items.Any(x => ProfileKey(x.CommonName, x.VpnServerId) == key))
+                continue;
+
+            items.Add(new VpnDnsProfileSummaryResponseItem
+            {
+                CommonName = dns.CommonName,
+                VpnServerId = dns.VpnServerId,
+                IsRevoked = false,
+                QueryCount = dns.QueryCount,
+                LastQueriedAtUtc = dns.LastQueriedAtUtc
+            });
+        }
+
+        return Ok(ApiResponse<IReadOnlyList<VpnDnsProfileSummaryResponseItem>>.SuccessResponse(items));
     }
 
     [HttpGet("top-domains")]
@@ -41,4 +117,38 @@ public class VpnDnsQueryController(IVpnDnsQueryLogQueryService queryService) : B
             Items = items
         }));
     }
+
+    private async Task<IReadOnlyList<string>?> ResolveProfileCommonNamesAsync(
+        string? externalId,
+        bool matchUserProfiles,
+        CancellationToken cancellationToken)
+    {
+        if (!matchUserProfiles || string.IsNullOrWhiteSpace(externalId))
+            return null;
+
+        var files = await issuedOvpnFileQueryService.GetAllByExternalId(externalId.Trim(), cancellationToken);
+        var names = files
+            .Select(f => f.CommonName)
+            .Where(cn => !string.IsNullOrWhiteSpace(cn))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        return names.Count == 0 ? null : names;
+    }
+
+    private static string ProfileKey(string commonName, int vpnServerId) =>
+        $"{vpnServerId}|{commonName}";
+}
+
+public sealed class VpnDnsProfileSummaryResponseItem
+{
+    public string CommonName { get; set; } = string.Empty;
+
+    public int VpnServerId { get; set; }
+
+    public bool IsRevoked { get; set; }
+
+    public int QueryCount { get; set; }
+
+    public DateTimeOffset? LastQueriedAtUtc { get; set; }
 }

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.56</Version>
-        <AssemblyVersion>1.0.3.56</AssemblyVersion>
-        <FileVersion>1.0.3.56</FileVersion>
+        <Version>1.0.3.57</Version>
+        <AssemblyVersion>1.0.3.57</AssemblyVersion>
+        <FileVersion>1.0.3.57</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.31" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.54</Version>
-        <AssemblyVersion>1.0.3.54</AssemblyVersion>
-        <FileVersion>1.0.3.54</FileVersion>
+        <Version>1.0.3.55</Version>
+        <AssemblyVersion>1.0.3.55</AssemblyVersion>
+        <FileVersion>1.0.3.55</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.29" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.30" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />
@@ -65,6 +65,10 @@
       <Content Update="data/startup-history.json">
         <CopyToPublishDirectory>Never</CopyToPublishDirectory>
       </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="DataGateMonitor.Tests" />
     </ItemGroup>
 
 </Project>

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.55</Version>
-        <AssemblyVersion>1.0.3.55</AssemblyVersion>
-        <FileVersion>1.0.3.55</FileVersion>
+        <Version>1.0.3.56</Version>
+        <AssemblyVersion>1.0.3.56</AssemblyVersion>
+        <FileVersion>1.0.3.56</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/Program.cs
+++ b/DataGateMonitor/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using DataGateMonitor.Configurations;
+using DataGateMonitor.Services.PiHoleHealth;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 
@@ -45,6 +46,7 @@ builder.Services.ConfigureQueryCommand();
 builder.Services.ConfigureTelegramServices();
 builder.Services.ConfigureGeoLiteServices(databaseRuntime);
 builder.Services.ConfigureCertExpiryServices(databaseRuntime);
+builder.Services.ConfigurePiHoleHealthServices(databaseRuntime);
 builder.Services.ConfigureAdminEmailBroadcast();
 builder.Services.ConfigureAuthServices(builder.Configuration);
 builder.Services.DataBaseServices(builder.Configuration, logger, databaseRuntime);

--- a/DataGateMonitor/Program.cs
+++ b/DataGateMonitor/Program.cs
@@ -44,6 +44,7 @@ builder.Services.ConfigureServices(builder.Configuration, databaseRuntime);
 builder.Services.ConfigureQueryCommand();
 builder.Services.ConfigureTelegramServices();
 builder.Services.ConfigureGeoLiteServices(databaseRuntime);
+builder.Services.ConfigureCertExpiryServices(databaseRuntime);
 builder.Services.ConfigureAdminEmailBroadcast();
 builder.Services.ConfigureAuthServices(builder.Configuration);
 builder.Services.DataBaseServices(builder.Configuration, logger, databaseRuntime);

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryBackgroundService.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryBackgroundService.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Hosting;
+
+namespace DataGateMonitor.Services.CertExpiry;
+
+/// <summary>
+/// Polls OpenVPN nodes for client certificate expiry and notifies admins when issued profiles need renewal.
+/// Join key: <see cref="Models.IssuedOvpnFile.CommonName"/> ↔ PKI <c>index.txt</c> (serial in <c>CertId</c> is not persisted today).
+/// </summary>
+public sealed class CertExpiryBackgroundService(
+    ILogger<CertExpiryBackgroundService> logger,
+    ICertExpiryScheduledCheckRunner scheduledCheckRunner) : BackgroundService
+{
+    private static readonly TimeSpan LoopDelay = TimeSpan.FromHours(1);
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(1);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!CertExpiryEnvironment.IsEnabled())
+        {
+            logger.LogInformation("{Service} is disabled via {Variable}",
+                nameof(CertExpiryBackgroundService),
+                CertExpiryEnvironment.DisabledVariable);
+            return;
+        }
+
+        logger.LogInformation("{Service} started", nameof(CertExpiryBackgroundService));
+
+        await Task.Delay(StartupDelay, stoppingToken).ConfigureAwait(false);
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await scheduledCheckRunner.RunAsync(stoppingToken).ConfigureAwait(false);
+                await Task.Delay(LoopDelay, stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // shutdown
+        }
+
+        logger.LogInformation("{Service} stopped", nameof(CertExpiryBackgroundService));
+    }
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryClassifier.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryClassifier.cs
@@ -1,0 +1,45 @@
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Services.CertExpiry;
+
+internal enum CertExpiryCheckOutcome
+{
+    None,
+    MissingOnNode,
+    Expired,
+    ExpiringSoon
+}
+
+internal static class CertExpiryClassifier
+{
+    public const int DefaultCertLifetimeDays = 365;
+
+    public static CertExpiryCheckOutcome Classify(
+        ServerCertificate? cert,
+        DateTimeOffset now,
+        DateTimeOffset warningThreshold)
+    {
+        if (cert is null)
+            return CertExpiryCheckOutcome.MissingOnNode;
+
+        var expiryUtc = cert.ExpiryDate.ToUniversalTime();
+        if (cert.Status == CertificateStatus.Expired
+            || cert.Status == CertificateStatus.Revoked
+            || expiryUtc <= now)
+        {
+            return CertExpiryCheckOutcome.Expired;
+        }
+
+        if (expiryUtc <= warningThreshold)
+            return CertExpiryCheckOutcome.ExpiringSoon;
+
+        return CertExpiryCheckOutcome.None;
+    }
+
+    public static DateTimeOffset EstimateExpiryFromIssuedAt(DateTimeOffset issuedAt, int lifetimeDays = DefaultCertLifetimeDays) =>
+        issuedAt.ToUniversalTime().AddDays(lifetimeDays);
+
+    public static int EstimateDaysLeft(DateTimeOffset expiryUtc, DateTimeOffset now) =>
+        Math.Max(0, (int)Math.Ceiling((expiryUtc.ToUniversalTime() - now.ToUniversalTime()).TotalDays));
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryEnvironment.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryEnvironment.cs
@@ -1,0 +1,13 @@
+namespace DataGateMonitor.Services.CertExpiry;
+
+public static class CertExpiryEnvironment
+{
+    public const string DisabledVariable = "OVPN_CERT_EXPIRY_CHECK_DISABLED";
+
+    public static bool IsEnabled()
+    {
+        var raw = Environment.GetEnvironmentVariable(DisabledVariable);
+        return !string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase)
+               && raw != "1";
+    }
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryNotificationTracker.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryNotificationTracker.cs
@@ -1,0 +1,24 @@
+using System.Collections.Concurrent;
+
+namespace DataGateMonitor.Services.CertExpiry;
+
+/// <summary>In-memory deduplication so hourly polls do not spam admins for the same profile/expiry.</summary>
+public sealed class CertExpiryNotificationTracker
+{
+    private const string ServerFailureCommonName = "_server_check_";
+    private static readonly DateTimeOffset ServerFailureExpiryAnchor = DateTimeOffset.UnixEpoch;
+
+    private readonly ConcurrentDictionary<string, byte> _sent = new();
+
+    public bool TryMarkNotified(int vpnServerId, string commonName, DateTimeOffset expiryUtc, string alertKind)
+    {
+        var key = BuildKey(vpnServerId, commonName, expiryUtc, alertKind);
+        return _sent.TryAdd(key, 0);
+    }
+
+    public bool TryMarkServerCheckFailureNotified(int vpnServerId) =>
+        TryMarkNotified(vpnServerId, ServerFailureCommonName, ServerFailureExpiryAnchor, "server-check-failed");
+
+    internal static string BuildKey(int vpnServerId, string commonName, DateTimeOffset expiryUtc, string alertKind) =>
+        $"{vpnServerId}|{commonName}|{expiryUtc.UtcDateTime:yyyyMMddHHmmss}|{alertKind}";
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryProdSimulation.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryProdSimulation.cs
@@ -1,0 +1,73 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Services.CertExpiry;
+
+/// <summary>Offline LINQ simulation of the scheduled check using DB rows only (PKI expiry estimated from IssuedAt).</summary>
+internal sealed record CertExpiryProdSimulationResult(
+    int TotalActiveInDb,
+    int OpenVpnServerCount,
+    int ProfilesOnEligibleServers,
+    int SkippedIneligible,
+    int EstimatedExpired,
+    int EstimatedExpiringSoon,
+    int EstimatedHealthy,
+    int EstimatedFirstRunNotifications);
+
+internal static class CertExpiryProdSimulation
+{
+    public static CertExpiryProdSimulationResult Simulate(
+        IReadOnlyList<IssuedOvpnFile> activeFiles,
+        IReadOnlyList<VpnServer> allServers,
+        DateTimeOffset nowUtc,
+        int warningDays,
+        int certLifetimeDays = CertExpiryClassifier.DefaultCertLifetimeDays)
+    {
+        var eligibleServerIds = allServers
+            .Where(CertExpiryScheduledCheckRunner.IsOpenVpnServerCandidate)
+            .Select(s => s.Id)
+            .ToHashSet();
+
+        var onEligible = activeFiles.Where(f => eligibleServerIds.Contains(f.VpnServerId)).ToList();
+        var warningThreshold = nowUtc.AddDays(warningDays);
+
+        var expired = 0;
+        var expiringSoon = 0;
+        var healthy = 0;
+
+        foreach (var file in onEligible)
+        {
+            var estExpiry = CertExpiryClassifier.EstimateExpiryFromIssuedAt(file.IssuedAt, certLifetimeDays);
+            var cert = new ServerCertificate
+            {
+                CommonName = file.CommonName,
+                ExpiryDate = estExpiry,
+                Status = estExpiry <= nowUtc ? CertificateStatus.Expired : CertificateStatus.Active
+            };
+
+            switch (CertExpiryClassifier.Classify(cert, nowUtc, warningThreshold))
+            {
+                case CertExpiryCheckOutcome.Expired:
+                    expired++;
+                    break;
+                case CertExpiryCheckOutcome.ExpiringSoon:
+                    expiringSoon++;
+                    break;
+                default:
+                    healthy++;
+                    break;
+            }
+        }
+
+        return new CertExpiryProdSimulationResult(
+            TotalActiveInDb: activeFiles.Count,
+            OpenVpnServerCount: eligibleServerIds.Count,
+            ProfilesOnEligibleServers: onEligible.Count,
+            SkippedIneligible: activeFiles.Count - onEligible.Count,
+            EstimatedExpired: expired,
+            EstimatedExpiringSoon: expiringSoon,
+            EstimatedHealthy: healthy,
+            EstimatedFirstRunNotifications: expired + expiringSoon);
+    }
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryRunHistoryStore.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryRunHistoryStore.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+
+namespace DataGateMonitor.Services.CertExpiry;
+
+public interface ICertExpiryRunHistoryStore
+{
+    void Save(CertExpiryCheckRunResponse run);
+
+    CertExpiryCheckRunResponse? Get(Guid runId);
+
+    IReadOnlyList<CertExpiryRunSummaryDto> List(int limit, int? vpnServerId = null);
+}
+
+public sealed class CertExpiryRunHistoryStore : ICertExpiryRunHistoryStore
+{
+    private const int MaxRuns = 100;
+    private readonly ConcurrentDictionary<Guid, CertExpiryCheckRunResponse> _runs = new();
+
+    public void Save(CertExpiryCheckRunResponse run)
+    {
+        _runs[run.RunId] = run;
+        TrimIfNeeded();
+    }
+
+    public CertExpiryCheckRunResponse? Get(Guid runId) =>
+        _runs.TryGetValue(runId, out var run) ? run : null;
+
+    public IReadOnlyList<CertExpiryRunSummaryDto> List(int limit, int? vpnServerId = null)
+    {
+        limit = Math.Clamp(limit, 1, MaxRuns);
+
+        var query = _runs.Values.AsEnumerable();
+
+        if (vpnServerId is int serverId)
+            query = query.Where(r => r.VpnServerId == serverId || r.Servers.Any(s => s.VpnServerId == serverId));
+
+        return query
+            .OrderByDescending(r => r.StartedAtUtc)
+            .Take(limit)
+            .Select(CertExpiryRunMapper.ToSummary)
+            .ToList();
+    }
+
+    private void TrimIfNeeded()
+    {
+        if (_runs.Count <= MaxRuns)
+            return;
+
+        var toRemove = _runs.Values
+            .OrderBy(r => r.StartedAtUtc)
+            .Take(_runs.Count - MaxRuns)
+            .Select(r => r.RunId)
+            .ToList();
+
+        foreach (var id in toRemove)
+            _runs.TryRemove(id, out _);
+    }
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryRunMapper.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryRunMapper.cs
@@ -1,0 +1,55 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Services.CertExpiry;
+
+internal static class CertExpiryRunMapper
+{
+    public static CertExpiryProfileOutcome ToProfileOutcome(CertExpiryCheckOutcome outcome) =>
+        outcome switch
+        {
+            CertExpiryCheckOutcome.ExpiringSoon => CertExpiryProfileOutcome.ExpiringSoon,
+            CertExpiryCheckOutcome.Expired => CertExpiryProfileOutcome.Expired,
+            CertExpiryCheckOutcome.MissingOnNode => CertExpiryProfileOutcome.MissingOnNode,
+            _ => CertExpiryProfileOutcome.Healthy
+        };
+
+    public static CertExpiryCheckSummaryDto BuildSummary(IEnumerable<CertExpiryServerResultDto> servers)
+    {
+        var serverList = servers.ToList();
+        var profiles = serverList.SelectMany(s => s.Profiles).ToList();
+
+        return new CertExpiryCheckSummaryDto
+        {
+            ServersChecked = serverList.Count(s => s.FetchStatus != CertExpiryServerFetchStatus.Skipped),
+            ProfilesChecked = profiles.Count,
+            Healthy = profiles.Count(p => p.Outcome == CertExpiryProfileOutcome.Healthy),
+            ExpiringSoon = profiles.Count(p => p.Outcome == CertExpiryProfileOutcome.ExpiringSoon),
+            Expired = profiles.Count(p => p.Outcome == CertExpiryProfileOutcome.Expired),
+            MissingOnNode = profiles.Count(p => p.Outcome == CertExpiryProfileOutcome.MissingOnNode),
+            ServerFailures = serverList.Count(s => s.FetchStatus == CertExpiryServerFetchStatus.Failed)
+        };
+    }
+
+    public static CertExpiryRunSummaryDto ToSummary(CertExpiryCheckRunResponse run) =>
+        new()
+        {
+            RunId = run.RunId,
+            StartedAtUtc = run.StartedAtUtc,
+            FinishedAtUtc = run.FinishedAtUtc,
+            DurationMs = run.DurationMs,
+            Status = run.Status,
+            VpnServerId = run.VpnServerId,
+            ScopeLabel = run.ScopeLabel,
+            SendNotifications = run.SendNotifications,
+            IsScheduled = run.IsScheduled,
+            ServersChecked = run.Summary.ServersChecked,
+            ProfilesChecked = run.Summary.ProfilesChecked,
+            Expired = run.Summary.Expired,
+            ExpiringSoon = run.Summary.ExpiringSoon,
+            MissingOnNode = run.Summary.MissingOnNode,
+            ServerFailures = run.Summary.ServerFailures,
+            ErrorMessage = run.ErrorMessage
+        };
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryScheduledCheckRunner.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryScheduledCheckRunner.cs
@@ -1,0 +1,245 @@
+using Microsoft.Extensions.DependencyInjection;
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.Others.Notifications.CertExpiry;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.Enums;
+
+namespace DataGateMonitor.Services.CertExpiry;
+
+public sealed class CertExpiryScheduledCheckRunner(
+    ILogger<CertExpiryScheduledCheckRunner> logger,
+    IServiceScopeFactory scopeFactory,
+    CertExpiryNotificationTracker notificationTracker) : ICertExpiryScheduledCheckRunner
+{
+    public const string WarningDaysSetting = "OvpnCertExpiry_Warning_Days";
+
+    private const int DefaultWarningDays = 30;
+    private const string AlertExpiringSoon = "expiring-soon";
+    private const string AlertExpired = "expired";
+    private const string AlertMissing = "missing-on-node";
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        if (!CertExpiryEnvironment.IsEnabled())
+            return;
+
+        try
+        {
+            await RunCoreAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "OpenVPN certificate expiry check failed");
+        }
+    }
+
+    private async Task RunCoreAsync(CancellationToken ct)
+    {
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var settings = scope.ServiceProvider.GetRequiredService<ISettingsService>();
+        var issuedFileQuery = scope.ServiceProvider.GetRequiredService<IIssuedOvpnFileQueryService>();
+        var vpnServerQuery = scope.ServiceProvider.GetRequiredService<IVpnServerQueryService>();
+        var certApiClient = scope.ServiceProvider.GetRequiredService<ICertApiClient>();
+        var notifier = scope.ServiceProvider.GetRequiredService<ICertExpiryNotificationService>();
+
+        var warningDays = await settings.GetValueAsync<int>(WarningDaysSetting, ct).ConfigureAwait(false);
+        if (warningDays <= 0)
+            warningDays = DefaultWarningDays;
+
+        var servers = (await vpnServerQuery.GetAll(ct: ct).ConfigureAwait(false))
+            .Where(IsOpenVpnServerCandidate)
+            .ToDictionary(s => s.Id);
+
+        if (servers.Count == 0)
+            return;
+
+        var activeFiles = await issuedFileQuery
+            .GetAllActiveByVpnServerIds(servers.Keys, ct)
+            .ConfigureAwait(false);
+
+        if (activeFiles.Count == 0)
+            return;
+
+        var filesByServer = activeFiles
+            .GroupBy(f => f.VpnServerId)
+            .ToList();
+
+        var now = DateTimeOffset.UtcNow;
+        var warningThreshold = now.AddDays(warningDays);
+
+        logger.LogInformation(
+            "OpenVPN cert expiry check: {FileCount} active profile(s) on {ServerCount} server(s); warning window {WarningDays} day(s)",
+            activeFiles.Count,
+            filesByServer.Count,
+            warningDays);
+
+        foreach (var serverGroup in filesByServer)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var server = servers[serverGroup.Key];
+            List<ServerCertificate> nodeCerts;
+            try
+            {
+                nodeCerts = await certApiClient
+                    .GetAllCertificatesAsync(server.Id, ct, notifyRead: false)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Failed to fetch certificates from server {ServerId} ({ServerName})",
+                    server.Id,
+                    server.ServerName);
+
+                if (!notificationTracker.TryMarkServerCheckFailureNotified(server.Id))
+                    continue;
+
+                await notifier.NotifyServerCheckFailedAsync(
+                    server.Id,
+                    server.ServerName,
+                    ex.Message,
+                    ct).ConfigureAwait(false);
+                continue;
+            }
+
+            var certsByCommonName = BuildCertificateLookup(nodeCerts);
+
+            foreach (var issuedFile in serverGroup)
+            {
+                await EvaluateIssuedFileAsync(
+                    issuedFile,
+                    server,
+                    certsByCommonName,
+                    now,
+                    warningThreshold,
+                    notifier,
+                    ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task EvaluateIssuedFileAsync(
+        IssuedOvpnFile issuedFile,
+        VpnServer server,
+        IReadOnlyDictionary<string, ServerCertificate> certsByCommonName,
+        DateTimeOffset now,
+        DateTimeOffset warningThreshold,
+        ICertExpiryNotificationService notifier,
+        CancellationToken ct)
+    {
+        certsByCommonName.TryGetValue(issuedFile.CommonName, out var cert);
+
+        var outcome = CertExpiryClassifier.Classify(cert, now, warningThreshold);
+
+        if (outcome == CertExpiryCheckOutcome.MissingOnNode)
+        {
+            if (!notificationTracker.TryMarkNotified(
+                    issuedFile.VpnServerId, issuedFile.CommonName, issuedFile.IssuedAt, AlertMissing))
+            {
+                return;
+            }
+
+            logger.LogWarning(
+                "Issued OVPN profile {IssuedOvpnFileId} CN={CommonName} not found on server {ServerId}",
+                issuedFile.Id,
+                issuedFile.CommonName,
+                server.Id);
+            await notifier.NotifyCertificateMissingAsync(issuedFile, server.ServerName, ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (!PathsMatch(issuedFile, cert!))
+        {
+            logger.LogDebug(
+                "Issued file paths differ from PKI for CN={CommonName} on server {ServerId}: " +
+                "DbCert={DbCertPath}, NodeCert={NodeCertPath}, DbKey={DbKeyPath}, NodeKey={NodeKeyPath}",
+                issuedFile.CommonName,
+                server.Id,
+                issuedFile.CertFilePath,
+                cert!.CertificatePath,
+                issuedFile.KeyFilePath,
+                cert.KeyPath);
+        }
+
+        var expiryUtc = cert!.ExpiryDate.ToUniversalTime();
+
+        if (outcome == CertExpiryCheckOutcome.Expired)
+        {
+            if (!notificationTracker.TryMarkNotified(
+                    issuedFile.VpnServerId, issuedFile.CommonName, expiryUtc, AlertExpired))
+            {
+                return;
+            }
+
+            await notifier.NotifyExpiredAsync(
+                issuedFile,
+                server.ServerName,
+                expiryUtc,
+                cert.SerialNumber,
+                ct).ConfigureAwait(false);
+            return;
+        }
+
+        if (outcome == CertExpiryCheckOutcome.ExpiringSoon)
+        {
+            var daysLeft = CertExpiryClassifier.EstimateDaysLeft(expiryUtc, now);
+            if (!notificationTracker.TryMarkNotified(
+                    issuedFile.VpnServerId, issuedFile.CommonName, expiryUtc, AlertExpiringSoon))
+            {
+                return;
+            }
+
+            await notifier.NotifyExpiringSoonAsync(
+                issuedFile,
+                server.ServerName,
+                expiryUtc,
+                daysLeft,
+                cert.SerialNumber,
+                ct).ConfigureAwait(false);
+        }
+    }
+
+    internal static bool IsOpenVpnServerCandidate(VpnServer server) =>
+        !server.IsDeleted
+        && !server.IsDisable
+        && server.ServerType == VpnServerType.OpenVpn
+        && !string.IsNullOrWhiteSpace(server.ApiUrl);
+
+    internal static Dictionary<string, ServerCertificate> BuildCertificateLookup(IEnumerable<ServerCertificate> nodeCerts)
+    {
+        return nodeCerts
+            .Where(c => !string.IsNullOrWhiteSpace(c.CommonName))
+            .GroupBy(c => c.CommonName, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => g
+                    .OrderBy(c => c.IsRevoked)
+                    .ThenByDescending(c => c.ExpiryDate)
+                    .First(),
+                StringComparer.Ordinal);
+    }
+
+    private static bool PathsMatch(IssuedOvpnFile issuedFile, ServerCertificate cert)
+    {
+        var certMatch = string.IsNullOrWhiteSpace(issuedFile.CertFilePath)
+                        || string.Equals(
+                            issuedFile.CertFilePath.Trim(),
+                            cert.CertificatePath.Trim(),
+                            StringComparison.OrdinalIgnoreCase);
+        var keyMatch = string.IsNullOrWhiteSpace(issuedFile.KeyFilePath)
+                       || string.Equals(
+                           issuedFile.KeyFilePath.Trim(),
+                           cert.KeyPath.Trim(),
+                           StringComparison.OrdinalIgnoreCase);
+        return certMatch && keyMatch;
+    }
+}

--- a/DataGateMonitor/Services/CertExpiry/CertExpiryScheduledCheckRunner.cs
+++ b/DataGateMonitor/Services/CertExpiry/CertExpiryScheduledCheckRunner.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
@@ -6,6 +7,9 @@ using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.Others.Notifications.CertExpiry;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Cert.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
 using DataGateMonitor.SharedModels.Enums;
 
 namespace DataGateMonitor.Services.CertExpiry;
@@ -13,8 +17,11 @@ namespace DataGateMonitor.Services.CertExpiry;
 public sealed class CertExpiryScheduledCheckRunner(
     ILogger<CertExpiryScheduledCheckRunner> logger,
     IServiceScopeFactory scopeFactory,
-    CertExpiryNotificationTracker notificationTracker) : ICertExpiryScheduledCheckRunner
+    CertExpiryNotificationTracker notificationTracker,
+    ICertExpiryRunHistoryStore runHistoryStore) : ICertExpiryScheduledCheckRunner
 {
+    private static readonly SemaphoreSlim RunLock = new(1, 1);
+
     public const string WarningDaysSetting = "OvpnCertExpiry_Warning_Days";
 
     private const int DefaultWarningDays = 30;
@@ -22,26 +29,98 @@ public sealed class CertExpiryScheduledCheckRunner(
     private const string AlertExpired = "expired";
     private const string AlertMissing = "missing-on-node";
 
-    public async Task RunAsync(CancellationToken ct)
+    public Task RunAsync(CancellationToken ct) =>
+        RunCheckInternalAsync(new RunCertExpiryCheckRequest { SendNotifications = true }, ct, isScheduled: true);
+
+    public Task<CertExpiryCheckRunResponse> RunCheckAsync(
+        RunCertExpiryCheckRequest request,
+        CancellationToken ct) =>
+        RunCheckInternalAsync(request, ct, isScheduled: false);
+
+    private async Task<CertExpiryCheckRunResponse> RunCheckInternalAsync(
+        RunCertExpiryCheckRequest request,
+        CancellationToken ct,
+        bool isScheduled)
     {
         if (!CertExpiryEnvironment.IsEnabled())
-            return;
+        {
+            return new CertExpiryCheckRunResponse
+            {
+                RunId = Guid.NewGuid(),
+                StartedAtUtc = DateTimeOffset.UtcNow,
+                FinishedAtUtc = DateTimeOffset.UtcNow,
+                Status = CertExpiryRunStatus.Failed,
+                ScopeLabel = BuildScopeLabel(request.VpnServerId),
+                VpnServerId = request.VpnServerId,
+                SendNotifications = request.SendNotifications,
+                IsScheduled = isScheduled,
+                ErrorMessage = $"Certificate expiry checks are disabled via {CertExpiryEnvironment.DisabledVariable}."
+            };
+        }
+
+        if (!await RunLock.WaitAsync(0, ct).ConfigureAwait(false))
+        {
+            logger.LogWarning("OpenVPN certificate expiry check skipped — another run is already in progress");
+            return new CertExpiryCheckRunResponse
+            {
+                RunId = Guid.NewGuid(),
+                StartedAtUtc = DateTimeOffset.UtcNow,
+                FinishedAtUtc = DateTimeOffset.UtcNow,
+                Status = CertExpiryRunStatus.SkippedAlreadyRunning,
+                ScopeLabel = BuildScopeLabel(request.VpnServerId),
+                VpnServerId = request.VpnServerId,
+                SendNotifications = request.SendNotifications,
+                IsScheduled = isScheduled,
+                ErrorMessage = "Another certificate expiry check is already running."
+            };
+        }
+
+        var run = new CertExpiryCheckRunResponse
+        {
+            RunId = Guid.NewGuid(),
+            StartedAtUtc = DateTimeOffset.UtcNow,
+            Status = CertExpiryRunStatus.Running,
+            VpnServerId = request.VpnServerId,
+            ScopeLabel = BuildScopeLabel(request.VpnServerId),
+            SendNotifications = request.SendNotifications,
+            IsScheduled = isScheduled
+        };
+
+        runHistoryStore.Save(run);
 
         try
         {
-            await RunCoreAsync(ct).ConfigureAwait(false);
+            await RunCoreAsync(run, request, ct).ConfigureAwait(false);
+            run.Status = CertExpiryRunStatus.Completed;
         }
         catch (OperationCanceledException)
         {
+            run.Status = CertExpiryRunStatus.Failed;
+            run.ErrorMessage = "The check was cancelled.";
             throw;
         }
         catch (Exception ex)
         {
+            run.Status = CertExpiryRunStatus.Failed;
+            run.ErrorMessage = ex.Message;
             logger.LogError(ex, "OpenVPN certificate expiry check failed");
         }
+        finally
+        {
+            run.FinishedAtUtc = DateTimeOffset.UtcNow;
+            run.DurationMs = (long)(run.FinishedAtUtc.Value - run.StartedAtUtc).TotalMilliseconds;
+            run.Summary = CertExpiryRunMapper.BuildSummary(run.Servers);
+            runHistoryStore.Save(run);
+            RunLock.Release();
+        }
+
+        return run;
     }
 
-    private async Task RunCoreAsync(CancellationToken ct)
+    private async Task RunCoreAsync(
+        CertExpiryCheckRunResponse run,
+        RunCertExpiryCheckRequest request,
+        CancellationToken ct)
     {
         await using var scope = scopeFactory.CreateAsyncScope();
         var settings = scope.ServiceProvider.GetRequiredService<ISettingsService>();
@@ -54,15 +133,30 @@ public sealed class CertExpiryScheduledCheckRunner(
         if (warningDays <= 0)
             warningDays = DefaultWarningDays;
 
-        var servers = (await vpnServerQuery.GetAll(ct: ct).ConfigureAwait(false))
+        run.WarningDays = warningDays;
+
+        var allServers = await vpnServerQuery.GetAll(ct: ct).ConfigureAwait(false);
+        var eligibleServers = allServers
             .Where(IsOpenVpnServerCandidate)
             .ToDictionary(s => s.Id);
 
-        if (servers.Count == 0)
+        if (request.VpnServerId is int singleServerId)
+        {
+            if (!eligibleServers.TryGetValue(singleServerId, out var singleServer))
+            {
+                throw new InvalidOperationException(
+                    $"Server {singleServerId} is not an eligible OpenVPN server for certificate expiry checks.");
+            }
+
+            eligibleServers = new Dictionary<int, VpnServer> { [singleServerId] = singleServer };
+            run.ScopeLabel = singleServer.ServerName;
+        }
+
+        if (eligibleServers.Count == 0)
             return;
 
         var activeFiles = await issuedFileQuery
-            .GetAllActiveByVpnServerIds(servers.Keys, ct)
+            .GetAllActiveByVpnServerIds(eligibleServers.Keys, ct)
             .ConfigureAwait(false);
 
         if (activeFiles.Count == 0)
@@ -76,7 +170,8 @@ public sealed class CertExpiryScheduledCheckRunner(
         var warningThreshold = now.AddDays(warningDays);
 
         logger.LogInformation(
-            "OpenVPN cert expiry check: {FileCount} active profile(s) on {ServerCount} server(s); warning window {WarningDays} day(s)",
+            "OpenVPN cert expiry check {RunId}: {FileCount} active profile(s) on {ServerCount} server(s); warning window {WarningDays} day(s)",
+            run.RunId,
             activeFiles.Count,
             filesByServer.Count,
             warningDays);
@@ -85,67 +180,118 @@ public sealed class CertExpiryScheduledCheckRunner(
         {
             ct.ThrowIfCancellationRequested();
 
-            var server = servers[serverGroup.Key];
-            List<ServerCertificate> nodeCerts;
-            try
-            {
-                nodeCerts = await certApiClient
-                    .GetAllCertificatesAsync(server.Id, ct, notifyRead: false)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex,
-                    "Failed to fetch certificates from server {ServerId} ({ServerName})",
-                    server.Id,
-                    server.ServerName);
+            var server = eligibleServers[serverGroup.Key];
+            var serverResult = await EvaluateServerAsync(
+                server,
+                serverGroup,
+                certApiClient,
+                notifier,
+                now,
+                warningThreshold,
+                request.SendNotifications,
+                ct).ConfigureAwait(false);
 
-                if (!notificationTracker.TryMarkServerCheckFailureNotified(server.Id))
-                    continue;
+            run.Servers.Add(serverResult);
+        }
+    }
 
+    private async Task<CertExpiryServerResultDto> EvaluateServerAsync(
+        VpnServer server,
+        IGrouping<int, IssuedOvpnFile> serverGroup,
+        ICertApiClient certApiClient,
+        ICertExpiryNotificationService notifier,
+        DateTimeOffset now,
+        DateTimeOffset warningThreshold,
+        bool sendNotifications,
+        CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var serverResult = new CertExpiryServerResultDto
+        {
+            VpnServerId = server.Id,
+            ServerName = server.ServerName
+        };
+
+        List<ServerCertificate> nodeCerts;
+        try
+        {
+            nodeCerts = await certApiClient
+                .GetAllCertificatesAsync(server.Id, ct, notifyRead: false)
+                .ConfigureAwait(false);
+            serverResult.FetchStatus = CertExpiryServerFetchStatus.Success;
+        }
+        catch (Exception ex)
+        {
+            serverResult.FetchStatus = CertExpiryServerFetchStatus.Failed;
+            serverResult.FetchError = ex.Message;
+            serverResult.DurationMs = sw.ElapsedMilliseconds;
+
+            logger.LogWarning(ex,
+                "Failed to fetch certificates from server {ServerId} ({ServerName})",
+                server.Id,
+                server.ServerName);
+
+            if (sendNotifications && notificationTracker.TryMarkServerCheckFailureNotified(server.Id))
+            {
                 await notifier.NotifyServerCheckFailedAsync(
                     server.Id,
                     server.ServerName,
                     ex.Message,
                     ct).ConfigureAwait(false);
-                continue;
             }
 
-            var certsByCommonName = BuildCertificateLookup(nodeCerts);
-
-            foreach (var issuedFile in serverGroup)
-            {
-                await EvaluateIssuedFileAsync(
-                    issuedFile,
-                    server,
-                    certsByCommonName,
-                    now,
-                    warningThreshold,
-                    notifier,
-                    ct).ConfigureAwait(false);
-            }
+            return serverResult;
         }
+
+        var certsByCommonName = BuildCertificateLookup(nodeCerts);
+
+        foreach (var issuedFile in serverGroup)
+        {
+            var profileResult = await EvaluateIssuedFileAsync(
+                issuedFile,
+                server,
+                certsByCommonName,
+                now,
+                warningThreshold,
+                sendNotifications,
+                notifier,
+                ct).ConfigureAwait(false);
+
+            serverResult.Profiles.Add(profileResult);
+        }
+
+        serverResult.DurationMs = sw.ElapsedMilliseconds;
+        return serverResult;
     }
 
-    private async Task EvaluateIssuedFileAsync(
+    private async Task<CertExpiryProfileResultDto> EvaluateIssuedFileAsync(
         IssuedOvpnFile issuedFile,
         VpnServer server,
         IReadOnlyDictionary<string, ServerCertificate> certsByCommonName,
         DateTimeOffset now,
         DateTimeOffset warningThreshold,
+        bool sendNotifications,
         ICertExpiryNotificationService notifier,
         CancellationToken ct)
     {
         certsByCommonName.TryGetValue(issuedFile.CommonName, out var cert);
 
         var outcome = CertExpiryClassifier.Classify(cert, now, warningThreshold);
+        var profileResult = new CertExpiryProfileResultDto
+        {
+            IssuedOvpnFileId = issuedFile.Id,
+            CommonName = issuedFile.CommonName,
+            Outcome = CertExpiryRunMapper.ToProfileOutcome(outcome)
+        };
 
         if (outcome == CertExpiryCheckOutcome.MissingOnNode)
         {
-            if (!notificationTracker.TryMarkNotified(
+            if (sendNotifications
+                && notificationTracker.TryMarkNotified(
                     issuedFile.VpnServerId, issuedFile.CommonName, issuedFile.IssuedAt, AlertMissing))
             {
-                return;
+                await notifier.NotifyCertificateMissingAsync(issuedFile, server.ServerName, ct).ConfigureAwait(false);
+                profileResult.NotificationSent = true;
             }
 
             logger.LogWarning(
@@ -153,11 +299,12 @@ public sealed class CertExpiryScheduledCheckRunner(
                 issuedFile.Id,
                 issuedFile.CommonName,
                 server.Id);
-            await notifier.NotifyCertificateMissingAsync(issuedFile, server.ServerName, ct).ConfigureAwait(false);
-            return;
+
+            return profileResult;
         }
 
-        if (!PathsMatch(issuedFile, cert!))
+        profileResult.PathsMatch = PathsMatch(issuedFile, cert!);
+        if (!profileResult.PathsMatch)
         {
             logger.LogDebug(
                 "Issued file paths differ from PKI for CN={CommonName} on server {ServerId}: " +
@@ -171,41 +318,47 @@ public sealed class CertExpiryScheduledCheckRunner(
         }
 
         var expiryUtc = cert!.ExpiryDate.ToUniversalTime();
+        profileResult.ExpiryUtc = expiryUtc;
+        profileResult.SerialNumber = cert.SerialNumber;
+        profileResult.DaysLeft = CertExpiryClassifier.EstimateDaysLeft(expiryUtc, now);
 
         if (outcome == CertExpiryCheckOutcome.Expired)
         {
-            if (!notificationTracker.TryMarkNotified(
+            if (sendNotifications
+                && notificationTracker.TryMarkNotified(
                     issuedFile.VpnServerId, issuedFile.CommonName, expiryUtc, AlertExpired))
             {
-                return;
+                await notifier.NotifyExpiredAsync(
+                    issuedFile,
+                    server.ServerName,
+                    expiryUtc,
+                    cert.SerialNumber,
+                    ct).ConfigureAwait(false);
+                profileResult.NotificationSent = true;
             }
 
-            await notifier.NotifyExpiredAsync(
-                issuedFile,
-                server.ServerName,
-                expiryUtc,
-                cert.SerialNumber,
-                ct).ConfigureAwait(false);
-            return;
+            return profileResult;
         }
 
         if (outcome == CertExpiryCheckOutcome.ExpiringSoon)
         {
-            var daysLeft = CertExpiryClassifier.EstimateDaysLeft(expiryUtc, now);
-            if (!notificationTracker.TryMarkNotified(
+            var daysLeft = profileResult.DaysLeft ?? 0;
+            if (sendNotifications
+                && notificationTracker.TryMarkNotified(
                     issuedFile.VpnServerId, issuedFile.CommonName, expiryUtc, AlertExpiringSoon))
             {
-                return;
+                await notifier.NotifyExpiringSoonAsync(
+                    issuedFile,
+                    server.ServerName,
+                    expiryUtc,
+                    daysLeft,
+                    cert.SerialNumber,
+                    ct).ConfigureAwait(false);
+                profileResult.NotificationSent = true;
             }
-
-            await notifier.NotifyExpiringSoonAsync(
-                issuedFile,
-                server.ServerName,
-                expiryUtc,
-                daysLeft,
-                cert.SerialNumber,
-                ct).ConfigureAwait(false);
         }
+
+        return profileResult;
     }
 
     internal static bool IsOpenVpnServerCandidate(VpnServer server) =>
@@ -242,4 +395,7 @@ public sealed class CertExpiryScheduledCheckRunner(
                            StringComparison.OrdinalIgnoreCase);
         return certMatch && keyMatch;
     }
+
+    private static string BuildScopeLabel(int? vpnServerId) =>
+        vpnServerId is null ? "All eligible servers" : $"Server #{vpnServerId}";
 }

--- a/DataGateMonitor/Services/CertExpiry/ICertExpiryScheduledCheckRunner.cs
+++ b/DataGateMonitor/Services/CertExpiry/ICertExpiryScheduledCheckRunner.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.CertExpiry;
+
+public interface ICertExpiryScheduledCheckRunner
+{
+    Task RunAsync(CancellationToken ct);
+}

--- a/DataGateMonitor/Services/CertExpiry/ICertExpiryScheduledCheckRunner.cs
+++ b/DataGateMonitor/Services/CertExpiry/ICertExpiryScheduledCheckRunner.cs
@@ -1,6 +1,11 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.CertExpiry.Responses;
+
 namespace DataGateMonitor.Services.CertExpiry;
 
 public interface ICertExpiryScheduledCheckRunner
 {
     Task RunAsync(CancellationToken ct);
+
+    Task<CertExpiryCheckRunResponse> RunCheckAsync(RunCertExpiryCheckRequest request, CancellationToken ct);
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/CertApiClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/CertApiClient.cs
@@ -88,7 +88,7 @@ public class CertApiClient(
     }
 
     public async Task<List<ServerCertificate>> GetAllCertificatesAsync(int vpnServerId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken, bool notifyRead = true)
     {
         try
         {
@@ -114,8 +114,12 @@ public class CertApiClient(
                     await MicroserviceApiResponseHelper.ReadSuccessDataAsync<List<ServerCertificate>>(
                         response, cancellationToken);
 
-                await certificateNotificationService.NotifyReadAllAsync(vpnServerId, certificates.Count,
-                    cancellationToken);
+                if (notifyRead)
+                {
+                    await certificateNotificationService.NotifyReadAllAsync(vpnServerId, certificates.Count,
+                        cancellationToken);
+                }
+
                 return certificates;
             }
         }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Interfaces/ICertApiClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Interfaces/ICertApiClient.cs
@@ -5,7 +5,8 @@ namespace DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 
 public interface ICertApiClient
 {
-    Task<List<ServerCertificate>> GetAllCertificatesAsync(int serverId, CancellationToken cancellationToken);
+    Task<List<ServerCertificate>> GetAllCertificatesAsync(int serverId, CancellationToken cancellationToken,
+        bool notifyRead = true);
     Task<ServerCertificate> BuildCertificateAsync(int serverId, string commonName, CancellationToken cancellationToken);
     Task<ServerCertificate> RevokeCertificateAsync(RevokeCertificateRequest request, CancellationToken cancellationToken);
 }

--- a/DataGateMonitor/Services/Others/Notifications/CertExpiry/CertExpiryNotificationService.cs
+++ b/DataGateMonitor/Services/Others/Notifications/CertExpiry/CertExpiryNotificationService.cs
@@ -1,0 +1,102 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.SharedModels.Notifications.Requests;
+
+namespace DataGateMonitor.Services.Others.Notifications.CertExpiry;
+
+public sealed class CertExpiryNotificationService(INotificationService notifications) : ICertExpiryNotificationService
+{
+    private static readonly string[] Channels = ["web", "telegram"];
+    private const string Source = "ovpn-cert-expiry";
+
+    public Task NotifyExpiringSoonAsync(
+        IssuedOvpnFile issuedFile,
+        string serverName,
+        DateTimeOffset expiryUtc,
+        int daysLeft,
+        string? serialNumber,
+        CancellationToken ct)
+        => Notify(
+            ApplicationNotificationKind.OvpnCertExpiryWarning,
+            NotificationTypes.OvpnCertExpiryWarning,
+            "OpenVPN client certificate expiring soon",
+            BuildMessage(issuedFile, serverName, expiryUtc, serialNumber,
+                $"Expires in {daysLeft} day(s). Issue a new profile or revoke and re-issue."),
+            issuedFile.VpnServerId,
+            NotificationSeverity.Warning,
+            ct);
+
+    public Task NotifyExpiredAsync(
+        IssuedOvpnFile issuedFile,
+        string serverName,
+        DateTimeOffset expiryUtc,
+        string? serialNumber,
+        CancellationToken ct)
+        => Notify(
+            ApplicationNotificationKind.OvpnCertExpired,
+            NotificationTypes.OvpnCertExpired,
+            "OpenVPN client certificate expired",
+            BuildMessage(issuedFile, serverName, expiryUtc, serialNumber,
+                "Clients can no longer connect with this profile. Revoke and issue a replacement."),
+            issuedFile.VpnServerId,
+            NotificationSeverity.Error,
+            ct);
+
+    public Task NotifyCertificateMissingAsync(
+        IssuedOvpnFile issuedFile,
+        string serverName,
+        CancellationToken ct)
+        => Notify(
+            ApplicationNotificationKind.OvpnCertExpiryWarning,
+            NotificationTypes.OvpnCertExpiryWarning,
+            "OpenVPN certificate missing on node",
+            $"Server={serverName} (id {issuedFile.VpnServerId}); " +
+            $"IssuedOvpnFileId={issuedFile.Id}; CN={issuedFile.CommonName}; ExternalId={issuedFile.ExternalId}. " +
+            "Active profile in DB but no matching certificate on the node PKI.",
+            issuedFile.VpnServerId,
+            NotificationSeverity.Warning,
+            ct);
+
+    public Task NotifyServerCheckFailedAsync(int vpnServerId, string serverName, string detail, CancellationToken ct)
+        => Notify(
+            ApplicationNotificationKind.OvpnCertExpiryWarning,
+            NotificationTypes.OvpnCertExpiryWarning,
+            "OpenVPN certificate expiry check failed",
+            $"Server={serverName} (id {vpnServerId}). {detail}",
+            vpnServerId,
+            NotificationSeverity.Error,
+            ct);
+
+    private static string BuildMessage(
+        IssuedOvpnFile issuedFile,
+        string serverName,
+        DateTimeOffset expiryUtc,
+        string? serialNumber,
+        string action)
+    {
+        var serial = string.IsNullOrWhiteSpace(serialNumber) ? "n/a" : serialNumber;
+        return $"Server={serverName} (id {issuedFile.VpnServerId}); " +
+               $"IssuedOvpnFileId={issuedFile.Id}; CN={issuedFile.CommonName}; ExternalId={issuedFile.ExternalId}; " +
+               $"Serial={serial}; ExpiresAt={expiryUtc:O}. {action}";
+    }
+
+    private Task Notify(
+        ApplicationNotificationKind preferenceKind,
+        string type,
+        string title,
+        string message,
+        int serverId,
+        NotificationSeverity severity,
+        CancellationToken ct)
+        => notifications.NotifyAdmins(new NotifyAdminsRequest
+        {
+            Type = type,
+            Title = title,
+            Message = message,
+            Severity = severity,
+            Source = Source,
+            ServerId = serverId,
+            PreferenceKind = preferenceKind
+        }, Channels, ct);
+}

--- a/DataGateMonitor/Services/Others/Notifications/CertExpiry/ICertExpiryNotificationService.cs
+++ b/DataGateMonitor/Services/Others/Notifications/CertExpiry/ICertExpiryNotificationService.cs
@@ -1,0 +1,29 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Others.Notifications.CertExpiry;
+
+namespace DataGateMonitor.Services.Others.Notifications.CertExpiry;
+
+public interface ICertExpiryNotificationService
+{
+    Task NotifyExpiringSoonAsync(
+        IssuedOvpnFile issuedFile,
+        string serverName,
+        DateTimeOffset expiryUtc,
+        int daysLeft,
+        string? serialNumber,
+        CancellationToken ct);
+
+    Task NotifyExpiredAsync(
+        IssuedOvpnFile issuedFile,
+        string serverName,
+        DateTimeOffset expiryUtc,
+        string? serialNumber,
+        CancellationToken ct);
+
+    Task NotifyCertificateMissingAsync(
+        IssuedOvpnFile issuedFile,
+        string serverName,
+        CancellationToken ct);
+
+    Task NotifyServerCheckFailedAsync(int vpnServerId, string serverName, string detail, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/PiHoleHealth/IPiHoleHealthCheckRunner.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/IPiHoleHealthCheckRunner.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public interface IPiHoleHealthCheckRunner
+{
+    Task RunAsync(CancellationToken ct);
+}

--- a/DataGateMonitor/Services/PiHoleHealth/IPiHoleHealthNotificationService.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/IPiHoleHealthNotificationService.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public interface IPiHoleHealthNotificationService
+{
+    Task NotifyUnhealthyAsync(int vpnServerId, string serverName, string health, string healthMessage, CancellationToken ct);
+
+    Task NotifyRecoveredAsync(int vpnServerId, string serverName, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthBackgroundService.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthBackgroundService.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Hosting;
+
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public sealed class PiHoleHealthBackgroundService(
+    ILogger<PiHoleHealthBackgroundService> logger,
+    IPiHoleHealthCheckRunner checkRunner) : BackgroundService
+{
+    private static readonly TimeSpan LoopDelay = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(30);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!PiHoleHealthEnvironment.IsEnabled())
+        {
+            logger.LogInformation("{Service} is disabled via {Variable}",
+                nameof(PiHoleHealthBackgroundService),
+                PiHoleHealthEnvironment.DisabledVariable);
+            return;
+        }
+
+        logger.LogInformation("{Service} started", nameof(PiHoleHealthBackgroundService));
+
+        await Task.Delay(StartupDelay, stoppingToken).ConfigureAwait(false);
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await checkRunner.RunAsync(stoppingToken).ConfigureAwait(false);
+                await Task.Delay(LoopDelay, stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // shutdown
+        }
+
+        logger.LogInformation("{Service} stopped", nameof(PiHoleHealthBackgroundService));
+    }
+}

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthCheckRunner.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthCheckRunner.cs
@@ -41,6 +41,20 @@ public sealed class PiHoleHealthCheckRunner(
 
             if (IsHealthy(diagnostics.Health))
             {
+                if (notificationTracker.HasUnhealthyNotification(server.Id)
+                    && notificationTracker.TryMarkRecoveredNotified(server.Id))
+                {
+                    logger.LogInformation(
+                        "Pi-hole recovered on VpnServerId={VpnServerId} ({ServerName})",
+                        server.Id,
+                        server.ServerName);
+
+                    await notificationService.NotifyRecoveredAsync(
+                        server.Id,
+                        server.ServerName,
+                        ct).ConfigureAwait(false);
+                }
+
                 notificationTracker.ClearUnhealthy(server.Id);
                 return;
             }

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthCheckRunner.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthCheckRunner.cs
@@ -1,0 +1,92 @@
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api;
+using DataGateMonitor.Services.Api.Interfaces;
+
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public sealed class PiHoleHealthCheckRunner(
+    ILogger<PiHoleHealthCheckRunner> logger,
+    IVpnServerQueryService vpnServerQueryService,
+    IVpnServerPiHoleConfigService piHoleConfigService,
+    IPiHoleHealthNotificationService notificationService,
+    PiHoleHealthNotificationTracker notificationTracker) : IPiHoleHealthCheckRunner
+{
+    public async Task RunAsync(CancellationToken ct)
+    {
+        var servers = await vpnServerQueryService.GetAll(ct: ct).ConfigureAwait(false);
+        var piHoleServers = servers
+            .Where(s => s.IsPiHoleEnabled && !s.IsDeleted && !s.IsDisable)
+            .ToList();
+
+        if (piHoleServers.Count == 0)
+            return;
+
+        logger.LogDebug("Pi-hole health check: evaluating {Count} server(s)", piHoleServers.Count);
+
+        foreach (var server in piHoleServers)
+        {
+            ct.ThrowIfCancellationRequested();
+            await EvaluateServerAsync(server, ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task EvaluateServerAsync(VpnServer server, CancellationToken ct)
+    {
+        try
+        {
+            var diagnostics = await piHoleConfigService
+                .GetMicroserviceDiagnosticsAsync(server.Id, ct)
+                .ConfigureAwait(false);
+
+            if (IsHealthy(diagnostics.Health))
+            {
+                notificationTracker.ClearUnhealthy(server.Id);
+                return;
+            }
+
+            if (!notificationTracker.TryMarkUnhealthyNotified(
+                    server.Id,
+                    diagnostics.Health ?? "Unknown",
+                    diagnostics.HealthMessage ?? diagnostics.Error ?? "Unknown issue"))
+            {
+                return;
+            }
+
+            logger.LogWarning(
+                "Pi-hole unhealthy on VpnServerId={VpnServerId} ({ServerName}): {Health} — {Message}",
+                server.Id,
+                server.ServerName,
+                diagnostics.Health,
+                diagnostics.HealthMessage);
+
+            await notificationService.NotifyUnhealthyAsync(
+                server.Id,
+                server.ServerName,
+                diagnostics.Health ?? "Unknown",
+                diagnostics.HealthMessage ?? diagnostics.Error ?? "Unknown issue",
+                ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            if (!notificationTracker.TryMarkUnhealthyNotified(server.Id, "Error", ex.Message))
+                return;
+
+            logger.LogError(
+                ex,
+                "Pi-hole health check failed for VpnServerId={VpnServerId} ({ServerName})",
+                server.Id,
+                server.ServerName);
+
+            await notificationService.NotifyUnhealthyAsync(
+                server.Id,
+                server.ServerName,
+                "Error",
+                ex.Message,
+                ct).ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsHealthy(string? health) =>
+        string.Equals(health, "Ok", StringComparison.OrdinalIgnoreCase);
+}

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthEnvironment.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthEnvironment.cs
@@ -1,0 +1,13 @@
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public static class PiHoleHealthEnvironment
+{
+    public const string DisabledVariable = "PIHOLE_HEALTH_CHECK_DISABLED";
+
+    public static bool IsEnabled()
+    {
+        var raw = Environment.GetEnvironmentVariable(DisabledVariable);
+        return !string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase)
+               && raw != "1";
+    }
+}

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthNotificationService.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthNotificationService.cs
@@ -1,0 +1,43 @@
+using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.SharedModels.Notifications.Requests;
+
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public sealed class PiHoleHealthNotificationService(INotificationService notifications) : IPiHoleHealthNotificationService
+{
+    private static readonly string[] Channels = ["web", "telegram"];
+    private const string Source = "pihole-health";
+
+    public Task NotifyUnhealthyAsync(
+        int vpnServerId,
+        string serverName,
+        string health,
+        string healthMessage,
+        CancellationToken ct)
+        => notifications.NotifyAdmins(new NotifyAdminsRequest
+        {
+            Type = NotificationTypes.PiHoleCollectorUnhealthy,
+            Title = $"Pi-hole integration unhealthy ({health})",
+            Message = $"Server={serverName} (id {vpnServerId}). {healthMessage}",
+            Severity = string.Equals(health, "Error", StringComparison.OrdinalIgnoreCase)
+                ? NotificationSeverity.Error
+                : NotificationSeverity.Warning,
+            Source = Source,
+            ServerId = vpnServerId,
+            PreferenceKind = ApplicationNotificationKind.OpenVpnServerSyncError
+        }, Channels, ct);
+
+    public Task NotifyRecoveredAsync(int vpnServerId, string serverName, CancellationToken ct)
+        => notifications.NotifyAdmins(new NotifyAdminsRequest
+        {
+            Type = NotificationTypes.PiHoleCollectorRecovered,
+            Title = "Pi-hole integration recovered",
+            Message = $"Server={serverName} (id {vpnServerId}). Collector and diagnostics are healthy again.",
+            Severity = NotificationSeverity.Info,
+            Source = Source,
+            ServerId = vpnServerId,
+            PreferenceKind = ApplicationNotificationKind.OpenVpnServerSyncError
+        }, Channels, ct);
+}

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthNotificationTracker.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthNotificationTracker.cs
@@ -1,0 +1,26 @@
+using System.Collections.Concurrent;
+
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public sealed class PiHoleHealthNotificationTracker
+{
+    private readonly ConcurrentDictionary<string, byte> _unhealthySent = new();
+    private readonly ConcurrentDictionary<int, byte> _recoveredSent = new();
+
+    public bool TryMarkUnhealthyNotified(int vpnServerId, string health, string healthMessage) =>
+        _unhealthySent.TryAdd(BuildUnhealthyKey(vpnServerId, health, healthMessage), 0);
+
+    public bool TryMarkRecoveredNotified(int vpnServerId) =>
+        _recoveredSent.TryAdd(vpnServerId, 0);
+
+    public void ClearUnhealthy(int vpnServerId)
+    {
+        foreach (var key in _unhealthySent.Keys.Where(k => k.StartsWith($"{vpnServerId}|", StringComparison.Ordinal)))
+            _unhealthySent.TryRemove(key, out _);
+
+        _recoveredSent.TryRemove(vpnServerId, out _);
+    }
+
+    internal static string BuildUnhealthyKey(int vpnServerId, string health, string healthMessage) =>
+        $"{vpnServerId}|{health}|{healthMessage}";
+}

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthNotificationTracker.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthNotificationTracker.cs
@@ -13,6 +13,9 @@ public sealed class PiHoleHealthNotificationTracker
     public bool TryMarkRecoveredNotified(int vpnServerId) =>
         _recoveredSent.TryAdd(vpnServerId, 0);
 
+    public bool HasUnhealthyNotification(int vpnServerId) =>
+        _unhealthySent.Keys.Any(k => k.StartsWith($"{vpnServerId}|", StringComparison.Ordinal));
+
     public void ClearUnhealthy(int vpnServerId)
     {
         foreach (var key in _unhealthySent.Keys.Where(k => k.StartsWith($"{vpnServerId}|", StringComparison.Ordinal)))

--- a/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthServiceConfiguration.cs
+++ b/DataGateMonitor/Services/PiHoleHealth/PiHoleHealthServiceConfiguration.cs
@@ -1,0 +1,16 @@
+using DataGateMonitor.Configurations;
+
+namespace DataGateMonitor.Services.PiHoleHealth;
+
+public static class PiHoleHealthServiceConfiguration
+{
+    public static void ConfigurePiHoleHealthServices(this IServiceCollection services, DatabaseRuntimeOptions databaseRuntime)
+    {
+        services.AddSingleton<PiHoleHealthNotificationTracker>();
+        services.AddScoped<IPiHoleHealthNotificationService, PiHoleHealthNotificationService>();
+        services.AddScoped<IPiHoleHealthCheckRunner, PiHoleHealthCheckRunner>();
+
+        if (databaseRuntime.IsConnectionConfigured)
+            services.AddHostedService<PiHoleHealthBackgroundService>();
+    }
+}


### PR DESCRIPTION
## Summary
- Add hourly OpenVPN certificate expiry monitoring with admin notifications and manual check runs (v1.0.3.55–1.0.3.57).
- Add Pi-hole integration health background checks (every 5 min) with deduplicated admin alerts and recovery notifications when a server becomes healthy again.
- Extend VPN DNS query search to match user OpenVPN profiles (CN) and expose profile summary API for the user page.

## Test plan
- [x] `dotnet test` — PiHoleHealth, VpnDnsQuery, CertExpiry suites
- [ ] Deploy backend 1.0.3.57 and confirm Pi-hole unhealthy alert fires once per server, recovery Info after Save & apply
- [ ] Verify user profile DNS section shows queries filtered by CN