### PR TITLE
OpenVPN events, app versions, and SignalR client hardening

### DIFF
--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.32" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
       <PackageReference Include="Mapster" Version="10.0.8" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerEventLogTable/IVpnServerEventLogQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerEventLogTable/IVpnServerEventLogQueryService.cs
@@ -1,4 +1,5 @@
 ﻿using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Dto;
 using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateMonitor.DataBase.Services.Query.VpnServerEventLogTable;
@@ -8,7 +9,17 @@ public interface IVpnServerEventLogQueryService
     Task<List<VpnServerEventLog>> GetAll(CancellationToken ct);
     Task<VpnServerEventLog?> GetById(int id, CancellationToken ct);
 
-    Task<IPagedResult<VpnServerEventLog>> GetByVpnServerId(int vpnServerId, int page, int pageSize, CancellationToken ct);
+    Task<IPagedResult<VpnServerEventLog>> GetByVpnServerId(
+        int vpnServerId,
+        int page,
+        int pageSize,
+        CancellationToken ct,
+        IReadOnlyList<string>? commonNames = null);
+
+    Task<IReadOnlyList<VpnClientAppVersionSummaryItemDto>> GetAppVersionSummaryAsync(
+        int vpnServerId,
+        IReadOnlyList<string>? commonNames,
+        CancellationToken ct);
 
     Task<IPagedResult<VpnServerEventLog>> GetPage(int page, int pageSize, CancellationToken ct);
 }

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryService.cs
@@ -61,7 +61,9 @@ public class VpnServerEventLogQueryService(IQueryService<VpnServerEventLog, int>
         var baseQuery = q.Query()
             .Where(x => x.VpnServerId == vpnServerId)
             .Where(x => ConnectEventTypes.Contains(x.EventType))
-            .Where(x => x.IvGuiVer != null && x.IvGuiVer != "");
+            .Where(x =>
+                (x.IvGuiVer != null && x.IvGuiVer != "")
+                || (x.IvVer != null && x.IvVer != ""));
 
         if (commonNames is { Count: > 0 })
         {
@@ -70,10 +72,13 @@ public class VpnServerEventLogQueryService(IQueryService<VpnServerEventLog, int>
         }
 
         return await baseQuery
-            .GroupBy(x => x.IvGuiVer!)
+            .GroupBy(x =>
+                x.IvGuiVer != null && x.IvGuiVer != ""
+                    ? x.IvGuiVer
+                    : x.IvVer!)
             .Select(g => new VpnClientAppVersionSummaryItemDto
             {
-                IvGuiVer = g.Key,
+                IvGuiVer = g.Key!,
                 LastConnectedAtUtc = g.Max(x => x.EventTimeUtc ?? x.CreateDate),
                 ConnectionCount = g.Count(),
             })

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Dto;
 using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateMonitor.DataBase.Services.Query.VpnServerEventLogTable;
@@ -7,6 +8,8 @@ namespace DataGateMonitor.DataBase.Services.Query.VpnServerEventLogTable;
 public class VpnServerEventLogQueryService(IQueryService<VpnServerEventLog, int> q)
     : IVpnServerEventLogQueryService
 {
+    private static readonly string[] ConnectEventTypes = ["ClientConnected", "ClientConnect"];
+
     public Task<List<VpnServerEventLog>> GetAll(CancellationToken ct)
         => q.GetAll(ct: ct);
 
@@ -14,13 +17,23 @@ public class VpnServerEventLogQueryService(IQueryService<VpnServerEventLog, int>
         => q.FindById(id, ct: ct);
 
     public async Task<IPagedResult<VpnServerEventLog>> GetByVpnServerId(
-        int vpnServerId, int page, int pageSize, CancellationToken ct)
+        int vpnServerId,
+        int page,
+        int pageSize,
+        CancellationToken ct,
+        IReadOnlyList<string>? commonNames = null)
     {
         if (page < 1) page = 1;
         if (pageSize < 1) pageSize = 10;
 
         var baseQuery = q.Query()
             .Where(x => x.VpnServerId == vpnServerId);
+
+        if (commonNames is { Count: > 0 })
+        {
+            baseQuery = baseQuery.Where(x =>
+                x.CommonName != null && commonNames.Contains(x.CommonName));
+        }
 
         var totalCount = await baseQuery.CountAsync(ct);
 
@@ -38,6 +51,35 @@ public class VpnServerEventLogQueryService(IQueryService<VpnServerEventLog, int>
             TotalCount = totalCount,
             Items = items
         };
+    }
+
+    public async Task<IReadOnlyList<VpnClientAppVersionSummaryItemDto>> GetAppVersionSummaryAsync(
+        int vpnServerId,
+        IReadOnlyList<string>? commonNames,
+        CancellationToken ct)
+    {
+        var baseQuery = q.Query()
+            .Where(x => x.VpnServerId == vpnServerId)
+            .Where(x => ConnectEventTypes.Contains(x.EventType))
+            .Where(x => x.IvGuiVer != null && x.IvGuiVer != "");
+
+        if (commonNames is { Count: > 0 })
+        {
+            baseQuery = baseQuery.Where(x =>
+                x.CommonName != null && commonNames.Contains(x.CommonName));
+        }
+
+        return await baseQuery
+            .GroupBy(x => x.IvGuiVer!)
+            .Select(g => new VpnClientAppVersionSummaryItemDto
+            {
+                IvGuiVer = g.Key,
+                LastConnectedAtUtc = g.Max(x => x.EventTimeUtc ?? x.CreateDate),
+                ConnectionCount = g.Count(),
+            })
+            .OrderByDescending(x => x.LastConnectedAtUtc)
+            .AsNoTracking()
+            .ToListAsync(ct);
     }
 
     public async Task<IPagedResult<VpnServerEventLog>> GetPage(int page, int pageSize, CancellationToken ct)

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.32" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
       <PackageReference Include="Mapster" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.32" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.33</Version>
-        <AssemblyVersion>1.0.33.0</AssemblyVersion>
-        <FileVersion>1.0.33.0</FileVersion>
+        <Version>1.0.34</Version>
+        <AssemblyVersion>1.0.34.0</AssemblyVersion>
+        <FileVersion>1.0.34.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.32</Version>
-        <AssemblyVersion>1.0.32.0</AssemblyVersion>
-        <FileVersion>1.0.32.0</FileVersion>
+        <Version>1.0.33</Version>
+        <AssemblyVersion>1.0.33.0</AssemblyVersion>
+        <FileVersion>1.0.33.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServerEvent/Dto/VpnClientAppVersionSummaryItemDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServerEvent/Dto/VpnClientAppVersionSummaryItemDto.cs
@@ -1,0 +1,13 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Dto;
+
+public sealed class VpnClientAppVersionSummaryItemDto
+{
+    /// <summary>OpenVPN <c>IV_GUI_VER</c> value (client app identifier).</summary>
+    public string IvGuiVer { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp of the latest connect event for this client version.</summary>
+    public DateTimeOffset LastConnectedAtUtc { get; set; }
+
+    /// <summary>Number of connect events recorded for this client version.</summary>
+    public int ConnectionCount { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServerEvent/Requests/GetVpnClientAppVersionsRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServerEvent/Requests/GetVpnClientAppVersionsRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Requests;
+
+public class GetVpnClientAppVersionsRequest
+{
+    [Required(ErrorMessage = "vpnServerId is required.")]
+    [Range(1, int.MaxValue, ErrorMessage = "vpnServerId must be greater than 0.")]
+    public int VpnServerId { get; set; }
+
+    /// <summary>Optional filter: single OpenVPN common name (CN).</summary>
+    public string? CommonName { get; set; }
+
+    /// <summary>Optional filter: resolve all issued profile CNs for this external id on the server.</summary>
+    public string? ExternalId { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/VpnServerEvent/Requests/GetVpnServerEventRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/VpnServerEvent/Requests/GetVpnServerEventRequest.cs
@@ -13,4 +13,10 @@ public class GetVpnServerEventRequest
 
     [Range(1, int.MaxValue, ErrorMessage = "pageSize must be greater than 0.")]
     public int PageSize { get; set; } = 10;
+
+    /// <summary>Optional filter: single OpenVPN common name (CN).</summary>
+    public string? CommonName { get; set; }
+
+    /// <summary>Optional filter: resolve all issued profile CNs for this external id on the server.</summary>
+    public string? ExternalId { get; set; }
 }

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryServiceTests.cs
@@ -1,139 +1,101 @@
-using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore;
-using Moq;
+using DataGateMonitor.DataBase.Contexts;
+using DataGateMonitor.DataBase.Services.Query;
 using DataGateMonitor.DataBase.Services.Query.VpnServerEventLogTable;
 using DataGateMonitor.Models;
-using DataGateMonitor.SharedModels.Responses;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 
 namespace DataGateMonitor.Tests.DataBase.Services.Query.VpnServerEventLogTable;
 
 public class VpnServerEventLogQueryServiceTests
 {
-    private sealed class TestDbContext : DbContext
+    [Fact]
+    public async Task GetAppVersionSummaryAsync_GroupsByIvGuiVer_AndReturnsLastConnectTime()
     {
-        public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
-        public DbSet<VpnServerEventLog> VpnServerEventLogs => Set<VpnServerEventLog>();
-    }
+        var t1 = new DateTimeOffset(2026, 6, 1, 10, 0, 0, TimeSpan.Zero);
+        var t2 = new DateTimeOffset(2026, 6, 2, 12, 0, 0, TimeSpan.Zero);
+        var t3 = new DateTimeOffset(2026, 6, 3, 8, 0, 0, TimeSpan.Zero);
 
-    private static List<VpnServerEventLog> CreateSample()
-    {
-        return new List<VpnServerEventLog>
+        await using var context = CreateContext();
+        context.VpnServerEventLogs.AddRange(
+            Event(1, "cn-a", "ClientConnected", "3.12_datagate_android_1.0.7", t1),
+            Event(2, "cn-a", "ClientConnected", "3.12_datagate_android_1.0.7", t2),
+            Event(3, "cn-b", "ClientConnected", "3.12_datagate_windows_1.0.6", t3),
+            Event(4, "cn-a", "ClientDisconnect", "3.12_datagate_android_1.0.7", t2),
+            Event(5, "cn-a", "ClientConnected", null, t2),
+            Event(6, "cn-other", "ClientConnected", "3.12_datagate_android_1.0.7", t2));
+
+        await context.SaveChangesAsync();
+
+        var queries = new Dictionary<Type, object>
         {
-            new() { Id = 1, VpnServerId = 10, EventType = "ClientConnect" },
-            new() { Id = 2, VpnServerId = 10, EventType = "ClientConnect" },
-            new() { Id = 3, VpnServerId = 20, EventType = "ClientConnect" },
-            new() { Id = 4, VpnServerId = 10, EventType = "ClientDisconnect" },
-            new() { Id = 5, VpnServerId = 10, EventType = "ClientDisconnect" },
+            [typeof(VpnServerEventLog)] = new TestQuery<VpnServerEventLog>(context.VpnServerEventLogs),
         };
+        var sut = new VpnServerEventLogQueryService(new EfQueryService<VpnServerEventLog, int>(new TestUnitOfWork(queries)));
+
+        var items = await sut.GetAppVersionSummaryAsync(75, ["cn-a", "cn-b"], CancellationToken.None);
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal("3.12_datagate_windows_1.0.6", items[0].IvGuiVer);
+        Assert.Equal(t3, items[0].LastConnectedAtUtc);
+        Assert.Equal(1, items[0].ConnectionCount);
+        Assert.Equal("3.12_datagate_android_1.0.7", items[1].IvGuiVer);
+        Assert.Equal(t2, items[1].LastConnectedAtUtc);
+        Assert.Equal(2, items[1].ConnectionCount);
     }
 
-    private static (Mock<IQueryService<VpnServerEventLog, int>> q, TestDbContext ctx, List<VpnServerEventLog> data) CreateEfBackedQuery()
+    [Fact]
+    public async Task GetAppVersionSummaryAsync_WithSingleCommonName_FiltersProfiles()
     {
-        var data = CreateSample();
-        var options = new DbContextOptionsBuilder<TestDbContext>()
+        var t1 = new DateTimeOffset(2026, 6, 1, 10, 0, 0, TimeSpan.Zero);
+        var t2 = new DateTimeOffset(2026, 6, 2, 12, 0, 0, TimeSpan.Zero);
+
+        await using var context = CreateContext();
+        context.VpnServerEventLogs.AddRange(
+            Event(1, "cn-a", "ClientConnect", "3.12_datagate_android_1.0.7", t1),
+            Event(2, "cn-b", "ClientConnect", "3.12_datagate_windows_1.0.6", t2));
+
+        await context.SaveChangesAsync();
+
+        var queries = new Dictionary<Type, object>
+        {
+            [typeof(VpnServerEventLog)] = new TestQuery<VpnServerEventLog>(context.VpnServerEventLogs),
+        };
+        var sut = new VpnServerEventLogQueryService(new EfQueryService<VpnServerEventLog, int>(new TestUnitOfWork(queries)));
+
+        var items = await sut.GetAppVersionSummaryAsync(75, ["cn-a"], CancellationToken.None);
+
+        Assert.Single(items);
+        Assert.Equal("3.12_datagate_android_1.0.7", items[0].IvGuiVer);
+    }
+
+    private static VpnServerEventLog Event(
+        int id,
+        string commonName,
+        string eventType,
+        string? ivGuiVer,
+        DateTimeOffset eventTimeUtc)
+        => new()
+        {
+            Id = id,
+            VpnServerId = 75,
+            CommonName = commonName,
+            EventType = eventType,
+            IvGuiVer = ivGuiVer,
+            EventTimeUtc = eventTimeUtc,
+            CreateDate = eventTimeUtc,
+            LastUpdate = eventTimeUtc,
+        };
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
-        var ctx = new TestDbContext(options);
-        ctx.VpnServerEventLogs.AddRange(data);
-        ctx.SaveChanges();
-
-        var mock = new Mock<IQueryService<VpnServerEventLog, int>>();
-        mock
-            .Setup(q => q.Query(It.IsAny<bool>(), It.IsAny<Expression<Func<VpnServerEventLog, object>>[]>()))
-            .Returns(ctx.VpnServerEventLogs);
-        return (mock, ctx, data);
-    }
-
-    [Fact]
-    public async Task GetAllAsync_Delegates_To_IQueryService()
-    {
-        var (q, ctx, data) = CreateEfBackedQuery();
-        q.Setup(x => x.GetAll(true, It.IsAny<CancellationToken>()))
-         .ReturnsAsync(data)
-         .Verifiable();
-
-        var sut = new VpnServerEventLogQueryService(q.Object);
-        var result = await sut.GetAll(CancellationToken.None);
-
-        Assert.Equal(data.Count, result.Count);
-        Assert.True(result.SequenceEqual(data));
-        q.Verify(x => x.GetAll(true, It.IsAny<CancellationToken>()), Times.Once);
-        await ctx.DisposeAsync();
-    }
-
-    [Fact]
-    public async Task GetByIdAsync_Delegates_To_FindByIdAsync()
-    {
-        var (q, ctx, _) = CreateEfBackedQuery();
-        var expected = new VpnServerEventLog { Id = 42, VpnServerId = 99 };
-        q.Setup(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<VpnServerEventLog, object>>[]>()))
-         .ReturnsAsync(expected)
-         .Verifiable();
-
-        var sut = new VpnServerEventLogQueryService(q.Object);
-        var result = await sut.GetById(42, CancellationToken.None);
-
-        Assert.Same(expected, result);
-        q.Verify(x => x.FindById(42, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<VpnServerEventLog, object>>[]>()), Times.Once);
-        await ctx.DisposeAsync();
-    }
-
-    [Fact]
-    public async Task GetByVpnServerIdAsync_Normalizes_And_Paginates_Descending_By_Id()
-    {
-        var (q, ctx, data) = CreateEfBackedQuery();
-        var sut = new VpnServerEventLogQueryService(q.Object);
-
-        // Pass invalid page/pageSize to test normalization to 1 and 10
-        var pageResult = await sut.GetByVpnServerId(10, 0, 0, CancellationToken.None);
-
-        Assert.Equal(1, pageResult.Page);
-        Assert.Equal(10, pageResult.PageSize);
-
-        // Now request page 1 size 2 to test ordering and paging
-        var result = await sut.GetByVpnServerId(10, 1, 2, CancellationToken.None);
-
-        var expectedAll = data.Where(x => x.VpnServerId == 10).OrderByDescending(x => x.Id).ToList();
-        Assert.Equal(expectedAll.Count, result.TotalCount);
-        Assert.Equal(1, result.Page);
-        Assert.Equal(2, result.PageSize);
-        Assert.Equal(2, result.Items.Count);
-        // Expect top two by Id desc for serverId 10 are Id=5 and Id=4
-        Assert.Collection(result.Items,
-            i => Assert.Equal(5, i.Id),
-            i => Assert.Equal(4, i.Id));
-
-        // Next page should contain next two items: Id=2 and Id=1 (only those with serverId 10)
-        var result2 = await sut.GetByVpnServerId(10, 2, 2, CancellationToken.None);
-        Assert.Collection(result2.Items,
-            i => Assert.Equal(2, i.Id),
-            i => Assert.Equal(1, i.Id));
-
-        await ctx.DisposeAsync();
-    }
-
-    [Fact]
-    public async Task GetPageAsync_Delegates_To_PageAsync()
-    {
-        var (q, ctx, data) = CreateEfBackedQuery();
-
-        var paged = new PagedResponse<VpnServerEventLog>
-        {
-            Page = 2,
-            PageSize = 2,
-            TotalCount = data.Count,
-            Items = data.Skip(2).Take(2).ToList()
-        } as IPagedResult<VpnServerEventLog>;
-
-        q.Setup(x => x.Page(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<VpnServerEventLog, object>>[]>()))
-         .ReturnsAsync(paged)
-         .Verifiable();
-
-        var sut = new VpnServerEventLogQueryService(q.Object);
-        var result = await sut.GetPage(2, 2, CancellationToken.None);
-
-        Assert.Same(paged, result);
-        q.Verify(x => x.Page(2, 2, null, null, true, It.IsAny<CancellationToken>(), It.IsAny<Expression<Func<VpnServerEventLog, object>>[]>()), Times.Once);
-        await ctx.DisposeAsync();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["DataBaseSettings:DefaultSchema"] = "test_schema" })
+            .Build();
+        return new ApplicationDbContext(options, configuration);
     }
 }

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerEventLogTable/VpnServerEventLogQueryServiceTests.cs
@@ -70,11 +70,53 @@ public class VpnServerEventLogQueryServiceTests
         Assert.Equal("3.12_datagate_android_1.0.7", items[0].IvGuiVer);
     }
 
+    [Fact]
+    public async Task GetAppVersionSummaryAsync_FallsBackToIvVer_WhenIvGuiVerMissing()
+    {
+        var t1 = new DateTimeOffset(2026, 6, 28, 8, 0, 0, TimeSpan.Zero);
+        var t2 = new DateTimeOffset(2026, 6, 29, 1, 53, 0, TimeSpan.Zero);
+        var t3 = new DateTimeOffset(2026, 6, 30, 10, 0, 0, TimeSpan.Zero);
+
+        await using var context = CreateContext();
+        context.VpnServerEventLogs.AddRange(
+            Event(1, "cn-a", "ClientConnected", ivGuiVer: null, ivVer: "3.12_datagate_android_1.0.6", t1),
+            Event(2, "cn-a", "ClientConnected", ivGuiVer: null, ivVer: "3.12_datagate_android_1.0.6", t2),
+            Event(3, "cn-a", "ClientConnected", ivGuiVer: "3.12_datagate_android_1.0.7", ivVer: "3.11.5", t3));
+
+        await context.SaveChangesAsync();
+
+        var queries = new Dictionary<Type, object>
+        {
+            [typeof(VpnServerEventLog)] = new TestQuery<VpnServerEventLog>(context.VpnServerEventLogs),
+        };
+        var sut = new VpnServerEventLogQueryService(new EfQueryService<VpnServerEventLog, int>(new TestUnitOfWork(queries)));
+
+        var items = await sut.GetAppVersionSummaryAsync(75, ["cn-a"], CancellationToken.None);
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal("3.12_datagate_android_1.0.7", items[0].IvGuiVer);
+        Assert.Equal(1, items[0].ConnectionCount);
+        Assert.Equal(t3, items[0].LastConnectedAtUtc);
+        Assert.Equal("3.12_datagate_android_1.0.6", items[1].IvGuiVer);
+        Assert.Equal(2, items[1].ConnectionCount);
+        Assert.Equal(t2, items[1].LastConnectedAtUtc);
+    }
+
     private static VpnServerEventLog Event(
         int id,
         string commonName,
         string eventType,
         string? ivGuiVer,
+        DateTimeOffset eventTimeUtc,
+        string? ivVer = null)
+        => Event(id, commonName, eventType, ivGuiVer, ivVer, eventTimeUtc);
+
+    private static VpnServerEventLog Event(
+        int id,
+        string commonName,
+        string eventType,
+        string? ivGuiVer,
+        string? ivVer,
         DateTimeOffset eventTimeUtc)
         => new()
         {
@@ -83,6 +125,7 @@ public class VpnServerEventLogQueryServiceTests
             CommonName = commonName,
             EventType = eventType,
             IvGuiVer = ivGuiVer,
+            IvVer = ivVer,
             EventTimeUtc = eventTimeUtc,
             CreateDate = eventTimeUtc,
             LastUpdate = eventTimeUtc,

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.32" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/Helpers/FakeHubConnectionFactory.cs
+++ b/DataGateMonitor.Tests/Helpers/FakeHubConnectionFactory.cs
@@ -2,7 +2,7 @@ using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfac
 
 namespace DataGateMonitor.Tests.Helpers;
 
-internal sealed class FakeHubConnectionFactory : IHubConnectionFactory
+internal sealed class FakeHubConnectionFactory : IHubConnectionFactory, IEventHubConnectionFactory
 {
     public FakeHubConnectionProxy? LastCreated { get; private set; }
     public List<FakeHubConnectionProxy> Created { get; } = [];

--- a/DataGateMonitor.Tests/Helpers/FakeHubConnectionFactory.cs
+++ b/DataGateMonitor.Tests/Helpers/FakeHubConnectionFactory.cs
@@ -1,0 +1,17 @@
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+
+namespace DataGateMonitor.Tests.Helpers;
+
+internal sealed class FakeHubConnectionFactory : IHubConnectionFactory
+{
+    public FakeHubConnectionProxy? LastCreated { get; private set; }
+    public List<FakeHubConnectionProxy> Created { get; } = [];
+
+    public IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider)
+    {
+        var proxy = new FakeHubConnectionProxy();
+        LastCreated = proxy;
+        Created.Add(proxy);
+        return proxy;
+    }
+}

--- a/DataGateMonitor.Tests/Helpers/FakeHubConnectionProxy.cs
+++ b/DataGateMonitor.Tests/Helpers/FakeHubConnectionProxy.cs
@@ -109,6 +109,14 @@ internal class FakeHubConnectionProxy : IHubConnectionProxy
         return Task.CompletedTask;
     }
 
+    public Task RaiseClosedAsync(Exception? ex = null)
+    {
+        _state = HubConnectionState.Disconnected;
+        if (_handlers.TryGetValue("__Closed", out var handler) && handler is Func<Exception?, Task> closedHandler)
+            return closedHandler(ex);
+        return Task.CompletedTask;
+    }
+
     public async Task SimulateReconnectingThenConnectedAsync(TimeSpan reconnectDuration)
     {
         _state = HubConnectionState.Reconnecting;

--- a/DataGateMonitor.Tests/Helpers/FakeHubConnectionProxy.cs
+++ b/DataGateMonitor.Tests/Helpers/FakeHubConnectionProxy.cs
@@ -13,6 +13,8 @@ internal class FakeHubConnectionProxy : IHubConnectionProxy
     public int StopCallCount { get; private set; }
     public bool Disposed { get; private set; }
 
+    public string? ConnectionId { get; set; } = "fake-conn";
+
     public Func<CancellationToken, Task>? StartAsyncOverride { get; set; }
 
     public Func<string, object?, CancellationToken, Task>? InvokeOneArgHandler { get; set; }
@@ -94,6 +96,19 @@ internal class FakeHubConnectionProxy : IHubConnectionProxy
         return Task.CompletedTask;
     }
 
+    public void OnReconnecting(Func<Exception?, Task> handler) => _handlers["__Reconnecting"] = handler;
+
+    public void OnReconnected(Func<string?, Task> handler) => _handlers["__Reconnected"] = handler;
+
+    public void OnClosed(Func<Exception?, Task> handler) => _handlers["__Closed"] = handler;
+
+    public Task RaiseReconnectingAsync(Exception? ex = null)
+    {
+        if (_handlers["__Reconnecting"] is Func<Exception?, Task> handler)
+            return handler(ex);
+        return Task.CompletedTask;
+    }
+
     public async Task SimulateReconnectingThenConnectedAsync(TimeSpan reconnectDuration)
     {
         _state = HubConnectionState.Reconnecting;
@@ -103,6 +118,11 @@ internal class FakeHubConnectionProxy : IHubConnectionProxy
 }
 
 internal sealed class SingleProxyHubConnectionFactory(FakeHubConnectionProxy proxy) : IHubConnectionFactory
+{
+    public IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider) => proxy;
+}
+
+internal sealed class SingleProxyEventHubConnectionFactory(FakeHubConnectionProxy proxy) : IEventHubConnectionFactory
 {
     public IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider) => proxy;
 }

--- a/DataGateMonitor.Tests/Helpers/FakeHubConnectionProxy.cs
+++ b/DataGateMonitor.Tests/Helpers/FakeHubConnectionProxy.cs
@@ -1,0 +1,108 @@
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace DataGateMonitor.Tests.Helpers;
+
+internal class FakeHubConnectionProxy : IHubConnectionProxy
+{
+    private readonly Dictionary<string, Delegate> _handlers = new(StringComparer.Ordinal);
+    private HubConnectionState _state = HubConnectionState.Disconnected;
+    private bool _simulateDisconnectOnNextStateRead;
+
+    public int StartCallCount { get; private set; }
+    public int StopCallCount { get; private set; }
+    public bool Disposed { get; private set; }
+
+    public Func<CancellationToken, Task>? StartAsyncOverride { get; set; }
+
+    public Func<string, object?, CancellationToken, Task>? InvokeOneArgHandler { get; set; }
+
+    public Func<string, object?, object?, CancellationToken, Task>? InvokeTwoArgHandler { get; set; }
+
+    public virtual HubConnectionState State
+    {
+        get
+        {
+            if (_simulateDisconnectOnNextStateRead)
+            {
+                _simulateDisconnectOnNextStateRead = false;
+                return HubConnectionState.Disconnected;
+            }
+
+            return _state;
+        }
+        set => _state = value;
+    }
+
+    public void SimulateDisconnectOnNextStateRead() => _simulateDisconnectOnNextStateRead = true;
+
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        StartCallCount++;
+        if (StartAsyncOverride is not null)
+            return StartAsyncOverride(cancellationToken);
+
+        _state = HubConnectionState.Connected;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        StopCallCount++;
+        _state = HubConnectionState.Disconnected;
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        _state = HubConnectionState.Disconnected;
+        return ValueTask.CompletedTask;
+    }
+
+    public virtual Task InvokeAsync(string methodName, object? arg1, CancellationToken cancellationToken = default)
+    {
+        if (InvokeOneArgHandler is not null)
+            return InvokeOneArgHandler(methodName, arg1, cancellationToken);
+
+        return Task.CompletedTask;
+    }
+
+    public virtual Task InvokeAsync(string methodName, object? arg1, object? arg2, CancellationToken cancellationToken = default)
+    {
+        if (InvokeTwoArgHandler is not null)
+            return InvokeTwoArgHandler(methodName, arg1, arg2, cancellationToken);
+
+        return Task.CompletedTask;
+    }
+
+    public void On<T>(string methodName, Func<T, Task> handler) => _handlers[methodName] = handler;
+
+    public void On<T1, T2>(string methodName, Action<T1, T2> handler) => _handlers[methodName] = handler;
+
+    public void Raise<T1, T2>(string methodName, T1 arg1, T2 arg2)
+    {
+        if (_handlers[methodName] is Action<T1, T2> handler)
+            handler(arg1, arg2);
+    }
+
+    public Task RaiseAsync<T>(string methodName, T arg)
+    {
+        if (_handlers[methodName] is Func<T, Task> handler)
+            return handler(arg);
+
+        return Task.CompletedTask;
+    }
+
+    public async Task SimulateReconnectingThenConnectedAsync(TimeSpan reconnectDuration)
+    {
+        _state = HubConnectionState.Reconnecting;
+        await Task.Delay(reconnectDuration);
+        _state = HubConnectionState.Connected;
+    }
+}
+
+internal sealed class SingleProxyHubConnectionFactory(FakeHubConnectionProxy proxy) : IHubConnectionFactory
+{
+    public IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider) => proxy;
+}

--- a/DataGateMonitor.Tests/Helpers/OpenVpnHubTestHelpers.cs
+++ b/DataGateMonitor.Tests/Helpers/OpenVpnHubTestHelpers.cs
@@ -1,0 +1,66 @@
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Helpers;
+
+internal static class OpenVpnHubTestHelpers
+{
+    public static VpnServer OpenVpnServer(int id = 75, string apiUrl = "https://s5.datagateapp.com/") =>
+        new()
+        {
+            Id = id,
+            ServerName = "Test Norway",
+            ApiUrl = apiUrl,
+            ServerType = SharedModels.Enums.VpnServerType.OpenVpn,
+        };
+
+    public static (Mock<IHubContext<OpenVpnFrontendHub>> Hub, Mock<IClientProxy> Client) CreateFrontendHubMock(int serverId)
+    {
+        var hubClients = new Mock<IHubClients>();
+        var clientProxy = new Mock<IClientProxy>();
+        hubClients.Setup(h => h.Group(serverId.ToString())).Returns(clientProxy.Object);
+        clientProxy
+            .Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var hubContext = new Mock<IHubContext<OpenVpnFrontendHub>>();
+        hubContext.Setup(h => h.Clients).Returns(hubClients.Object);
+        return (hubContext, clientProxy);
+    }
+
+    public static (Mock<IHubContext<OpenVpnProxyTrafficFlowHub>> Hub, Mock<IClientProxy> Client) CreateTrafficFlowHubMock(int serverId)
+    {
+        var hubClients = new Mock<IHubClients>();
+        var clientProxy = new Mock<IClientProxy>();
+        hubClients.Setup(h => h.Group(serverId.ToString())).Returns(clientProxy.Object);
+        clientProxy
+            .Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var hubContext = new Mock<IHubContext<OpenVpnProxyTrafficFlowHub>>();
+        hubContext.Setup(h => h.Clients).Returns(hubClients.Object);
+        return (hubContext, clientProxy);
+    }
+
+    public static IServiceScopeFactory CreateScopeFactory(
+        IOpenVpnMicroserviceNotificationService? notifications = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(notifications ?? new Mock<IOpenVpnMicroserviceNotificationService>().Object);
+        var root = services.BuildServiceProvider();
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(x => x.CreateScope()).Returns(() => root.CreateScope());
+        return scopeFactory.Object;
+    }
+
+    public static IMicroserviceTokenService CreateTokenService() =>
+        Mock.Of<IMicroserviceTokenService>(x =>
+            x.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())
+            == "test-jwt");
+}

--- a/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnEventBackgroundServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnEventBackgroundServiceTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Services.BackgroundServices;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using DataGateMonitor.Tests.Helpers;
+using DataGateMonitor.Tests.Services.DataGateOpenVpnManager.Events;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.BackgroundServices;
+
+[Collection("OpenVpnBackgroundServiceSingleton")]
+public class OpenVpnEventBackgroundServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_CreatesEventClientForEachEnabledServer()
+    {
+        ResetInstanceCount();
+
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        StubOpenVpnEventClient? stubClient = null;
+        var factory = new Mock<IOpenVpnEventClientFactory>();
+        factory.Setup(x => x.Create(server)).Returns(() =>
+        {
+            stubClient ??= new StubOpenVpnEventClient(
+                server,
+                NullLogger<OpenVpnEventClient>.Instance,
+                Mock.Of<IHubContext<OpenVpnEventHub>>(),
+                OpenVpnHubTestHelpers.CreateTokenService(),
+                Mock.Of<IServiceScopeFactory>());
+            return stubClient;
+        });
+
+        var query = new Mock<IVpnServerQueryService>();
+        query.Setup(x => x.GetAll(false, false, null, It.IsAny<CancellationToken>())).ReturnsAsync([server]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(query.Object);
+        var sp = services.BuildServiceProvider();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new OpenVpnEventBackgroundService(
+            NullLogger<OpenVpnEventBackgroundService>.Instance,
+            factory.Object,
+            sp.GetRequiredService<IServiceScopeFactory>());
+
+        await sut.StartAsync(cts.Token);
+        await Task.Delay(200, CancellationToken.None);
+        await cts.CancelAsync();
+        await sut.StopAsync(CancellationToken.None);
+
+        factory.Verify(x => x.Create(server), Times.AtLeastOnce);
+        Assert.NotNull(stubClient);
+        Assert.True(stubClient!.StartListeningCallCount >= 1);
+
+        ResetInstanceCount();
+    }
+
+    private static void ResetInstanceCount()
+    {
+        var field = typeof(OpenVpnEventBackgroundService).GetField("_instanceCount", BindingFlags.Static | BindingFlags.NonPublic);
+        field!.SetValue(null, 0);
+    }
+}
+
+[CollectionDefinition("OpenVpnBackgroundServiceSingleton", DisableParallelization = true)]
+public sealed class OpenVpnBackgroundServiceSingletonCollection;

--- a/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnProxyTrafficFlowBackgroundServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnProxyTrafficFlowBackgroundServiceTests.cs
@@ -1,116 +1,83 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Moq;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
-using DataGateMonitor.Models;
 using DataGateMonitor.Services.BackgroundServices;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
-using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.BackgroundServices;
 
 public class OpenVpnProxyTrafficFlowBackgroundServiceTests
 {
     [Fact]
-    public async Task ExecuteAsync_StartsListeners_OnlyForEnabledOpenVpnServers()
+    public async Task ExecuteAsync_StartsListenerWhenServerSupportsTrafficFlow()
     {
-        var serverQuery = new Mock<IVpnServerQueryService>();
-        serverQuery.Setup(q => q.GetAll(
-                It.IsAny<bool>(),
-                It.IsAny<bool>(),
-                It.IsAny<int?>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<VpnServer>
-            {
-                new() { Id = 1, ServerType = VpnServerType.OpenVpn, IsDisable = false, ApiUrl = "https://ovpn-1" },
-                new() { Id = 2, ServerType = VpnServerType.OpenVpn, IsDisable = true, ApiUrl = "https://ovpn-2" },
-                new() { Id = 3, ServerType = VpnServerType.Xray, IsDisable = false, ApiUrl = "https://xray-1" }
-            });
-
-        var scopedProvider = new Mock<IServiceProvider>();
-        scopedProvider.Setup(p => p.GetService(typeof(IVpnServerQueryService))).Returns(serverQuery.Object);
-
-        var scope = new Mock<IServiceScope>();
-        scope.SetupGet(s => s.ServiceProvider).Returns(scopedProvider.Object);
-
-        var scopeFactory = new Mock<IServiceScopeFactory>();
-        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
-
-        var started = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var flowClient = new Mock<IOpenVpnProxyTrafficFlowClient>();
-        flowClient
-            .Setup(c => c.StartListeningAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
-            .Callback(() => started.TrySetResult(true));
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var client = new Mock<IOpenVpnProxyTrafficFlowClient>();
+        client.Setup(x => x.StartListeningAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
         var factory = new Mock<IOpenVpnProxyTrafficFlowClientFactory>();
-        factory.Setup(f => f.Create(It.Is<VpnServer>(s => s.Id == 1))).Returns(flowClient.Object);
+        factory.Setup(x => x.Create(server)).Returns(client.Object);
 
-        var supportChecker = new Mock<IOpenVpnProxyTrafficFlowSupportChecker>();
-        supportChecker
-            .Setup(c => c.ShouldListenAsync(It.Is<VpnServer>(s => s.Id == 1), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-        supportChecker
-            .Setup(c => c.ShouldListenAsync(It.Is<VpnServer>(s => s.Id != 1), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+        var checker = new Mock<IOpenVpnProxyTrafficFlowSupportChecker>();
+        checker.Setup(x => x.ShouldListenAsync(server, It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
-        var logger = new Mock<ILogger<OpenVpnProxyTrafficFlowBackgroundService>>();
-        var service = new OpenVpnProxyTrafficFlowBackgroundService(
-            logger.Object,
+        var query = new Mock<IVpnServerQueryService>();
+        query.Setup(x => x.GetAll(false, false, null, It.IsAny<CancellationToken>())).ReturnsAsync([server]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(query.Object);
+        var sp = services.BuildServiceProvider();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new OpenVpnProxyTrafficFlowBackgroundService(
+            NullLogger<OpenVpnProxyTrafficFlowBackgroundService>.Instance,
             factory.Object,
-            supportChecker.Object,
-            scopeFactory.Object);
+            checker.Object,
+            sp.GetRequiredService<IServiceScopeFactory>());
 
-        await service.StartAsync(CancellationToken.None);
-        var completed = await Task.WhenAny(started.Task, Task.Delay(TimeSpan.FromSeconds(2)));
-        await service.StopAsync(CancellationToken.None);
+        await sut.StartAsync(cts.Token);
+        await Task.Delay(200, CancellationToken.None);
+        await cts.CancelAsync();
+        await sut.StopAsync(CancellationToken.None);
 
-        Assert.Same(started.Task, completed);
-        factory.Verify(f => f.Create(It.Is<VpnServer>(s => s.Id == 1)), Times.AtLeastOnce);
-        factory.Verify(f => f.Create(It.Is<VpnServer>(s => s.Id == 2)), Times.Never);
-        factory.Verify(f => f.Create(It.Is<VpnServer>(s => s.Id == 3)), Times.Never);
-        flowClient.Verify(c => c.StartListeningAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        factory.Verify(x => x.Create(server), Times.AtLeastOnce);
+        client.Verify(x => x.StartListeningAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        factory.Verify(x => x.Remove(It.IsAny<int>()), Times.Never);
     }
 
     [Fact]
-    public async Task ExecuteAsync_WhenServerUnsupported_RemovesClient_AndDoesNotStartListener()
+    public async Task ExecuteAsync_RemovesClientWhenTrafficFlowUnsupported()
     {
-        var server = new VpnServer { Id = 4, ServerType = VpnServerType.OpenVpn, IsDisable = false, ApiUrl = "https://ovpn-old" };
-        var serverQuery = new Mock<IVpnServerQueryService>();
-        serverQuery.Setup(q => q.GetAll(
-                It.IsAny<bool>(),
-                It.IsAny<bool>(),
-                It.IsAny<int?>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<VpnServer> { server });
-
-        var scopedProvider = new Mock<IServiceProvider>();
-        scopedProvider.Setup(p => p.GetService(typeof(IVpnServerQueryService))).Returns(serverQuery.Object);
-
-        var scope = new Mock<IServiceScope>();
-        scope.SetupGet(s => s.ServiceProvider).Returns(scopedProvider.Object);
-
-        var scopeFactory = new Mock<IServiceScopeFactory>();
-        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
         var factory = new Mock<IOpenVpnProxyTrafficFlowClientFactory>();
-        var supportChecker = new Mock<IOpenVpnProxyTrafficFlowSupportChecker>();
-        supportChecker
-            .Setup(c => c.ShouldListenAsync(server, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+        factory.Setup(x => x.Remove(server.Id)).Returns(true);
 
-        var logger = new Mock<ILogger<OpenVpnProxyTrafficFlowBackgroundService>>();
-        var service = new OpenVpnProxyTrafficFlowBackgroundService(
-            logger.Object,
+        var checker = new Mock<IOpenVpnProxyTrafficFlowSupportChecker>();
+        checker.Setup(x => x.ShouldListenAsync(server, It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var query = new Mock<IVpnServerQueryService>();
+        query.Setup(x => x.GetAll(false, false, null, It.IsAny<CancellationToken>())).ReturnsAsync([server]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(query.Object);
+        var sp = services.BuildServiceProvider();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var sut = new OpenVpnProxyTrafficFlowBackgroundService(
+            NullLogger<OpenVpnProxyTrafficFlowBackgroundService>.Instance,
             factory.Object,
-            supportChecker.Object,
-            scopeFactory.Object);
+            checker.Object,
+            sp.GetRequiredService<IServiceScopeFactory>());
 
-        await service.StartAsync(CancellationToken.None);
-        await Task.Delay(TimeSpan.FromMilliseconds(200));
-        await service.StopAsync(CancellationToken.None);
+        await sut.StartAsync(cts.Token);
+        await Task.Delay(200, CancellationToken.None);
+        await cts.CancelAsync();
+        await sut.StopAsync(CancellationToken.None);
 
-        factory.Verify(f => f.Remove(server.Id), Times.AtLeastOnce);
-        factory.Verify(f => f.Create(It.IsAny<VpnServer>()), Times.Never);
+        factory.Verify(x => x.Remove(server.Id), Times.AtLeastOnce);
+        factory.Verify(x => x.Create(It.IsAny<Models.VpnServer>()), Times.Never);
     }
 }

--- a/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnServerProcessorTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnServerProcessorTests.cs
@@ -1,46 +1,71 @@
-using Microsoft.EntityFrameworkCore.Query;
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.BackgroundServices;
 using DataGateMonitor.Services.BackgroundServices.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
-using Xunit;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.BackgroundServices;
 
 public class OpenVpnServerProcessorTests
 {
-    [Fact]
-    public async Task ProcessServerAsync_CallsConflogService_FetchAndSaveIfChangedByServerId()
+    private static (OpenVpnServerProcessor Processor, Mock<IVpnServerService> VpnService, Mock<ICommandService<VpnServer, int>> ServerCmd)
+        CreateProcessor()
     {
-        var conflogService = new Mock<IVpnServerConflogService>();
-        conflogService.Setup(s => s.FetchAndSaveIfChangedByServerIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        var vpnService = new Mock<IVpnServerService>();
+        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
+        serverCmd.Setup(x => x.UpdateWhere(
+                It.IsAny<System.Linq.Expressions.Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var conflog = new Mock<IVpnServerConflogService>();
+        conflog.Setup(x => x.FetchAndSaveIfChangedByServerIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((VpnServerConflog?)null);
 
-        var openVpnServerService = new Mock<IVpnServerService>();
-        openVpnServerService.Setup(s => s.SaveVpnServerStatusLogAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        openVpnServerService.Setup(s => s.SaveConnectedClientsAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-
-        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
-        serverCmd.Setup(c => c.UpdateWhere(It.IsAny<System.Linq.Expressions.Expression<Func<VpnServer, bool>>>(), It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<VpnServer>>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(1));
-
         var services = new ServiceCollection();
-        services.AddSingleton(openVpnServerService.Object);
+        services.AddSingleton(vpnService.Object);
         services.AddSingleton(serverCmd.Object);
-        services.AddSingleton(conflogService.Object);
+        services.AddSingleton(conflog.Object);
         var sp = services.BuildServiceProvider();
 
-        var logger = new Mock<Microsoft.Extensions.Logging.ILogger<OpenVpnServerProcessor>>();
-        var processor = new OpenVpnServerProcessor(logger.Object, sp);
+        return (new OpenVpnServerProcessor(NullLogger<OpenVpnServerProcessor>.Instance, sp), vpnService, serverCmd);
+    }
 
-        var server = new VpnServer { Id = 42, ServerName = "Test", ApiUrl = "https://test" };
+    [Fact]
+    public async Task ProcessServerAsync_OnSuccess_SetsServerOnline()
+    {
+        var (processor, vpnService, serverCmd) = CreateProcessor();
+        vpnService.Setup(x => x.SaveVpnServerStatusLogAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        vpnService.Setup(x => x.SaveConnectedClientsAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
 
-        await processor.ProcessServerAsync(server, CancellationToken.None);
+        await processor.ProcessServerAsync(OpenVpnHubTestHelpers.OpenVpnServer(), CancellationToken.None);
 
-        conflogService.Verify(s => s.FetchAndSaveIfChangedByServerIdAsync(42, It.IsAny<CancellationToken>()), Times.Once);
-        openVpnServerService.Verify(s => s.SaveVpnServerStatusLogAsync(server, It.IsAny<CancellationToken>()), Times.Once);
-        openVpnServerService.Verify(s => s.SaveConnectedClientsAsync(server, It.IsAny<CancellationToken>()), Times.Once);
+        serverCmd.Verify(x => x.UpdateWhere(
+            It.IsAny<System.Linq.Expressions.Expression<Func<VpnServer, bool>>>(),
+            It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<VpnServer>>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessServerAsync_OnFailure_SetsServerOfflineAndRethrows()
+    {
+        var (processor, vpnService, serverCmd) = CreateProcessor();
+        vpnService.Setup(x => x.SaveVpnServerStatusLogAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("hub down"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            processor.ProcessServerAsync(OpenVpnHubTestHelpers.OpenVpnServer(), CancellationToken.None));
+
+        serverCmd.Verify(x => x.UpdateWhere(
+            It.IsAny<System.Linq.Expressions.Expression<Func<VpnServer, bool>>>(),
+            It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<VpnServer>>>(),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientConnectionTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientConnectionTests.cs
@@ -1,0 +1,86 @@
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.Events;
+
+public class OpenVpnEventClientConnectionTests
+{
+    [Fact]
+    public async Task StartListeningAsync_UsesInjectedHubFactory_AndStartsOnce()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        var eventHubFactory = new SingleProxyEventHubConnectionFactory(proxy);
+
+        var services = new ServiceCollection();
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(x => x.CreateScope()).Returns(Mock.Of<IServiceScope>());
+
+        var client = new OpenVpnEventClient(
+            server,
+            NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            scopeFactory.Object,
+            eventHubFactory);
+
+        await client.StartListeningAsync(CancellationToken.None);
+        await client.StartListeningAsync(CancellationToken.None);
+
+        Assert.Equal(1, proxy.StartCallCount);
+        Assert.Equal(HubConnectionState.Connected, proxy.State);
+        Assert.Contains("openvpn-event", client.GetStatus().ConnectionStatus.Url);
+    }
+
+    [Fact]
+    public async Task StartListeningAsync_WhenReconnecting_WaitsWithoutSecondStart()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        var client = new OpenVpnEventClient(
+            server,
+            NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            Mock.Of<IServiceScopeFactory>(),
+            new SingleProxyEventHubConnectionFactory(proxy));
+
+        await client.StartListeningAsync(CancellationToken.None);
+        proxy.State = HubConnectionState.Reconnecting;
+        _ = Task.Run(() => proxy.SimulateReconnectingThenConnectedAsync(TimeSpan.FromMilliseconds(50)));
+
+        await client.StartListeningAsync(CancellationToken.None);
+
+        Assert.Equal(1, proxy.StartCallCount);
+    }
+
+    [Fact]
+    public async Task StartListeningAsync_RecreatesConnection_WhenBoundServerApiUrlChanges()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var client = new OpenVpnEventClient(
+            server,
+            NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            Mock.Of<IServiceScopeFactory>(),
+            hubFactory);
+
+        await client.StartListeningAsync(CancellationToken.None);
+        Assert.Single(hubFactory.Created);
+
+        server.ApiUrl = "https://mutated.datagateapp.com/";
+        await client.StartListeningAsync(CancellationToken.None);
+
+        Assert.Equal(2, hubFactory.Created.Count);
+        Assert.True(hubFactory.Created[0].Disposed);
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientConnectionTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientConnectionTests.cs
@@ -83,4 +83,51 @@ public class OpenVpnEventClientConnectionTests
         Assert.Equal(2, hubFactory.Created.Count);
         Assert.True(hubFactory.Created[0].Disposed);
     }
+
+    [Fact]
+    public async Task StartListeningAsync_OnReconnecting_UpdatesDiagnosticsState()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        var client = new OpenVpnEventClient(
+            server,
+            NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            Mock.Of<IServiceScopeFactory>(),
+            new SingleProxyEventHubConnectionFactory(proxy));
+
+        await client.StartListeningAsync(CancellationToken.None);
+        await proxy.RaiseReconnectingAsync(new InvalidOperationException("reconnecting"));
+
+        Assert.Equal("Reconnecting", client.GetStatus().ConnectionStatus.State);
+    }
+
+    /// <summary>
+    /// Microsoft docs: after WithAutomaticReconnect gives up, Closed fires and the app must call StartAsync again.
+    /// Background service does that on the next poll via StartListeningAsync.
+    /// </summary>
+    [Fact]
+    public async Task StartListeningAsync_RestartsHub_AfterClosedEvent()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        var client = new OpenVpnEventClient(
+            server,
+            NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            Mock.Of<IServiceScopeFactory>(),
+            new SingleProxyEventHubConnectionFactory(proxy));
+
+        await client.StartListeningAsync(CancellationToken.None);
+        Assert.Equal(1, proxy.StartCallCount);
+
+        await proxy.RaiseClosedAsync(new InvalidOperationException("auto-reconnect exhausted"));
+        Assert.Equal(HubConnectionState.Disconnected, proxy.State);
+        Assert.Equal("Disconnected", client.GetStatus().ConnectionStatus.State);
+
+        await client.StartListeningAsync(CancellationToken.None);
+        Assert.Equal(2, proxy.StartCallCount);
+    }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactoryTests.cs
@@ -32,6 +32,36 @@ public class OpenVpnEventClientFactoryTests
         var second = factory.Create(server);
 
         Assert.Same(first, second);
+        Assert.Equal(server.ApiUrl, first.RegisteredApiUrl);
+    }
+
+    [Fact]
+    public void Create_RecreatesClient_WhenApiUrlChanges()
+    {
+        var factory = CreateFactory();
+        var firstServer = OpenVpnHubTestHelpers.OpenVpnServer();
+        var changedServer = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/");
+
+        var first = factory.Create(firstServer);
+        var second = factory.Create(changedServer);
+
+        Assert.NotSame(first, second);
+        Assert.Equal("https://changed.datagateapp.com/", second.RegisteredApiUrl);
+    }
+
+    [Fact]
+    public void Create_RecreatesClient_WhenSameServerObjectApiUrlIsMutated()
+    {
+        var factory = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+
+        var first = factory.Create(server);
+        server.ApiUrl = "https://mutated.datagateapp.com/";
+        var second = factory.Create(server);
+
+        Assert.NotSame(first, second);
+        Assert.Equal("https://s5.datagateapp.com/", first.RegisteredApiUrl);
+        Assert.Equal("https://mutated.datagateapp.com/", second.RegisteredApiUrl);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactoryTests.cs
@@ -1,169 +1,85 @@
-using FluentAssertions;
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Moq;
-using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
-using Xunit;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.Events;
 
 public class OpenVpnEventClientFactoryTests
 {
-    private static VpnServer Server(int id, string apiUrl = "https://vpn.test/") => new()
+    private static OpenVpnEventClientFactory CreateFactory()
     {
-        Id = id,
-        ApiUrl = apiUrl,
-        ServerName = $"Server{id}",
-        CreateDate = DateTimeOffset.UtcNow,
-        LastUpdate = DateTimeOffset.UtcNow
-    };
-
-    [Fact]
-    public void Create_SameServerId_ReturnsSameCachedInstance()
-    {
-        var server = Server(1);
-        var (provider, _) = CreateProvider(server);
-        var factory = new OpenVpnEventClientFactory(provider);
-
-        var client1 = factory.Create(server);
-        var client2 = factory.Create(server);
-
-        client1.Should().BeSameAs(client2);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IHubContext<OpenVpnEventHub>>(Mock.Of<IHubContext<OpenVpnEventHub>>());
+        services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
+        var sp = services.BuildServiceProvider();
+        return new OpenVpnEventClientFactory(sp);
     }
 
     [Fact]
-    public void Create_DifferentServerIds_ReturnsDifferentInstances()
+    public void Create_ReturnsCachedClient_ForSameServerId()
     {
-        var (provider, _) = CreateProvider(Server(1));
-        var factory = new OpenVpnEventClientFactory(provider);
+        var factory = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
-        var client1 = factory.Create(Server(1));
-        var client2 = factory.Create(Server(2));
+        var first = factory.Create(server);
+        var second = factory.Create(server);
 
-        client1.Should().NotBeSameAs(client2);
+        Assert.Same(first, second);
     }
 
     [Fact]
-    public void GetAllClients_ReturnsAllCachedClients()
+    public void Remove_StopsClientAndEvictsFromCache()
     {
-        var (provider, _) = CreateProvider(Server(1));
-        var factory = new OpenVpnEventClientFactory(provider);
-        factory.Create(Server(1));
-        factory.Create(Server(2));
+        var factory = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
-        var all = factory.GetAllClients();
+        var client = factory.Create(server);
+        Assert.True(factory.Remove(server.Id));
 
-        all.Should().HaveCount(2);
+        var recreated = factory.Create(server);
+        Assert.NotSame(client, recreated);
     }
 
     [Fact]
-    public void TryGetClientStatus_WhenCached_ReturnsTrueAndStatus()
+    public void TryGetClientStatus_ReturnsStatus_AfterCreate()
     {
-        var server = Server(1);
-        var (provider, _) = CreateProvider(server);
-        var factory = new OpenVpnEventClientFactory(provider);
-        factory.Create(server);
+        var factory = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
-        var found = factory.TryGetClientStatus(1, out var status);
+        _ = factory.Create(server);
 
-        found.Should().BeTrue();
-        status.Should().NotBeNull();
-        status!.ConnectionStatus.ServerId.Should().Be(1);
+        Assert.True(factory.TryGetClientStatus(server.Id, out var status));
+        Assert.NotNull(status);
+        Assert.Equal(server.Id, status!.ConnectionStatus.ServerId);
     }
 
     [Fact]
-    public void TryGetClientStatus_WhenNotCached_ReturnsFalseAndNull()
+    public void GetAllClientStatuses_IncludesCreatedClients()
     {
-        var (provider, _) = CreateProvider(Server(1));
-        var factory = new OpenVpnEventClientFactory(provider);
+        var factory = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        _ = factory.Create(server);
 
-        var found = factory.TryGetClientStatus(99, out var status);
+        var statuses = factory.GetAllClientStatuses();
 
-        found.Should().BeFalse();
-        status.Should().BeNull();
+        Assert.Single(statuses.ConnectionStatuses);
+        Assert.Equal(server.Id, statuses.ConnectionStatuses[0].ServerId);
     }
 
     [Fact]
-    public void Remove_WhenCached_ReturnsTrue_AndTryGetClientStatusReturnsFalse()
+    public void Create_Throws_ForNonOpenVpnServer()
     {
-        var server = Server(1);
-        var (provider, _) = CreateProvider(server);
-        var factory = new OpenVpnEventClientFactory(provider);
-        factory.Create(server);
+        var factory = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        server.ServerType = SharedModels.Enums.VpnServerType.Xray;
 
-        var removed = factory.Remove(1);
-
-        removed.Should().BeTrue();
-        factory.TryGetClientStatus(1, out _).Should().BeFalse();
-    }
-
-    [Fact]
-    public void Remove_WhenNotCached_ReturnsFalse()
-    {
-        var (provider, _) = CreateProvider(Server(1));
-        var factory = new OpenVpnEventClientFactory(provider);
-
-        var removed = factory.Remove(99);
-
-        removed.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task TryCreateByServerIdAsync_WhenServerExists_ReturnsClient()
-    {
-        var server = Server(5);
-        var (provider, serverQuery) = CreateProvider(server);
-        serverQuery.Setup(q => q.GetById(5, It.IsAny<CancellationToken>())).ReturnsAsync(server);
-        var factory = new OpenVpnEventClientFactory(provider);
-
-        var client = await factory.TryCreateByServerIdAsync(5, CancellationToken.None);
-
-        client.Should().NotBeNull();
-        factory.TryGetClientStatus(5, out _).Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task TryCreateByServerIdAsync_WhenServerNotFound_ReturnsNull()
-    {
-        var (provider, serverQuery) = CreateProvider(Server(1));
-        serverQuery.Setup(q => q.GetById(99, It.IsAny<CancellationToken>())).ReturnsAsync((VpnServer?)null);
-        var factory = new OpenVpnEventClientFactory(provider);
-
-        var client = await factory.TryCreateByServerIdAsync(99, CancellationToken.None);
-
-        client.Should().BeNull();
-    }
-
-    private static (IServiceProvider provider, Mock<IVpnServerQueryService> serverQuery) CreateProvider(VpnServer? server = null)
-    {
-        var logger = new Mock<ILogger<OpenVpnEventClient>>(MockBehavior.Loose);
-        var eventHub = new Mock<IHubContext<OpenVpnEventHub>>(MockBehavior.Loose);
-        var tokenService = new Mock<IMicroserviceTokenService>(MockBehavior.Loose);
-        tokenService.Setup(t => t.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns("token");
-        var scopeFactory = new Mock<IServiceScopeFactory>(MockBehavior.Loose);
-        var scope = new Mock<IServiceScope>(MockBehavior.Loose);
-        var scopeProvider = new Mock<IServiceProvider>(MockBehavior.Loose);
-        scope.Setup(s => s.ServiceProvider).Returns(scopeProvider.Object);
-        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
-
-        var serverQuery = new Mock<IVpnServerQueryService>(MockBehavior.Strict);
-        if (server != null)
-            serverQuery.Setup(q => q.GetById(server.Id, It.IsAny<CancellationToken>())).ReturnsAsync(server);
-        scopeProvider.Setup(p => p.GetService(typeof(IVpnServerQueryService))).Returns(serverQuery.Object);
-
-        var rootProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
-        rootProvider.Setup(p => p.GetService(typeof(ILogger<OpenVpnEventClient>))).Returns(logger.Object);
-        rootProvider.Setup(p => p.GetService(typeof(IHubContext<OpenVpnEventHub>))).Returns(eventHub.Object);
-        rootProvider.Setup(p => p.GetService(typeof(IMicroserviceTokenService))).Returns(tokenService.Object);
-        rootProvider.Setup(p => p.GetService(typeof(IServiceScopeFactory))).Returns(scopeFactory.Object);
-        rootProvider.Setup(p => p.GetService(typeof(ILogger<OpenVpnEventClientFactory>))).Returns(Mock.Of<ILogger<OpenVpnEventClientFactory>>());
-        // CreateScope() is an extension method that uses GetRequiredService<IServiceScopeFactory>().CreateScope(), so no need to mock it on rootProvider
-
-        return (rootProvider.Object, serverQuery);
+        Assert.Throws<InvalidOperationException>(() => factory.Create(server));
     }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactoryTests.cs
@@ -1,7 +1,9 @@
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 using DataGateMonitor.Tests.Helpers;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,20 +14,22 @@ namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.Events;
 
 public class OpenVpnEventClientFactoryTests
 {
-    private static OpenVpnEventClientFactory CreateFactory()
+    private static (OpenVpnEventClientFactory Factory, Mock<IVpnServerQueryService> ServerQuery) CreateFactory()
     {
+        var serverQuery = new Mock<IVpnServerQueryService>();
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton(serverQuery.Object);
         services.AddSingleton<IHubContext<OpenVpnEventHub>>(Mock.Of<IHubContext<OpenVpnEventHub>>());
         services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
         var sp = services.BuildServiceProvider();
-        return new OpenVpnEventClientFactory(sp);
+        return (new OpenVpnEventClientFactory(sp), serverQuery);
     }
 
     [Fact]
     public void Create_ReturnsCachedClient_ForSameServerId()
     {
-        var factory = CreateFactory();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
         var first = factory.Create(server);
@@ -36,14 +40,33 @@ public class OpenVpnEventClientFactoryTests
     }
 
     [Fact]
+    public void Create_ReturnsDifferentInstances_ForDifferentServerIds()
+    {
+        var (factory, _) = CreateFactory();
+
+        var client1 = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(id: 1));
+        var client2 = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(id: 2));
+
+        Assert.NotSame(client1, client2);
+        Assert.Equal(2, factory.GetAllClients().Count);
+    }
+
+    [Fact]
+    public void Create_ReusesInstance_WhenUrlDiffersOnlyByCaseOrTrailingSlash()
+    {
+        var (factory, _) = CreateFactory();
+        var first = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://MS.Example/api/"));
+        var second = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://ms.example/api"));
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
     public void Create_RecreatesClient_WhenApiUrlChanges()
     {
-        var factory = CreateFactory();
-        var firstServer = OpenVpnHubTestHelpers.OpenVpnServer();
-        var changedServer = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/");
-
-        var first = factory.Create(firstServer);
-        var second = factory.Create(changedServer);
+        var (factory, _) = CreateFactory();
+        var first = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer());
+        var second = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/"));
 
         Assert.NotSame(first, second);
         Assert.Equal("https://changed.datagateapp.com/", second.RegisteredApiUrl);
@@ -52,7 +75,7 @@ public class OpenVpnEventClientFactoryTests
     [Fact]
     public void Create_RecreatesClient_WhenSameServerObjectApiUrlIsMutated()
     {
-        var factory = CreateFactory();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
         var first = factory.Create(server);
@@ -67,22 +90,30 @@ public class OpenVpnEventClientFactoryTests
     [Fact]
     public void Remove_StopsClientAndEvictsFromCache()
     {
-        var factory = CreateFactory();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
         var client = factory.Create(server);
         Assert.True(factory.Remove(server.Id));
+        Assert.False(factory.TryGetClientStatus(server.Id, out _));
 
         var recreated = factory.Create(server);
         Assert.NotSame(client, recreated);
+        Assert.True(factory.TryGetClientStatus(server.Id, out _));
+    }
+
+    [Fact]
+    public void Remove_ReturnsFalse_WhenNotCached()
+    {
+        var (factory, _) = CreateFactory();
+        Assert.False(factory.Remove(99));
     }
 
     [Fact]
     public void TryGetClientStatus_ReturnsStatus_AfterCreate()
     {
-        var factory = CreateFactory();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
-
         _ = factory.Create(server);
 
         Assert.True(factory.TryGetClientStatus(server.Id, out var status));
@@ -91,22 +122,53 @@ public class OpenVpnEventClientFactoryTests
     }
 
     [Fact]
+    public void TryGetClientStatus_ReturnsFalse_WhenNotCached()
+    {
+        var (factory, _) = CreateFactory();
+        Assert.False(factory.TryGetClientStatus(99, out var status));
+        Assert.Null(status);
+    }
+
+    [Fact]
     public void GetAllClientStatuses_IncludesCreatedClients()
     {
-        var factory = CreateFactory();
-        var server = OpenVpnHubTestHelpers.OpenVpnServer();
-        _ = factory.Create(server);
+        var (factory, _) = CreateFactory();
+        _ = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(id: 1));
+        _ = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(id: 2));
 
         var statuses = factory.GetAllClientStatuses();
 
-        Assert.Single(statuses.ConnectionStatuses);
-        Assert.Equal(server.Id, statuses.ConnectionStatuses[0].ServerId);
+        Assert.Equal(2, statuses.ConnectionStatuses.Count);
+    }
+
+    [Fact]
+    public async Task TryCreateByServerIdAsync_ReturnsClient_WhenServerExists()
+    {
+        var (factory, serverQuery) = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer(id: 5);
+        serverQuery.Setup(q => q.GetById(5, It.IsAny<CancellationToken>())).ReturnsAsync(server);
+
+        var client = await factory.TryCreateByServerIdAsync(5, CancellationToken.None);
+
+        Assert.NotNull(client);
+        Assert.True(factory.TryGetClientStatus(5, out _));
+    }
+
+    [Fact]
+    public async Task TryCreateByServerIdAsync_ReturnsNull_WhenServerNotFound()
+    {
+        var (factory, serverQuery) = CreateFactory();
+        serverQuery.Setup(q => q.GetById(99, It.IsAny<CancellationToken>())).ReturnsAsync((VpnServer?)null);
+
+        var client = await factory.TryCreateByServerIdAsync(99, CancellationToken.None);
+
+        Assert.Null(client);
     }
 
     [Fact]
     public void Create_Throws_ForNonOpenVpnServer()
     {
-        var factory = CreateFactory();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
         server.ServerType = SharedModels.Enums.VpnServerType.Xray;
 

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientLifecycleTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientLifecycleTests.cs
@@ -1,0 +1,52 @@
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.Events;
+
+public class OpenVpnEventClientLifecycleTests
+{
+    private static OpenVpnEventClient CreateClient()
+    {
+        var services = new ServiceCollection();
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(x => x.CreateScope()).Returns(Mock.Of<IServiceScope>());
+
+        return new OpenVpnEventClient(
+            OpenVpnHubTestHelpers.OpenVpnServer(),
+            NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            scopeFactory.Object);
+    }
+
+    [Fact]
+    public void GetStatus_BeforeStart_ReportsDisconnected()
+    {
+        var client = CreateClient();
+        var status = client.GetStatus();
+
+        Assert.Equal("Disconnected", status.ConnectionStatus.State);
+        Assert.Equal(75, status.ConnectionStatus.ServerId);
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenNeverStarted_DoesNotThrow()
+    {
+        var client = CreateClient();
+        await client.StopAsync();
+    }
+
+    [Fact]
+    public async Task StopAsync_AfterStop_RemainsDisconnected()
+    {
+        var client = CreateClient();
+        await client.StopAsync();
+
+        Assert.Equal("Disconnected", client.GetStatus().ConnectionStatus.State);
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientStartRetryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientStartRetryTests.cs
@@ -1,0 +1,78 @@
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.Events;
+
+public class OpenVpnEventClientStartRetryTests
+{
+    [Fact]
+    public async Task StartListeningAsync_OnStartFailure_RetriesWithInjectableDelay_AndNotifiesOnce()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var failFirstStart = true;
+        var proxy = new FakeHubConnectionProxy();
+        proxy.StartAsyncOverride = _ =>
+        {
+            if (failFirstStart)
+            {
+                failFirstStart = false;
+                throw new InvalidOperationException("hub unreachable");
+            }
+
+            proxy.State = HubConnectionState.Connected;
+            return Task.CompletedTask;
+        };
+
+        var delayCalls = 0;
+        var notifications = new Mock<IOpenVpnMicroserviceNotificationService>();
+        notifications
+            .Setup(x => x.NotifyEventHubConnectionFailed(
+                server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var scopeFactory = OpenVpnHubTestHelpers.CreateScopeFactory(notifications.Object);
+
+        var client = new OpenVpnEventClient(
+            server,
+            NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            scopeFactory,
+            new SingleProxyEventHubConnectionFactory(proxy),
+            startRetryDelay: TimeSpan.FromMilliseconds(5),
+            retryDelayAsync: (delay, ct) =>
+            {
+                delayCalls++;
+                Assert.Equal(TimeSpan.FromMilliseconds(5), delay);
+                return Task.CompletedTask;
+            });
+
+        await client.StartListeningAsync(CancellationToken.None);
+
+        Assert.Equal(2, proxy.StartCallCount);
+        Assert.Equal(1, delayCalls);
+        Assert.Equal(HubConnectionState.Connected, proxy.State);
+        notifications.Verify(
+            x => x.NotifyEventHubConnectionFailed(
+                server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void OpenVpnHubConnectionDefaults_MicroserviceAndEventFactoriesShareReconnectSchedule()
+    {
+        Assert.Equal(6, OpenVpnHubConnectionDefaults.AutomaticReconnectDelays.Length);
+        Assert.Equal(TimeSpan.Zero, OpenVpnHubConnectionDefaults.AutomaticReconnectDelays[0]);
+        Assert.Equal(TimeSpan.FromSeconds(60), OpenVpnHubConnectionDefaults.AutomaticReconnectDelays[^1]);
+        Assert.Equal(TimeSpan.FromSeconds(5), OpenVpnHubConnectionDefaults.StartFailureRetryDelay);
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/StubOpenVpnEventClient.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/Events/StubOpenVpnEventClient.cs
@@ -1,0 +1,25 @@
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.Events;
+
+internal sealed class StubOpenVpnEventClient(
+    VpnServer server,
+    ILogger<OpenVpnEventClient> logger,
+    IHubContext<OpenVpnEventHub> eventHub,
+    IMicroserviceTokenService tokenService,
+    IServiceScopeFactory scopeFactory) : OpenVpnEventClient(server, logger, eventHub, tokenService, scopeFactory)
+{
+    public int StartListeningCallCount { get; private set; }
+
+    public override Task StartListeningAsync(CancellationToken cancellationToken)
+    {
+        StartListeningCallCount++;
+        return Task.CompletedTask;
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionStartupTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionStartupTests.cs
@@ -1,0 +1,214 @@
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+
+/// <summary>
+/// SignalR <see cref="HubConnectionState"/> has exactly four documented values:
+/// Disconnected (0), Connected (1), Connecting (2), Reconnecting (3).
+/// </summary>
+public class HubConnectionStartupTests
+{
+    private static readonly TimeSpan ShortTimeout = TimeSpan.FromMilliseconds(350);
+
+    public static IEnumerable<object[]> DocumentedStates =>
+        Enum.GetValues<HubConnectionState>().Select(s => new object[] { s });
+
+    [Theory]
+    [MemberData(nameof(DocumentedStates))]
+    public void HubConnectionState_HasOnlyDocumentedSignalRValues(HubConnectionState state)
+    {
+        Assert.True(Enum.IsDefined(state));
+        Assert.Contains(state, new[]
+        {
+            HubConnectionState.Disconnected,
+            HubConnectionState.Connected,
+            HubConnectionState.Connecting,
+            HubConnectionState.Reconnecting,
+        });
+    }
+
+    [Fact]
+    public async Task Connected_ReturnsImmediately_WithoutCallingStart()
+    {
+        var startCalls = 0;
+
+        await HubConnectionStartup.StartWhenReadyAsync(
+            () => HubConnectionState.Connected,
+            _ =>
+            {
+                startCalls++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.Equal(0, startCalls);
+    }
+
+    [Fact]
+    public async Task Disconnected_CallsStartOnce()
+    {
+        var state = HubConnectionState.Disconnected;
+        var startCalls = 0;
+
+        await HubConnectionStartup.StartWhenReadyAsync(
+            () => state,
+            _ =>
+            {
+                startCalls++;
+                state = HubConnectionState.Connected;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.Equal(1, startCalls);
+        Assert.Equal(HubConnectionState.Connected, state);
+    }
+
+    [Fact]
+    public async Task Disconnected_PropagatesStartAsyncException()
+    {
+        var expected = new InvalidOperationException("start failed");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            HubConnectionStartup.StartWhenReadyAsync(
+                () => HubConnectionState.Disconnected,
+                _ => throw expected,
+                CancellationToken.None));
+
+        Assert.Same(expected, ex);
+    }
+
+    [Fact]
+    public async Task Connecting_WaitsUntilConnected_WithoutCallingStart()
+    {
+        var state = HubConnectionState.Connecting;
+        var startCalls = 0;
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            state = HubConnectionState.Connected;
+        });
+
+        await HubConnectionStartup.StartWhenReadyAsync(
+            () => state,
+            _ =>
+            {
+                startCalls++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            TimeSpan.FromSeconds(2));
+
+        Assert.Equal(0, startCalls);
+        Assert.Equal(HubConnectionState.Connected, state);
+    }
+
+    [Fact]
+    public async Task Connecting_ThrowsTimeout_WhenStillConnecting()
+    {
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            HubConnectionStartup.StartWhenReadyAsync(
+                () => HubConnectionState.Connecting,
+                _ => Task.CompletedTask,
+                CancellationToken.None,
+                ShortTimeout));
+
+        Assert.Contains(nameof(HubConnectionState.Connecting), ex.Message);
+    }
+
+    [Fact]
+    public async Task Reconnecting_WaitsUntilConnected_WithoutCallingStart()
+    {
+        var state = HubConnectionState.Reconnecting;
+        var startCalls = 0;
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            state = HubConnectionState.Connected;
+        });
+
+        await HubConnectionStartup.StartWhenReadyAsync(
+            () => state,
+            _ =>
+            {
+                startCalls++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            TimeSpan.FromSeconds(2));
+
+        Assert.Equal(0, startCalls);
+        Assert.Equal(HubConnectionState.Connected, state);
+    }
+
+    [Fact]
+    public async Task Reconnecting_ThrowsTimeout_WhenStillReconnecting()
+    {
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            HubConnectionStartup.StartWhenReadyAsync(
+                () => HubConnectionState.Reconnecting,
+                _ => Task.CompletedTask,
+                CancellationToken.None,
+                ShortTimeout));
+
+        Assert.Contains(nameof(HubConnectionState.Reconnecting), ex.Message);
+    }
+
+    [Fact]
+    public async Task Connecting_CanBeCancelledWhileWaiting()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(150));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            HubConnectionStartup.StartWhenReadyAsync(
+                () => HubConnectionState.Connecting,
+                _ => Task.CompletedTask,
+                cts.Token,
+                TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task Reconnecting_TransitionsToDisconnected_ThenCallsStart()
+    {
+        var state = HubConnectionState.Reconnecting;
+        var startCalls = 0;
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            state = HubConnectionState.Disconnected;
+        });
+
+        await HubConnectionStartup.StartWhenReadyAsync(
+            () => state,
+            _ =>
+            {
+                startCalls++;
+                state = HubConnectionState.Connected;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None,
+            TimeSpan.FromSeconds(2));
+
+        Assert.Equal(1, startCalls);
+        Assert.Equal(HubConnectionState.Connected, state);
+    }
+
+    [Fact]
+    public async Task UnknownEnumValue_ThrowsTimeout_WhenItNeverChanges()
+    {
+        const HubConnectionState unknown = (HubConnectionState)99;
+
+        var ex = await Assert.ThrowsAsync<TimeoutException>(() =>
+            HubConnectionStartup.StartWhenReadyAsync(
+                () => unknown,
+                _ => Task.CompletedTask,
+                CancellationToken.None,
+                ShortTimeout));
+
+        Assert.Contains("99", ex.Message);
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
@@ -1,162 +1,79 @@
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
-using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
-using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
-using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public class OpenVpnMicroserviceClientFactoryTests
 {
-    private static (OpenVpnMicroserviceClientFactory factory,
-        ServiceProvider provider,
-        Mock<IVpnServerQueryService> serverQueryMock)
-        CreateFactory()
+    private static (IServiceProvider Sp, FakeHubConnectionFactory HubFactory) CreateServices()
     {
+        var hubFactory = new FakeHubConnectionFactory();
         var services = new ServiceCollection();
-
-        // Query service
-        var serverQueryMock = new Mock<IVpnServerQueryService>();
-        services.AddSingleton(serverQueryMock.Object);
-
-        // Logger for OpenVpnMicroserviceClient
         services.AddLogging();
+        services.AddSingleton<IHubContext<OpenVpnFrontendHub>>(Mock.Of<IHubContext<OpenVpnFrontendHub>>());
+        services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
+        services.AddSingleton<IHubConnectionFactory>(hubFactory);
+        services.AddSingleton<OpenVpnMicroserviceClientFactory>();
+        var sp = services.BuildServiceProvider();
+        return (sp, hubFactory);
+    }
 
-        // Hub context (not used in these tests, so minimal mock is fine)
-        var hubContextMock = new Mock<IHubContext<OpenVpnFrontendHub>>();
-        services.AddSingleton(hubContextMock.Object);
+  [Fact]
+    public void Create_ReturnsCachedClient_ForSameServerId()
+    {
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
-        // Token service (not used directly in these tests)
-        var tokenServiceMock = new Mock<IMicroserviceTokenService>();
-        tokenServiceMock
-            .Setup(t => t.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns("dummy-token");
-        services.AddSingleton(tokenServiceMock.Object);
+        var first = factory.Create(server);
+        var second = factory.Create(server);
 
-        // Microservice notification (required by OpenVpnMicroserviceClient)
-        var microserviceNotificationMock = new Mock<IOpenVpnMicroserviceNotificationService>();
-        microserviceNotificationMock.Setup(n => n.NotifySendCommandFailed(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        microserviceNotificationMock.Setup(n => n.NotifyReconnectFailed(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        microserviceNotificationMock.Setup(n => n.NotifyEventHubConnectionFailed(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        services.AddSingleton(microserviceNotificationMock.Object);
-
-        var provider = services.BuildServiceProvider();
-        var factory = new OpenVpnMicroserviceClientFactory(provider);
-
-        return (factory, provider, serverQueryMock);
+        Assert.Same(first, second);
     }
 
     [Fact]
-    public void Create_SameId_And_ExactUrl_ReturnsSameInstance()
+    public void Create_RecreatesClient_WhenApiUrlChanges()
     {
-        var (factory, _, _) = CreateFactory();
+        var (sp, hubFactory) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var firstServer = OpenVpnHubTestHelpers.OpenVpnServer();
+        var changedServer = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/");
 
-        var server1 = new VpnServer { Id = 1, ApiUrl = "http://ms.example/api" };
-        var server2 = new VpnServer { Id = 1, ApiUrl = "http://ms.example/api" };
+        var first = factory.Create(firstServer);
+        var second = factory.Create(changedServer);
 
-        var client1 = factory.Create(server1);
-        var client2 = factory.Create(server2);
-
-        Assert.Same(client1, client2);
+        Assert.NotSame(first, second);
     }
 
     [Fact]
-    public void Create_SameId_UrlDiffersOnlyByCaseOrTrailingSlash_ReusesInstance()
+    public void Invalidate_RemovesClientFromCache()
     {
-        var (factory, _, _) = CreateFactory();
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
-        var server1 = new VpnServer { Id = 1, ApiUrl = "http://MS.Example/api/" };
-        var server2 = new VpnServer { Id = 1, ApiUrl = "http://ms.example/api" };
+        var first = factory.Create(server);
+        factory.Invalidate(server.Id);
+        var second = factory.Create(server);
 
-        var client1 = factory.Create(server1);
-        var client2 = factory.Create(server2);
-
-        Assert.Same(client1, client2);
+        Assert.NotSame(first, second);
     }
 
     [Fact]
-    public void Create_SameId_DifferentUrl_CreatesNewInstance()
+    public void Create_Throws_ForNonOpenVpnServer()
     {
-        var (factory, _, _) = CreateFactory();
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        server.ServerType = SharedModels.Enums.VpnServerType.Xray;
 
-        var server1 = new VpnServer { Id = 1, ApiUrl = "http://ms.example/a" };
-        var server2 = new VpnServer { Id = 1, ApiUrl = "http://ms.example/b" };
-
-        var client1 = factory.Create(server1);
-        var client2 = factory.Create(server2);
-
-        Assert.NotSame(client1, client2);
-    }
-
-    [Fact]
-    public async Task TryCreateByServerIdAsync_ReturnsClient_WhenServerExists()
-    {
-        var (factory, _, serverQueryMock) = CreateFactory();
-
-        var server = new VpnServer
-        {
-            Id = 42,
-            ApiUrl = "http://ms.example/openvpn"
-        };
-
-        serverQueryMock
-            .Setup(q => q.GetById(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(server);
-
-        var client = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
-
-        Assert.NotNull(client);
-
-        // Cache should return the same instance for the same server id
-        var client2 = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
-        Assert.Same(client, client2);
-
-        serverQueryMock.Verify(q => q.GetById(42, It.IsAny<CancellationToken>()), Times.Exactly(2));
-    }
-
-    [Fact]
-    public async Task TryCreateByServerIdAsync_ReturnsNull_WhenServerNotFound()
-    {
-        var (factory, _, serverQueryMock) = CreateFactory();
-
-        serverQueryMock
-            .Setup(q => q.GetById(99, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((VpnServer?)null);
-
-        var client = await factory.TryCreateByServerIdAsync(99, CancellationToken.None);
-
-        Assert.Null(client);
-    }
-
-    [Fact]
-    public async Task TryCreateByServerIdAsync_ReturnsNull_WhenServerIsXray()
-    {
-        var (factory, _, serverQueryMock) = CreateFactory();
-
-        var server = new VpnServer { Id = 7, ApiUrl = "http://xray/health", ServerType = VpnServerType.Xray };
-        serverQueryMock
-            .Setup(q => q.GetById(7, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(server);
-
-        var client = await factory.TryCreateByServerIdAsync(7, CancellationToken.None);
-
-        Assert.Null(client);
-    }
-
-    [Fact]
-    public void Create_Throws_WhenServerTypeIsXray()
-    {
-        var (factory, _, _) = CreateFactory();
-
-        var server = new VpnServer { Id = 1, ApiUrl = "http://x/", ServerType = VpnServerType.Xray };
-
-        var ex = Assert.Throws<InvalidOperationException>(() => factory.Create(server));
-
-        Assert.Contains("OpenVPN microservice client", ex.Message);
+        Assert.Throws<InvalidOperationException>(() => factory.Create(server));
     }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
@@ -41,7 +41,7 @@ public class OpenVpnMicroserviceClientFactoryTests
     [Fact]
     public void Create_RecreatesClient_WhenApiUrlChanges()
     {
-        var (sp, hubFactory) = CreateServices();
+        var (sp, _) = CreateServices();
         var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
         var firstServer = OpenVpnHubTestHelpers.OpenVpnServer();
         var changedServer = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/");
@@ -50,6 +50,24 @@ public class OpenVpnMicroserviceClientFactoryTests
         var second = factory.Create(changedServer);
 
         Assert.NotSame(first, second);
+        Assert.Equal("https://s5.datagateapp.com/", first.RegisteredApiUrl);
+        Assert.Equal("https://changed.datagateapp.com/", second.RegisteredApiUrl);
+    }
+
+    [Fact]
+    public void Create_RecreatesClient_WhenSameServerObjectApiUrlIsMutated()
+    {
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+
+        var first = factory.Create(server);
+        server.ApiUrl = "https://mutated.datagateapp.com/";
+        var second = factory.Create(server);
+
+        Assert.NotSame(first, second);
+        Assert.Equal("https://s5.datagateapp.com/", first.RegisteredApiUrl);
+        Assert.Equal("https://mutated.datagateapp.com/", second.RegisteredApiUrl);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactoryTests.cs
@@ -1,8 +1,11 @@
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
+using DataGateMonitor.SharedModels.Enums;
 using DataGateMonitor.Tests.Helpers;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,24 +15,27 @@ namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public class OpenVpnMicroserviceClientFactoryTests
 {
-    private static (IServiceProvider Sp, FakeHubConnectionFactory HubFactory) CreateServices()
+    private static (OpenVpnMicroserviceClientFactory Factory, Mock<IVpnServerQueryService> ServerQuery) CreateFactory(
+        FakeHubConnectionFactory? hubFactory = null)
     {
-        var hubFactory = new FakeHubConnectionFactory();
+        hubFactory ??= new FakeHubConnectionFactory();
+        var serverQueryMock = new Mock<IVpnServerQueryService>();
         var services = new ServiceCollection();
         services.AddLogging();
+        services.AddSingleton(serverQueryMock.Object);
         services.AddSingleton<IHubContext<OpenVpnFrontendHub>>(Mock.Of<IHubContext<OpenVpnFrontendHub>>());
         services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
         services.AddSingleton<IHubConnectionFactory>(hubFactory);
+        services.AddSingleton(Mock.Of<IOpenVpnMicroserviceNotificationService>());
         services.AddSingleton<OpenVpnMicroserviceClientFactory>();
         var sp = services.BuildServiceProvider();
-        return (sp, hubFactory);
+        return (sp.GetRequiredService<OpenVpnMicroserviceClientFactory>(), serverQueryMock);
     }
 
-  [Fact]
+    [Fact]
     public void Create_ReturnsCachedClient_ForSameServerId()
     {
-        var (sp, _) = CreateServices();
-        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
         var first = factory.Create(server);
@@ -39,10 +45,19 @@ public class OpenVpnMicroserviceClientFactoryTests
     }
 
     [Fact]
+    public void Create_ReusesInstance_WhenUrlDiffersOnlyByCaseOrTrailingSlash()
+    {
+        var (factory, _) = CreateFactory();
+        var first = factory.Create(new VpnServer { Id = 1, ApiUrl = "https://MS.Example/api/", ServerType = VpnServerType.OpenVpn });
+        var second = factory.Create(new VpnServer { Id = 1, ApiUrl = "https://ms.example/api", ServerType = VpnServerType.OpenVpn });
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
     public void Create_RecreatesClient_WhenApiUrlChanges()
     {
-        var (sp, _) = CreateServices();
-        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var (factory, _) = CreateFactory();
         var firstServer = OpenVpnHubTestHelpers.OpenVpnServer();
         var changedServer = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/");
 
@@ -57,8 +72,7 @@ public class OpenVpnMicroserviceClientFactoryTests
     [Fact]
     public void Create_RecreatesClient_WhenSameServerObjectApiUrlIsMutated()
     {
-        var (sp, _) = CreateServices();
-        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
         var first = factory.Create(server);
@@ -73,8 +87,7 @@ public class OpenVpnMicroserviceClientFactoryTests
     [Fact]
     public void Invalidate_RemovesClientFromCache()
     {
-        var (sp, _) = CreateServices();
-        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
         var first = factory.Create(server);
@@ -85,12 +98,50 @@ public class OpenVpnMicroserviceClientFactoryTests
     }
 
     [Fact]
+    public async Task TryCreateByServerIdAsync_ReturnsClient_WhenServerExists()
+    {
+        var (factory, serverQuery) = CreateFactory();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer(id: 42);
+        serverQuery.Setup(q => q.GetById(42, It.IsAny<CancellationToken>())).ReturnsAsync(server);
+
+        var client = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
+        var cached = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
+
+        Assert.NotNull(client);
+        Assert.Same(client, cached);
+        serverQuery.Verify(q => q.GetById(42, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task TryCreateByServerIdAsync_ReturnsNull_WhenServerNotFound()
+    {
+        var (factory, serverQuery) = CreateFactory();
+        serverQuery.Setup(q => q.GetById(99, It.IsAny<CancellationToken>())).ReturnsAsync((VpnServer?)null);
+
+        var client = await factory.TryCreateByServerIdAsync(99, CancellationToken.None);
+
+        Assert.Null(client);
+    }
+
+    [Fact]
+    public async Task TryCreateByServerIdAsync_ReturnsNull_WhenServerIsXray()
+    {
+        var (factory, serverQuery) = CreateFactory();
+        serverQuery
+            .Setup(q => q.GetById(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 7, ApiUrl = "https://xray/", ServerType = VpnServerType.Xray });
+
+        var client = await factory.TryCreateByServerIdAsync(7, CancellationToken.None);
+
+        Assert.Null(client);
+    }
+
+    [Fact]
     public void Create_Throws_ForNonOpenVpnServer()
     {
-        var (sp, _) = CreateServices();
-        var factory = sp.GetRequiredService<OpenVpnMicroserviceClientFactory>();
+        var (factory, _) = CreateFactory();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
-        server.ServerType = SharedModels.Enums.VpnServerType.Xray;
+        server.ServerType = VpnServerType.Xray;
 
         Assert.Throws<InvalidOperationException>(() => factory.Create(server));
     }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientTests.cs
@@ -1,362 +1,205 @@
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Moq;
-using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
-using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public class OpenVpnMicroserviceClientTests
 {
-    private static (VpnServer server,
-        Mock<ILogger<OpenVpnMicroserviceClient>> log,
-        Mock<IHubContext<OpenVpnFrontendHub>> hub,
-        Mock<IHubClients> hubClients,
-        Mock<IClientProxy> groupProxy,
-        Mock<IMicroserviceTokenService> token,
-        IServiceScopeFactory scopeFactory,
-        Mock<IHubConnectionFactory> factory,
-        Mock<IHubConnectionProxy> connection) CreateCommon(string apiUrl = "https://ms.example")
+    private static OpenVpnMicroserviceClient CreateClient(
+        VpnServer server,
+        IHubConnectionFactory hubFactory,
+        out Mock<IClientProxy> frontendClient,
+        Mock<IOpenVpnMicroserviceNotificationService>? notifications = null)
     {
-        var server = new VpnServer { Id = 11, ApiUrl = apiUrl };
-        var log = new Mock<ILogger<OpenVpnMicroserviceClient>>();
-        var hub = new Mock<IHubContext<OpenVpnFrontendHub>>();
-        var hubClients = new Mock<IHubClients>();
-        var groupProxy = new Mock<IClientProxy>();
-
-        hub.SetupGet(h => h.Clients).Returns(hubClients.Object);
-        hubClients.Setup(c => c.Group(server.Id.ToString())).Returns(groupProxy.Object);
-        groupProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
-                  .Returns(Task.CompletedTask);
-
-        var token = new Mock<IMicroserviceTokenService>();
-        token.Setup(t => t.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-             .Returns("token");
-
-        var factory = new Mock<IHubConnectionFactory>(MockBehavior.Strict);
-        var connection = new Mock<IHubConnectionProxy>(MockBehavior.Strict);
-
-        HubConnectionState state = HubConnectionState.Disconnected;
-        connection.SetupGet(c => c.State).Returns(() => state);
-        connection.Setup(c => c.StartAsync(It.IsAny<CancellationToken>()))
-                  .Callback(() => state = HubConnectionState.Connected)
-                  .Returns(Task.CompletedTask);
-        connection.Setup(c => c.StopAsync(It.IsAny<CancellationToken>()))
-                  .Callback(() => state = HubConnectionState.Disconnected)
-                  .Returns(Task.CompletedTask);
-        connection.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask);
-
-        connection.Setup(c => c.On<string>("ReceiveCommandResult", It.IsAny<Func<string, Task>>()))
-                  .Verifiable();
-        connection.Setup(c => c.On<string>("ReceiveMessage", It.IsAny<Func<string, Task>>()))
-                  .Verifiable();
-        connection.Setup(c => c.On<string, string>("ReceiveCommandResultWithRequestId", It.IsAny<Action<string, string>>()))
-                  .Verifiable();
-
-        factory.Setup(f => f.Create(It.Is<string>(u => u == $"{apiUrl}/hubs/openvpn"),
-                                    It.IsAny<Func<Task<string?>>>()))
-               .Returns(connection.Object);
-
-        var microserviceNotification = new Mock<IOpenVpnMicroserviceNotificationService>();
-        microserviceNotification.Setup(n => n.NotifySendCommandFailed(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                                .Returns(Task.CompletedTask);
-        microserviceNotification.Setup(n => n.NotifyReconnectFailed(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                                .Returns(Task.CompletedTask);
-        microserviceNotification.Setup(n => n.NotifyEventHubConnectionFailed(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                                .Returns(Task.CompletedTask);
-
-        var services = new ServiceCollection();
-        services.AddSingleton<IOpenVpnMicroserviceNotificationService>(microserviceNotification.Object);
-        var sp = services.BuildServiceProvider();
-        var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
-
-        return (server, log, hub, hubClients, groupProxy, token, scopeFactory, factory, connection);
+        var (hub, client) = OpenVpnHubTestHelpers.CreateFrontendHubMock(server.Id);
+        frontendClient = client;
+        return new OpenVpnMicroserviceClient(
+            server,
+            NullLogger<OpenVpnMicroserviceClient>.Instance,
+            hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            OpenVpnHubTestHelpers.CreateScopeFactory(notifications?.Object),
+            hubFactory);
     }
 
     [Fact]
-    public async Task SendCommandWithResponseAsync_Completes_When_Callback_Receives_Result()
+    public async Task SendCommandAsync_WhenDisconnected_StartsOnce()
     {
-        var (server, log, hub, _, _, token, scopeFactory, factory, connection) = CreateCommon();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = CreateClient(server, hubFactory, out _);
 
-        Action<string, string>? resultHandler = null;
-        connection.Setup(c => c.On<string, string>("ReceiveCommandResultWithRequestId", It.IsAny<Action<string, string>>()))
-                  .Callback<string, Action<string, string>>((_, h) => resultHandler = h)
-                  .Verifiable();
+        await sut.SendCommandAsync("status", CancellationToken.None);
 
-        string? capturedRequestId = null;
-        string? capturedCommand = null;
-
-        connection.Setup(c => c.InvokeAsync(
-                            "SendCommandWithRequestId",
-                            It.IsAny<object?>(),
-                            It.IsAny<object?>(),
-                            It.IsAny<CancellationToken>()))
-                  .Callback<string, object?, object?, CancellationToken>((_, arg1, arg2, _) =>
-                  {
-                      capturedRequestId = Assert.IsType<string>(arg1);
-                      capturedCommand = Assert.IsType<string>(arg2);
-                  })
-                  .Returns(Task.CompletedTask);
-
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
-
-        var task = sut.SendCommandWithResponseAsync("status 3", CancellationToken.None);
-
-        Assert.NotNull(capturedRequestId);
-        Assert.Equal("status 3", capturedCommand);
-
-        Assert.NotNull(resultHandler);
-        resultHandler!(capturedRequestId!, "OK");
-
-        var result = await task;
-        Assert.Equal("OK", result);
-
-        connection.Verify(c => c.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal(1, hubFactory.LastCreated!.StartCallCount);
+        Assert.Equal(HubConnectionState.Connected, hubFactory.LastCreated.State);
     }
 
     [Fact]
-    public async Task SendCommandWithResponseAsync_Cancelled_Token_Cancels_Task_And_Cleans_Pending()
+    public async Task SendCommandAsync_WhenAlreadyConnected_DoesNotStartAgain()
     {
-        var (server, log, hub, _, _, token, scopeFactory, factory, connection) = CreateCommon();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = CreateClient(server, hubFactory, out _);
 
-        connection.Setup(c => c.On<string, string>("ReceiveCommandResultWithRequestId", It.IsAny<Action<string, string>>()))
-                  .Verifiable();
+        await sut.SendCommandAsync("status", CancellationToken.None);
+        await sut.SendCommandAsync("status", CancellationToken.None);
 
-        connection.Setup(c => c.InvokeAsync(
-                            "SendCommandWithRequestId",
-                            It.IsAny<object?>(),
-                            It.IsAny<object?>(),
-                            It.IsAny<CancellationToken>()))
-                  .Returns(Task.CompletedTask);
-
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
-
-        using var cts = new CancellationTokenSource();
-        var task = sut.SendCommandWithResponseAsync("status 3", cts.Token);
-        cts.Cancel();
-
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
+        Assert.Equal(1, hubFactory.LastCreated!.StartCallCount);
     }
 
     [Fact]
-    public async Task SendCommandAsync_Reconnects_When_NotConnected_Then_Sends()
+    public async Task SendCommandAsync_WhenReconnecting_WaitsWithoutCallingStart()
     {
-        var (server, log, hub, _, _, token, scopeFactory, factory, connection) = CreateCommon();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = CreateClient(server, hubFactory, out _);
 
-        connection.Setup(c => c.InvokeAsync(
-                            "SendCommand",
-                            It.IsAny<object?>(),
-                            It.IsAny<CancellationToken>()))
-                  .Returns(Task.CompletedTask)
-                  .Verifiable();
-
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
         await sut.SendCommandAsync("ping", CancellationToken.None);
+        var proxy = hubFactory.LastCreated!;
+        Assert.Equal(1, proxy.StartCallCount);
 
-        connection.Verify(c => c.StartAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
-        connection.Verify(c => c.InvokeAsync(
-                               "SendCommand",
-                               It.IsAny<object?>(),
-                               It.IsAny<CancellationToken>()),
-                          Times.Once);
+        proxy.State = HubConnectionState.Reconnecting;
+        _ = Task.Run(() => proxy.SimulateReconnectingThenConnectedAsync(TimeSpan.FromMilliseconds(50)));
+
+        await sut.SendCommandAsync("status", CancellationToken.None);
+
+        Assert.Equal(1, proxy.StartCallCount);
+        Assert.Equal(HubConnectionState.Connected, proxy.State);
     }
 
     [Fact]
-    public async Task SendCommandAsync_OnError_Logs_And_Forwards_Error_To_Group()
+    public async Task ReconnectAsync_StopsThenStartsHub()
     {
-        var (server, log, hub, hubClients, groupProxy, token, scopeFactory, factory, connection) = CreateCommon();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy { State = HubConnectionState.Disconnected };
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out _);
 
-        connection.Setup(c => c.InvokeAsync(
-                            "SendCommand",
-                            It.IsAny<object?>(),
-                            It.IsAny<CancellationToken>()))
-                  .ThrowsAsync(new InvalidOperationException("boom"));
+        var mi = typeof(OpenVpnMicroserviceClient).GetMethod(
+            "ReconnectAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(mi);
 
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
-        await sut.SendCommandAsync("cmd", CancellationToken.None);
+        var task = (Task)mi!.Invoke(sut, [proxy])!;
+        await task;
 
-        groupProxy.Verify(p => p.SendCoreAsync(
+        Assert.Equal(1, proxy.StopCallCount);
+        Assert.Equal(1, proxy.StartCallCount);
+        Assert.Equal(HubConnectionState.Connected, proxy.State);
+    }
+
+    [Fact]
+    public async Task ReconnectAsync_OnFailure_NotifiesAndRethrows()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy
+        {
+            StartAsyncOverride = _ => throw new InvalidOperationException("reconnect failed")
+        };
+        var notifications = new Mock<IOpenVpnMicroserviceNotificationService>();
+        notifications
+            .Setup(x => x.NotifyReconnectFailed(server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out _, notifications);
+
+        var mi = typeof(OpenVpnMicroserviceClient).GetMethod(
+            "ReconnectAsync",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => (Task)mi!.Invoke(sut, [proxy])!);
+        notifications.Verify(
+            x => x.NotifyReconnectFailed(server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendCommandAsync_OnFailure_NotifiesAndBroadcastsError()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy
+        {
+            StartAsyncOverride = _ => throw new InvalidOperationException("hub down")
+        };
+        var notifications = new Mock<IOpenVpnMicroserviceNotificationService>();
+        notifications
+            .Setup(x => x.NotifySendCommandFailed(server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out var frontendClient, notifications);
+
+        await sut.SendCommandAsync("status", CancellationToken.None);
+
+        frontendClient.Verify(
+            c => c.SendCoreAsync(
                 "ReceiveCommandResult",
-                It.Is<object?[]>(arr =>
-                    arr != null &&
-                    arr.Length == 1 &&
-                    arr[0] != null &&
-                    arr[0]!.ToString()!.Contains("[Error] Failed to send command")),
+                It.Is<object?[]>(a => a.Length == 1 && a[0]!.ToString()!.Contains("hub down")),
                 It.IsAny<CancellationToken>()),
             Times.Once);
-
-
-        log.Verify(x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((state, _) =>
-                    state!.ToString()!.Contains("Failed to send command to microservice")),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        notifications.Verify(
+            x => x.NotifySendCommandFailed(server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task UrlChange_DisposesOld_And_CreatesNew_Connection()
+    public async Task SendCommandWithResponseAsync_ReturnsResultFromHandler()
     {
-        var (server, log, hub, _, _, token, scopeFactory, factory, connection1) = CreateCommon("https://a.example");
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        proxy.InvokeTwoArgHandler = (method, arg1, _, _) =>
+        {
+            if (method == "SendCommandWithRequestId" && arg1 is string requestId)
+                proxy.Raise("ReceiveCommandResultWithRequestId", requestId, "payload-42");
+            return Task.CompletedTask;
+        };
 
-        var connection2 = new Mock<IHubConnectionProxy>(MockBehavior.Strict);
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out _);
+        var result = await sut.SendCommandWithResponseAsync("version", CancellationToken.None);
 
-        HubConnectionState state2 = HubConnectionState.Disconnected;
-        connection2.SetupGet(c => c.State).Returns(() => state2);
-        connection2.Setup(c => c.StartAsync(It.IsAny<CancellationToken>()))
-                   .Callback(() => state2 = HubConnectionState.Connected)
-                   .Returns(Task.CompletedTask);
-        connection2.Setup(c => c.StopAsync(It.IsAny<CancellationToken>()))
-                   .Returns(Task.CompletedTask);
-        connection2.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask);
-        connection2.Setup(c => c.On<string>(It.IsAny<string>(), It.IsAny<Func<string, Task>>()));
-        connection2.Setup(c => c.On<string>("ReceiveMessage", It.IsAny<Func<string, Task>>()));
-        connection2.Setup(c => c.On<string, string>("ReceiveCommandResultWithRequestId", It.IsAny<Action<string, string>>()));
-        connection2.Setup(c => c.InvokeAsync(
-                               It.IsAny<string>(),
-                               It.IsAny<object?>(),
-                               It.IsAny<object?>(),
-                               It.IsAny<CancellationToken>()))
-                   .Returns(Task.CompletedTask);
-
-        factory.Reset();
-        factory.Setup(f => f.Create("https://a.example/hubs/openvpn", It.IsAny<Func<Task<string?>>>()))
-               .Returns(connection1.Object);
-        factory.Setup(f => f.Create("https://b.example/hubs/openvpn", It.IsAny<Func<Task<string?>>>()))
-               .Returns(connection2.Object);
-
-        HubConnectionState state1 = HubConnectionState.Disconnected;
-        connection1.SetupGet(c => c.State).Returns(() => state1);
-        connection1.Setup(c => c.StartAsync(It.IsAny<CancellationToken>()))
-                   .Callback(() => state1 = HubConnectionState.Connected)
-                   .Returns(Task.CompletedTask);
-        connection1.Setup(c => c.StopAsync(It.IsAny<CancellationToken>()))
-                   .Returns(Task.CompletedTask);
-        connection1.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask).Verifiable();
-        connection1.Setup(c => c.On<string>(It.IsAny<string>(), It.IsAny<Func<string, Task>>()));
-        connection1.Setup(c => c.On<string>("ReceiveMessage", It.IsAny<Func<string, Task>>()));
-        connection1.Setup(c => c.On<string, string>("ReceiveCommandResultWithRequestId", It.IsAny<Action<string, string>>()));
-        connection1.Setup(c => c.InvokeAsync(
-                               It.IsAny<string>(),
-                               It.IsAny<object?>(),
-                               It.IsAny<object?>(),
-                               It.IsAny<CancellationToken>()))
-                   .Returns(Task.CompletedTask);
-
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
-
-        await sut.SendCommandAsync("a", CancellationToken.None);
-
-        server.ApiUrl = "https://b.example";
-
-        await sut.SendCommandAsync("b", CancellationToken.None);
-
-        connection1.Verify(c => c.DisposeAsync(), Times.Once);
-        factory.Verify(f => f.Create("https://a.example/hubs/openvpn", It.IsAny<Func<Task<string?>>>()), Times.Once);
-        factory.Verify(f => f.Create("https://b.example/hubs/openvpn", It.IsAny<Func<Task<string?>>>()), Times.Once);
+        Assert.Equal("payload-42", result);
+        Assert.Equal(1, proxy.StartCallCount);
     }
 
     [Fact]
-    public async Task DisposeAsync_Cancels_Pending_And_Disposes_Connection()
+    public async Task ApiUrlChange_DisposesOldConnectionAndCreatesNew()
     {
-        var (server, log, hub, _, _, token, scopeFactory, factory, connection) = CreateCommon();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = CreateClient(server, hubFactory, out _);
 
-        Action<string, string>? resultHandler = null;
-        connection.Setup(c => c.On<string, string>("ReceiveCommandResultWithRequestId", It.IsAny<Action<string, string>>()))
-                  .Callback<string, Action<string, string>>((_, h) => resultHandler = h);
+        await sut.SendCommandAsync("status", CancellationToken.None);
+        var first = hubFactory.Created[0];
+        Assert.False(first.Disposed);
 
-        string? capturedRequestId = null;
-        string? capturedCommand = null;
+        server.ApiUrl = "https://new-host.datagateapp.com/";
+        await sut.SendCommandAsync("status", CancellationToken.None);
 
-        connection.Setup(c => c.InvokeAsync(
-                            "SendCommandWithRequestId",
-                            It.IsAny<object?>(),
-                            It.IsAny<object?>(),
-                            It.IsAny<CancellationToken>()))
-                  .Callback<string, object?, object?, CancellationToken>((_, arg1, arg2, _) =>
-                  {
-                      capturedRequestId = Assert.IsType<string>(arg1);
-                      capturedCommand = Assert.IsType<string>(arg2);
-                  })
-                  .Returns(Task.CompletedTask);
+        Assert.True(first.Disposed);
+        Assert.Equal(2, hubFactory.Created.Count);
+    }
 
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
+    [Fact]
+    public async Task DisposeAsync_CancelsPendingCommandWaiters()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy
+        {
+            InvokeTwoArgHandler = (method, _, _, _) =>
+                method == "SendCommandWithRequestId" ? Task.CompletedTask : Task.CompletedTask
+        };
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out _);
 
-        var cts = new CancellationTokenSource();
-        var task = sut.SendCommandWithResponseAsync("status 3", cts.Token);
-
+        var responseTask = sut.SendCommandWithResponseAsync("slow", CancellationToken.None);
+        await Task.Delay(50);
         await sut.DisposeAsync();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
 
-        connection.Verify(c => c.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
-        connection.Verify(c => c.DisposeAsync(), Times.Once);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => responseTask);
     }
-    
-        [Fact]
-    public async Task SendCommandToMicroserviceAsync_Reconnects_When_NotConnected_Then_Sends()
-    {
-        var (server, log, hub, _, _, token, scopeFactory, factory, connection) = CreateCommon();
-
-        connection.Setup(c => c.InvokeAsync(
-                            "SendCommand",
-                            It.IsAny<object?>(),
-                            It.IsAny<CancellationToken>()))
-                  .Returns(Task.CompletedTask)
-                  .Verifiable();
-
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
-
-        await sut.SendCommandToMicroserviceAsync("ping", CancellationToken.None);
-
-        connection.Verify(c => c.StartAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
-        connection.Verify(c => c.InvokeAsync(
-                               "SendCommand",
-                               It.IsAny<object?>(),
-                               It.IsAny<CancellationToken>()),
-                          Times.Once);
-    }
-
-    [Fact]
-    public async Task SendCommandToMicroserviceAsync_OnError_Logs_And_Forwards_Error_To_Group()
-    {
-        var (server, log, hub, _, groupProxy, token, scopeFactory, factory, connection) = CreateCommon();
-
-        connection.Setup(c => c.InvokeAsync(
-                            "SendCommand",
-                            It.IsAny<object?>(),
-                            It.IsAny<CancellationToken>()))
-                  .ThrowsAsync(new InvalidOperationException("boom"));
-
-        var sut = new OpenVpnMicroserviceClient(server, log.Object, hub.Object, token.Object, scopeFactory, factory.Object);
-
-        await sut.SendCommandToMicroserviceAsync("cmd", CancellationToken.None);
-
-        groupProxy.Verify(p => p.SendCoreAsync(
-                "ReceiveCommandResult",
-                It.Is<object?[]>(arr =>
-                    arr != null &&
-                    arr.Length == 1 &&
-                    arr[0] != null &&
-                    arr[0]!.ToString()!.Contains("[Error] Failed to send command to server")),
-                It.IsAny<CancellationToken>()),
-            Times.Once);
-
-        log.Verify(x => x.Log(
-                LogLevel.Error,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((state, _) =>
-                    state!.ToString()!.Contains("Failed to send command to microservice")),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Once);
-    }
-
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientTests.cs
@@ -186,6 +186,64 @@ public class OpenVpnMicroserviceClientTests
     }
 
     [Fact]
+    public async Task SendCommandAsync_RestartsHub_AfterClosedEvent()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out _);
+
+        await sut.SendCommandAsync("ping", CancellationToken.None);
+        Assert.Equal(1, proxy.StartCallCount);
+
+        await proxy.RaiseClosedAsync(new InvalidOperationException("auto-reconnect exhausted"));
+
+        await sut.SendCommandAsync("status", CancellationToken.None);
+        Assert.Equal(2, proxy.StartCallCount);
+    }
+
+    [Fact]
+    public async Task SendCommandToMicroserviceAsync_OnFailure_NotifiesAndBroadcastsError()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy
+        {
+            InvokeOneArgHandler = (_, _, _) => throw new InvalidOperationException("invoke failed")
+        };
+        var notifications = new Mock<IOpenVpnMicroserviceNotificationService>();
+        notifications
+            .Setup(x => x.NotifySendCommandFailed(server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out var frontendClient, notifications);
+
+        await sut.SendCommandToMicroserviceAsync("status", CancellationToken.None);
+
+        frontendClient.Verify(
+            c => c.SendCoreAsync("ReceiveCommandResult", It.IsAny<object?[]>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        notifications.Verify(
+            x => x.NotifySendCommandFailed(server.Id, server.ServerName, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendCommandWithResponseAsync_CancelledToken_CancelsTask()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy
+        {
+            InvokeTwoArgHandler = (_, _, _, _) => Task.CompletedTask
+        };
+        var sut = CreateClient(server, new SingleProxyHubConnectionFactory(proxy), out _);
+
+        using var cts = new CancellationTokenSource();
+        var task = sut.SendCommandWithResponseAsync("status", cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
+    [Fact]
     public async Task DisposeAsync_CancelsPendingCommandWaiters()
     {
         var server = OpenVpnHubTestHelpers.OpenVpnServer();

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactoryTests.cs
@@ -1,86 +1,64 @@
-using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
-using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public class OpenVpnProxyTrafficFlowClientFactoryTests
 {
-    private static OpenVpnProxyTrafficFlowClientFactory CreateFactory()
+    private static (IServiceProvider Sp, FakeHubConnectionFactory HubFactory) CreateServices()
     {
+        var hubFactory = new FakeHubConnectionFactory();
         var services = new ServiceCollection();
         services.AddLogging();
-        services.AddSingleton(Mock.Of<IHubContext<OpenVpnProxyTrafficFlowHub>>());
-
-        var tokenService = new Mock<IMicroserviceTokenService>();
-        tokenService
-            .Setup(t => t.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns("token");
-        services.AddSingleton(tokenService.Object);
-
-        var provider = services.BuildServiceProvider();
-        return new OpenVpnProxyTrafficFlowClientFactory(provider);
+        services.AddSingleton<IHubContext<OpenVpnProxyTrafficFlowHub>>(Mock.Of<IHubContext<OpenVpnProxyTrafficFlowHub>>());
+        services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
+        services.AddSingleton<IHubConnectionFactory>(hubFactory);
+        services.AddSingleton<OpenVpnProxyTrafficFlowClientFactory>();
+        return (services.BuildServiceProvider(), hubFactory);
     }
 
     [Fact]
-    public void Create_SameServerId_ReturnsCachedInstance()
+    public void Create_ReturnsCachedClient_ForSameServerId()
     {
-        var factory = CreateFactory();
-        var server = new VpnServer { Id = 1, ApiUrl = "https://node/a", ServerType = VpnServerType.OpenVpn };
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
-        var client1 = factory.Create(server);
-        var client2 = factory.Create(new VpnServer { Id = 1, ApiUrl = "https://node/b", ServerType = VpnServerType.OpenVpn });
+        var first = factory.Create(server);
+        var second = factory.Create(server);
 
-        Assert.Same(client1, client2);
+        Assert.Same(first, second);
     }
 
     [Fact]
-    public void Create_XrayServer_Throws()
+    public void Remove_StopsClientAndEvictsFromCache()
     {
-        var factory = CreateFactory();
-        var xrayServer = new VpnServer { Id = 7, ApiUrl = "https://xray", ServerType = VpnServerType.Xray };
+        var (sp, hubFactory) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => factory.Create(xrayServer));
+        var first = factory.Create(server);
+        Assert.True(factory.Remove(server.Id));
 
-        Assert.Contains("only for OpenVPN servers", ex.Message);
+        var recreated = factory.Create(server);
+        Assert.NotSame(first, recreated);
     }
 
     [Fact]
-    public void GetAllClients_ReturnsAllCachedClients()
+    public void Create_Throws_ForNonOpenVpnServer()
     {
-        var factory = CreateFactory();
-        factory.Create(new VpnServer { Id = 1, ApiUrl = "https://node-1", ServerType = VpnServerType.OpenVpn });
-        factory.Create(new VpnServer { Id = 2, ApiUrl = "https://node-2", ServerType = VpnServerType.OpenVpn });
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        server.ServerType = SharedModels.Enums.VpnServerType.Xray;
 
-        var all = factory.GetAllClients();
-
-        Assert.Equal(2, all.Count);
-    }
-
-    [Fact]
-    public void Remove_WhenNotFound_ReturnsFalse()
-    {
-        var factory = CreateFactory();
-
-        var removed = factory.Remove(999);
-
-        Assert.False(removed);
-    }
-
-    [Fact]
-    public void Remove_WhenFound_ReturnsTrue_AndRemovesFromCache()
-    {
-        var factory = CreateFactory();
-        factory.Create(new VpnServer { Id = 3, ApiUrl = "https://node-3", ServerType = VpnServerType.OpenVpn });
-
-        var removed = factory.Remove(3);
-
-        Assert.True(removed);
-        Assert.Empty(factory.GetAllClients());
+        Assert.Throws<InvalidOperationException>(() => factory.Create(server));
     }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactoryTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactoryTests.cs
@@ -3,6 +3,7 @@ using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using DataGateMonitor.SharedModels.Enums;
 using DataGateMonitor.Tests.Helpers;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,9 +39,50 @@ public class OpenVpnProxyTrafficFlowClientFactoryTests
     }
 
     [Fact]
+    public void Create_ReusesInstance_WhenUrlDiffersOnlyByCaseOrTrailingSlash()
+    {
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
+        var first = factory.Create(new VpnServer { Id = 75, ApiUrl = "https://MS.Example/", ServerType = VpnServerType.OpenVpn });
+        var second = factory.Create(new VpnServer { Id = 75, ApiUrl = "https://ms.example", ServerType = VpnServerType.OpenVpn });
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void Create_RecreatesClient_WhenApiUrlChanges()
+    {
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
+
+        var first = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer());
+        var second = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/"));
+
+        Assert.NotSame(first, second);
+        Assert.Equal("https://s5.datagateapp.com/", first.RegisteredApiUrl);
+        Assert.Equal("https://changed.datagateapp.com/", second.RegisteredApiUrl);
+    }
+
+    [Fact]
+    public void Create_RecreatesClient_WhenSameServerObjectApiUrlIsMutated()
+    {
+        var (sp, _) = CreateServices();
+        var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+
+        var first = factory.Create(server);
+        server.ApiUrl = "https://mutated.datagateapp.com/";
+        var second = factory.Create(server);
+
+        Assert.NotSame(first, second);
+        Assert.Equal("https://s5.datagateapp.com/", first.RegisteredApiUrl);
+        Assert.Equal("https://mutated.datagateapp.com/", second.RegisteredApiUrl);
+    }
+
+    [Fact]
     public void Remove_StopsClientAndEvictsFromCache()
     {
-        var (sp, hubFactory) = CreateServices();
+        var (sp, _) = CreateServices();
         var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
 
@@ -57,7 +99,7 @@ public class OpenVpnProxyTrafficFlowClientFactoryTests
         var (sp, _) = CreateServices();
         var factory = sp.GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
-        server.ServerType = SharedModels.Enums.VpnServerType.Xray;
+        server.ServerType = VpnServerType.Xray;
 
         Assert.Throws<InvalidOperationException>(() => factory.Create(server));
     }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientTests.cs
@@ -1,177 +1,111 @@
-using FluentAssertions;
-using Microsoft.AspNetCore.SignalR;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+using DataGateMonitor.Tests.Helpers;
 using Microsoft.AspNetCore.SignalR.Client;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json.Linq;
-using DataGateMonitor.Hubs;
-using DataGateMonitor.Models;
-using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
-using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
-using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 
 namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public class OpenVpnProxyTrafficFlowClientTests
 {
     [Fact]
-    public async Task StartListeningAsync_WhenDisconnected_StartsConnection_AndRelaysFlowBatch()
+    public async Task StartListeningAsync_WhenDisconnected_StartsConnection()
     {
-        var server = new VpnServer { Id = 15, ApiUrl = "https://node.example/api" };
-
-        object? relayedPayload = null;
-        var groupProxy = new Mock<IClientProxy>();
-        groupProxy
-            .Setup(p => p.SendCoreAsync(
-                "TrafficFlowUpdated",
-                It.Is<object?[]>(args => args.Length == 1 && args[0] != null),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, object?[], CancellationToken>((_, args, _) => relayedPayload = args[0])
-            .Returns(Task.CompletedTask)
-            .Verifiable();
-
-        var hubClients = new Mock<IHubClients>();
-        hubClients.Setup(c => c.Group(server.Id.ToString())).Returns(groupProxy.Object);
-
-        var hubContext = new Mock<IHubContext<OpenVpnProxyTrafficFlowHub>>();
-        hubContext.SetupGet(h => h.Clients).Returns(hubClients.Object);
-
-        var tokenService = new Mock<IMicroserviceTokenService>();
-        tokenService
-            .Setup(t => t.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns("token");
-
-        Func<JToken, Task>? capturedHandler = null;
-        var connection = new Mock<IHubConnectionProxy>();
-        connection.SetupSequence(c => c.State)
-            .Returns(HubConnectionState.Disconnected)
-            .Returns(HubConnectionState.Connected);
-        connection.Setup(c => c.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask).Verifiable();
-        connection
-            .Setup(c => c.On("TrafficFlowUpdated", It.IsAny<Func<JToken, Task>>()))
-            .Callback<string, Func<JToken, Task>>((_, handler) => capturedHandler = handler);
-
-        var hubFactory = new Mock<IHubConnectionFactory>();
-        hubFactory
-            .Setup(f => f.Create(
-                "https://node.example/api/hubs/proxy-traffic-flow",
-                It.IsAny<Func<Task<string?>>>()))
-            .Returns(connection.Object)
-            .Verifiable();
-
-        var logger = new Mock<ILogger<OpenVpnProxyTrafficFlowClient>>();
-        var client = new OpenVpnProxyTrafficFlowClient(
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = new OpenVpnProxyTrafficFlowClient(
             server,
-            logger.Object,
-            hubContext.Object,
-            tokenService.Object,
-            hubFactory.Object);
+            NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id).Hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            hubFactory);
 
-        await client.StartListeningAsync(CancellationToken.None);
+        await sut.StartListeningAsync(CancellationToken.None);
 
-        capturedHandler.Should().NotBeNull();
-        var payload = JArray.Parse("""[{ "connectionId": "c1" }]""");
-        await capturedHandler!(payload);
-
-        relayedPayload.Should().NotBeNull();
-        hubFactory.VerifyAll();
-        connection.Verify(c => c.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
-        groupProxy.VerifyAll();
+        Assert.Equal(1, hubFactory.LastCreated!.StartCallCount);
     }
 
     [Fact]
-    public async Task StartListeningAsync_WhenAlreadyConnected_DoesNotRecreateConnection()
+    public async Task StartListeningAsync_WhenReconnecting_DoesNotCallStart()
     {
-        var server = new VpnServer { Id = 22, ApiUrl = "https://node.example" };
-
-        var hubContext = new Mock<IHubContext<OpenVpnProxyTrafficFlowHub>>();
-        hubContext.SetupGet(h => h.Clients).Returns(Mock.Of<IHubClients>());
-
-        var tokenService = new Mock<IMicroserviceTokenService>();
-        tokenService
-            .Setup(t => t.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns("token");
-
-        var connection = new Mock<IHubConnectionProxy>();
-        connection.SetupGet(c => c.State).Returns(HubConnectionState.Connected);
-        connection.Setup(c => c.On("TrafficFlowUpdated", It.IsAny<Func<JToken, Task>>()));
-
-        var hubFactory = new Mock<IHubConnectionFactory>();
-        hubFactory.Setup(f => f.Create(It.IsAny<string>(), It.IsAny<Func<Task<string?>>>()))
-            .Returns(connection.Object)
-            .Verifiable();
-
-        var logger = new Mock<ILogger<OpenVpnProxyTrafficFlowClient>>();
-        var client = new OpenVpnProxyTrafficFlowClient(
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = new OpenVpnProxyTrafficFlowClient(
             server,
-            logger.Object,
-            hubContext.Object,
-            tokenService.Object,
-            hubFactory.Object);
+            NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id).Hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            hubFactory);
 
-        await client.StartListeningAsync(CancellationToken.None);
-        await client.StartListeningAsync(CancellationToken.None);
+        await sut.StartListeningAsync(CancellationToken.None);
+        var proxy = hubFactory.LastCreated!;
+        proxy.State = HubConnectionState.Reconnecting;
+        _ = Task.Run(() => proxy.SimulateReconnectingThenConnectedAsync(TimeSpan.FromMilliseconds(50)));
 
-        hubFactory.Verify(f => f.Create(It.IsAny<string>(), It.IsAny<Func<Task<string?>>>()), Times.Once);
-        connection.Verify(c => c.StartAsync(It.IsAny<CancellationToken>()), Times.Never);
+        await sut.StartListeningAsync(CancellationToken.None);
+
+        Assert.Equal(1, proxy.StartCallCount);
     }
 
     [Fact]
-    public async Task StartListeningAsync_RelaysManyPayloads_WithoutDropping()
+    public async Task StartListeningAsync_SecondCall_DoesNotStartAgain()
     {
-        const int payloadCount = 250;
-        var server = new VpnServer { Id = 31, ApiUrl = "https://node.example" };
-
-        var relayed = 0;
-        var groupProxy = new Mock<IClientProxy>();
-        groupProxy
-            .Setup(p => p.SendCoreAsync(
-                "TrafficFlowUpdated",
-                It.Is<object?[]>(args => args.Length == 1 && args[0] != null),
-                It.IsAny<CancellationToken>()))
-            .Callback(() => Interlocked.Increment(ref relayed))
-            .Returns(Task.CompletedTask);
-
-        var hubClients = new Mock<IHubClients>();
-        hubClients.Setup(c => c.Group(server.Id.ToString())).Returns(groupProxy.Object);
-
-        var hubContext = new Mock<IHubContext<OpenVpnProxyTrafficFlowHub>>();
-        hubContext.SetupGet(h => h.Clients).Returns(hubClients.Object);
-
-        var tokenService = new Mock<IMicroserviceTokenService>();
-        tokenService
-            .Setup(t => t.GenerateToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .Returns("token");
-
-        Func<JToken, Task>? capturedHandler = null;
-        var connection = new Mock<IHubConnectionProxy>();
-        connection.SetupSequence(c => c.State)
-            .Returns(HubConnectionState.Disconnected)
-            .Returns(HubConnectionState.Connected);
-        connection.Setup(c => c.StartAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-        connection
-            .Setup(c => c.On("TrafficFlowUpdated", It.IsAny<Func<JToken, Task>>()))
-            .Callback<string, Func<JToken, Task>>((_, handler) => capturedHandler = handler);
-
-        var hubFactory = new Mock<IHubConnectionFactory>();
-        hubFactory.Setup(f => f.Create(It.IsAny<string>(), It.IsAny<Func<Task<string?>>>()))
-            .Returns(connection.Object);
-
-        var logger = new Mock<ILogger<OpenVpnProxyTrafficFlowClient>>();
-        var client = new OpenVpnProxyTrafficFlowClient(
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = new OpenVpnProxyTrafficFlowClient(
             server,
-            logger.Object,
-            hubContext.Object,
-            tokenService.Object,
-            hubFactory.Object);
+            NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id).Hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            hubFactory);
 
-        await client.StartListeningAsync(CancellationToken.None);
-        capturedHandler.Should().NotBeNull();
+        await sut.StartListeningAsync(CancellationToken.None);
+        await sut.StartListeningAsync(CancellationToken.None);
 
-        var payload = JArray.Parse("""[{ "connectionId": "c1", "clientToServerBytesDelta": 1 }]""");
-        var tasks = Enumerable.Range(0, payloadCount).Select(_ => capturedHandler!(payload));
-        await Task.WhenAll(tasks);
+        Assert.Equal(1, hubFactory.LastCreated!.StartCallCount);
+    }
 
-        relayed.Should().Be(payloadCount);
+    [Fact]
+    public async Task StopAsync_DisposesConnection()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = new OpenVpnProxyTrafficFlowClient(
+            server,
+            NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id).Hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            hubFactory);
+
+        await sut.StartListeningAsync(CancellationToken.None);
+        await sut.StopAsync();
+
+        Assert.True(hubFactory.LastCreated!.Disposed);
+    }
+
+    [Fact]
+    public async Task TrafficFlowUpdated_RelaysPayloadToFrontendHub()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        var (hub, frontendClient) = OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id);
+        var sut = new OpenVpnProxyTrafficFlowClient(
+            server,
+            NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            new SingleProxyHubConnectionFactory(proxy));
+
+        await sut.StartListeningAsync(CancellationToken.None);
+        await proxy.RaiseAsync("TrafficFlowUpdated", JToken.FromObject(new { serverId = server.Id, bytesIn = 10 }));
+
+        frontendClient.Verify(
+            c => c.SendCoreAsync(
+                "TrafficFlowUpdated",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientTests.cs
@@ -68,6 +68,28 @@ public class OpenVpnProxyTrafficFlowClientTests
     }
 
     [Fact]
+    public async Task StartListeningAsync_RecreatesConnection_WhenServerApiUrlChanges()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var hubFactory = new FakeHubConnectionFactory();
+        var sut = new OpenVpnProxyTrafficFlowClient(
+            server,
+            NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id).Hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            hubFactory);
+
+        await sut.StartListeningAsync(CancellationToken.None);
+        Assert.Single(hubFactory.Created);
+
+        server.ApiUrl = "https://mutated.datagateapp.com/";
+        await sut.StartListeningAsync(CancellationToken.None);
+
+        Assert.Equal(2, hubFactory.Created.Count);
+        Assert.True(hubFactory.Created[0].Disposed);
+    }
+
+    [Fact]
     public async Task StopAsync_DisposesConnection()
     {
         var server = OpenVpnHubTestHelpers.OpenVpnServer();
@@ -83,6 +105,27 @@ public class OpenVpnProxyTrafficFlowClientTests
         await sut.StopAsync();
 
         Assert.True(hubFactory.LastCreated!.Disposed);
+    }
+
+    [Fact]
+    public async Task StartListeningAsync_RestartsHub_AfterClosedEvent()
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+        var proxy = new FakeHubConnectionProxy();
+        var sut = new OpenVpnProxyTrafficFlowClient(
+            server,
+            NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id).Hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            new SingleProxyHubConnectionFactory(proxy));
+
+        await sut.StartListeningAsync(CancellationToken.None);
+        Assert.Equal(1, proxy.StartCallCount);
+
+        await proxy.RaiseClosedAsync(new InvalidOperationException("auto-reconnect exhausted"));
+
+        await sut.StartListeningAsync(CancellationToken.None);
+        Assert.Equal(2, proxy.StartCallCount);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowSupportCheckerTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowSupportCheckerTests.cs
@@ -1,111 +1,117 @@
-using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Moq;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
 using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public class OpenVpnProxyTrafficFlowSupportCheckerTests
 {
-    [Fact]
-    public async Task ShouldListenAsync_WhenApiUrlMissing_ReturnsFalse()
-    {
-        var checker = CreateChecker(out var infoService);
-
-        var supported = await checker.ShouldListenAsync(
-            new VpnServer { Id = 1, ApiUrl = " ", ServerType = VpnServerType.OpenVpn },
-            CancellationToken.None);
-
-        supported.Should().BeFalse();
-        infoService.Verify(
-            s => s.GetInfoByUrlAsync(It.IsAny<string>(), It.IsAny<VpnServerType?>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-    }
-
-    [Fact]
-    public async Task ShouldListenAsync_WhenMicroserviceVersionTooOld_ReturnsFalse()
-    {
-        var checker = CreateChecker(out var infoService, CreateInfo("1.2.5.53"));
-
-        var supported = await checker.ShouldListenAsync(
-            new VpnServer { Id = 7, ApiUrl = "https://ovpn-old", ServerType = VpnServerType.OpenVpn },
-            CancellationToken.None);
-
-        supported.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task ShouldListenAsync_WhenMicroserviceVersionSupported_ReturnsTrue()
-    {
-        var checker = CreateChecker(out var infoService, CreateInfo("1.2.5.54"));
-
-        var supported = await checker.ShouldListenAsync(
-            new VpnServer { Id = 8, ApiUrl = "https://ovpn-new", ServerType = VpnServerType.OpenVpn },
-            CancellationToken.None);
-
-        supported.Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task ShouldListenAsync_WhenInfoUnavailable_ReturnsFalse()
-    {
-        var checker = CreateChecker(out var infoService, null);
-
-        var supported = await checker.ShouldListenAsync(
-            new VpnServer { Id = 9, ApiUrl = "https://ovpn-missing", ServerType = VpnServerType.OpenVpn },
-            CancellationToken.None);
-
-        supported.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task ShouldListenAsync_CachesResult_ForSameServerAndApiUrl()
-    {
-        var checker = CreateChecker(out var infoService, CreateInfo("1.2.5.55"));
-        var server = new VpnServer { Id = 10, ApiUrl = "https://ovpn-cache", ServerType = VpnServerType.OpenVpn };
-
-        (await checker.ShouldListenAsync(server, CancellationToken.None)).Should().BeTrue();
-        (await checker.ShouldListenAsync(server, CancellationToken.None)).Should().BeTrue();
-
-        infoService.Verify(
-            s => s.GetInfoByUrlAsync(server.ApiUrl, VpnServerType.OpenVpn, It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
     private static OpenVpnProxyTrafficFlowSupportChecker CreateChecker(
-        out Mock<IMicroserviceInfoService> infoService,
-        VpnMicroserviceDiagnosticsDto? info = null)
+        Mock<IMicroserviceInfoService> infoMock)
     {
-        infoService = new Mock<IMicroserviceInfoService>();
-        infoService
-            .Setup(s => s.GetInfoByUrlAsync(It.IsAny<string>(), It.IsAny<VpnServerType?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(info);
-
         var services = new ServiceCollection();
-        services.AddSingleton(infoService.Object);
-        var provider = services.BuildServiceProvider();
-
-        var scope = new Mock<IServiceScope>();
-        scope.SetupGet(s => s.ServiceProvider).Returns(provider);
-
-        var scopeFactory = new Mock<IServiceScopeFactory>();
-        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
-
-        return new OpenVpnProxyTrafficFlowSupportChecker(
-            scopeFactory.Object,
-            Mock.Of<ILogger<OpenVpnProxyTrafficFlowSupportChecker>>());
+        services.AddSingleton(infoMock.Object);
+        var sp = services.BuildServiceProvider();
+        var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
+        return new OpenVpnProxyTrafficFlowSupportChecker(scopeFactory, NullLogger<OpenVpnProxyTrafficFlowSupportChecker>.Instance);
     }
 
-    private static VpnMicroserviceDiagnosticsDto CreateInfo(string version) =>
+    private static VpnServer Server(string? apiUrl = "https://vpn.example.com/") =>
+        new()
+        {
+            Id = 75,
+            ApiUrl = apiUrl ?? string.Empty,
+            ServerType = VpnServerType.OpenVpn,
+        };
+
+    private static VpnMicroserviceDiagnosticsDto Diagnostics(string version) =>
         new()
         {
             ServerType = VpnServerType.OpenVpn,
             OpenVpn = new RootOpenVpnInfoResponse { Version = version }
         };
+
+    [Fact]
+    public async Task ShouldListenAsync_ReturnsFalse_WhenApiUrlMissing()
+    {
+        var info = new Mock<IMicroserviceInfoService>(MockBehavior.Strict);
+        var sut = CreateChecker(info);
+
+        var result = await sut.ShouldListenAsync(Server(apiUrl: null), CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("1.2.5.54", true)]
+    [InlineData("1.2.5.55", true)]
+    [InlineData("1.2.5.53", false)]
+    [InlineData("", false)]
+    public async Task ShouldListenAsync_ComparesMicroserviceVersion(string version, bool expected)
+    {
+        var info = new Mock<IMicroserviceInfoService>();
+        info.Setup(x => x.GetInfoByUrlAsync(It.IsAny<string>(), VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Diagnostics(version));
+
+        var sut = CreateChecker(info);
+        var result = await sut.ShouldListenAsync(Server(), CancellationToken.None);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public async Task ShouldListenAsync_UsesCache_OnSecondCall()
+    {
+        var info = new Mock<IMicroserviceInfoService>();
+        info.Setup(x => x.GetInfoByUrlAsync(It.IsAny<string>(), VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Diagnostics("1.2.5.54"));
+
+        var sut = CreateChecker(info);
+        var server = Server();
+
+        Assert.True(await sut.ShouldListenAsync(server, CancellationToken.None));
+        Assert.True(await sut.ShouldListenAsync(server, CancellationToken.None));
+
+        info.Verify(
+            x => x.GetInfoByUrlAsync(It.IsAny<string>(), VpnServerType.OpenVpn, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ShouldListenAsync_ReturnsFalse_WhenInfoLookupFails()
+    {
+        var info = new Mock<IMicroserviceInfoService>();
+        info.Setup(x => x.GetInfoByUrlAsync(It.IsAny<string>(), VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("offline"));
+
+        var sut = CreateChecker(info);
+        var result = await sut.ShouldListenAsync(Server(), CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ShouldListenAsync_Reevaluates_WhenApiUrlChanges()
+    {
+        var info = new Mock<IMicroserviceInfoService>();
+        info.Setup(x => x.GetInfoByUrlAsync(It.IsAny<string>(), VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Diagnostics("1.2.5.54"));
+
+        var sut = CreateChecker(info);
+        var server = Server("https://a.example.com/");
+
+        Assert.True(await sut.ShouldListenAsync(server, CancellationToken.None));
+        server.ApiUrl = "https://b.example.com/";
+        Assert.True(await sut.ShouldListenAsync(server, CancellationToken.None));
+
+        info.Verify(
+            x => x.GetInfoByUrlAsync(It.IsAny<string>(), VpnServerType.OpenVpn, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlInvalidationTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlInvalidationTests.cs
@@ -1,0 +1,254 @@
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
+using DataGateMonitor.Tests.Helpers;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
+
+/// <summary>
+/// Cross-cutting contract: when VpnServer.ApiUrl changes, factories must evict/dispose stale clients
+/// and clients must recreate SignalR connections. Equivalent URLs (case/trailing slash) must not trigger that.
+/// </summary>
+public class VpnServerApiUrlInvalidationTests
+{
+    [Fact]
+    public async Task MicroserviceFactory_DisposesActiveHub_WhenApiUrlChanges()
+    {
+        var hubFactory = new FakeHubConnectionFactory();
+        var factory = CreateMicroserviceFactory(hubFactory);
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+
+        var firstClient = factory.Create(server);
+        await firstClient.SendCommandAsync("ping", CancellationToken.None);
+        var firstProxy = hubFactory.Created[0];
+
+        var secondClient = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/"));
+
+        Assert.True(firstProxy.Disposed);
+        Assert.NotSame(firstClient, secondClient);
+        await secondClient.SendCommandAsync("status", CancellationToken.None);
+        Assert.Equal(2, hubFactory.Created.Count);
+    }
+
+    [Fact]
+    public async Task EventFactory_DisposesActiveHub_WhenApiUrlChanges()
+    {
+        var hubFactory = new FakeHubConnectionFactory();
+        var factory = CreateEventFactory(hubFactory);
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+
+        var firstClient = factory.Create(server);
+        await firstClient.StartListeningAsync(CancellationToken.None);
+        var firstProxy = hubFactory.Created[0];
+
+        var secondClient = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/"));
+
+        Assert.True(firstProxy.Disposed);
+        Assert.NotSame(firstClient, secondClient);
+        await secondClient.StartListeningAsync(CancellationToken.None);
+        Assert.Equal(2, hubFactory.Created.Count);
+    }
+
+    [Fact]
+    public async Task TrafficFlowFactory_DisposesActiveHub_WhenApiUrlChanges()
+    {
+        var hubFactory = new FakeHubConnectionFactory();
+        var factory = CreateTrafficFlowFactory(hubFactory);
+        var server = OpenVpnHubTestHelpers.OpenVpnServer();
+
+        var firstClient = factory.Create(server);
+        await firstClient.StartListeningAsync(CancellationToken.None);
+        var firstProxy = hubFactory.Created[0];
+
+        var secondClient = factory.Create(OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: "https://changed.datagateapp.com/"));
+
+        Assert.True(firstProxy.Disposed);
+        Assert.NotSame(firstClient, secondClient);
+        await secondClient.StartListeningAsync(CancellationToken.None);
+        Assert.Equal(2, hubFactory.Created.Count);
+    }
+
+    [Fact]
+    public async Task EventFactory_TryCreateByServerId_RecreatesClient_WhenDbUrlChanges()
+    {
+        var hubFactory = new FakeHubConnectionFactory();
+        var (factory, serverQuery) = CreateEventFactoryWithQuery(hubFactory);
+        var server = OpenVpnHubTestHelpers.OpenVpnServer(id: 5, apiUrl: "https://old.example.com/");
+        serverQuery.Setup(q => q.GetById(5, It.IsAny<CancellationToken>())).ReturnsAsync(() => server);
+
+        var first = await factory.TryCreateByServerIdAsync(5, CancellationToken.None);
+        await first!.StartListeningAsync(CancellationToken.None);
+        var firstProxy = hubFactory.Created[0];
+
+        server.ApiUrl = "https://new.example.com/";
+        var second = await factory.TryCreateByServerIdAsync(5, CancellationToken.None);
+
+        Assert.NotSame(first, second);
+        Assert.True(firstProxy.Disposed);
+        Assert.Equal("https://new.example.com/", second!.RegisteredApiUrl);
+    }
+
+    [Fact]
+    public async Task MicroserviceFactory_TryCreateByServerId_RecreatesClient_WhenDbUrlChanges()
+    {
+        var hubFactory = new FakeHubConnectionFactory();
+        var (serverQuery, factory) = CreateMicroserviceFactoryWithQuery(hubFactory);
+        var server = OpenVpnHubTestHelpers.OpenVpnServer(id: 42, apiUrl: "https://old.example.com/");
+        serverQuery.Setup(q => q.GetById(42, It.IsAny<CancellationToken>())).ReturnsAsync(() => server);
+
+        var first = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
+        await first!.SendCommandAsync("ping", CancellationToken.None);
+        var firstProxy = hubFactory.Created[0];
+
+        server.ApiUrl = "https://new.example.com/";
+        var second = await factory.TryCreateByServerIdAsync(42, CancellationToken.None);
+
+        Assert.NotSame(first, second);
+        Assert.True(firstProxy.Disposed);
+        Assert.Equal("https://new.example.com/", second!.RegisteredApiUrl);
+    }
+
+    [Theory]
+    [InlineData("https://MS.Example/", "https://ms.example")]
+    [InlineData("https://host.example.com/api/", "https://host.example.com/api")]
+    public async Task MicroserviceClient_DoesNotRecreateHub_WhenUrlDiffersOnlyByNormalization(
+        string initialUrl,
+        string mutatedUrl)
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: initialUrl);
+        var hubFactory = new FakeHubConnectionFactory();
+        var client = CreateMicroserviceClient(server, hubFactory);
+
+        await client.SendCommandAsync("ping", CancellationToken.None);
+        server.ApiUrl = mutatedUrl;
+        await client.SendCommandAsync("status", CancellationToken.None);
+
+        Assert.Single(hubFactory.Created);
+    }
+
+    [Theory]
+    [InlineData("https://MS.Example/", "https://ms.example")]
+    [InlineData("https://host.example.com/api/", "https://host.example.com/api")]
+    public async Task EventClient_DoesNotRecreateHub_WhenUrlDiffersOnlyByNormalization(
+        string initialUrl,
+        string mutatedUrl)
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: initialUrl);
+        var hubFactory = new FakeHubConnectionFactory();
+        var client = CreateEventClient(server, hubFactory);
+
+        await client.StartListeningAsync(CancellationToken.None);
+        server.ApiUrl = mutatedUrl;
+        await client.StartListeningAsync(CancellationToken.None);
+
+        Assert.Single(hubFactory.Created);
+    }
+
+    [Theory]
+    [InlineData("https://MS.Example/", "https://ms.example")]
+    [InlineData("https://host.example.com/api/", "https://host.example.com/api")]
+    public async Task TrafficFlowClient_DoesNotRecreateHub_WhenUrlDiffersOnlyByNormalization(
+        string initialUrl,
+        string mutatedUrl)
+    {
+        var server = OpenVpnHubTestHelpers.OpenVpnServer(apiUrl: initialUrl);
+        var hubFactory = new FakeHubConnectionFactory();
+        var client = CreateTrafficFlowClient(server, hubFactory);
+
+        await client.StartListeningAsync(CancellationToken.None);
+        server.ApiUrl = mutatedUrl;
+        await client.StartListeningAsync(CancellationToken.None);
+
+        Assert.Single(hubFactory.Created);
+    }
+
+    private static OpenVpnMicroserviceClientFactory CreateMicroserviceFactory(FakeHubConnectionFactory hubFactory)
+    {
+        var (_, factory) = CreateMicroserviceFactoryWithQuery(hubFactory);
+        return factory;
+    }
+
+    private static (Mock<IVpnServerQueryService> ServerQuery, OpenVpnMicroserviceClientFactory Factory)
+        CreateMicroserviceFactoryWithQuery(FakeHubConnectionFactory hubFactory)
+    {
+        var serverQuery = new Mock<IVpnServerQueryService>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(serverQuery.Object);
+        services.AddSingleton<IHubContext<OpenVpnFrontendHub>>(Mock.Of<IHubContext<OpenVpnFrontendHub>>());
+        services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
+        services.AddSingleton<IHubConnectionFactory>(hubFactory);
+        services.AddSingleton(Mock.Of<IOpenVpnMicroserviceNotificationService>());
+        services.AddSingleton<OpenVpnMicroserviceClientFactory>();
+        var sp = services.BuildServiceProvider();
+        return (serverQuery, sp.GetRequiredService<OpenVpnMicroserviceClientFactory>());
+    }
+
+    private static OpenVpnEventClientFactory CreateEventFactory(FakeHubConnectionFactory hubFactory)
+    {
+        var (factory, _) = CreateEventFactoryWithQuery(hubFactory);
+        return factory;
+    }
+
+    private static (OpenVpnEventClientFactory Factory, Mock<IVpnServerQueryService> ServerQuery)
+        CreateEventFactoryWithQuery(FakeHubConnectionFactory hubFactory)
+    {
+        var serverQuery = new Mock<IVpnServerQueryService>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(serverQuery.Object);
+        services.AddSingleton<IHubContext<OpenVpnEventHub>>(Mock.Of<IHubContext<OpenVpnEventHub>>());
+        services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
+        services.AddSingleton<IEventHubConnectionFactory>(hubFactory);
+        var sp = services.BuildServiceProvider();
+        return (new OpenVpnEventClientFactory(sp), serverQuery);
+    }
+
+    private static OpenVpnProxyTrafficFlowClientFactory CreateTrafficFlowFactory(FakeHubConnectionFactory hubFactory)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IHubContext<OpenVpnProxyTrafficFlowHub>>(Mock.Of<IHubContext<OpenVpnProxyTrafficFlowHub>>());
+        services.AddSingleton<IMicroserviceTokenService>(OpenVpnHubTestHelpers.CreateTokenService());
+        services.AddSingleton<IHubConnectionFactory>(hubFactory);
+        services.AddSingleton<OpenVpnProxyTrafficFlowClientFactory>();
+        return services.BuildServiceProvider().GetRequiredService<OpenVpnProxyTrafficFlowClientFactory>();
+    }
+
+    private static OpenVpnMicroserviceClient CreateMicroserviceClient(VpnServer server, FakeHubConnectionFactory hubFactory)
+    {
+        var (hub, _) = OpenVpnHubTestHelpers.CreateFrontendHubMock(server.Id);
+        return new OpenVpnMicroserviceClient(
+            server,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<OpenVpnMicroserviceClient>.Instance,
+            hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            OpenVpnHubTestHelpers.CreateScopeFactory(),
+            hubFactory);
+    }
+
+    private static OpenVpnEventClient CreateEventClient(VpnServer server, FakeHubConnectionFactory hubFactory) =>
+        new(
+            server,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<OpenVpnEventClient>.Instance,
+            Mock.Of<IHubContext<OpenVpnEventHub>>(),
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            Mock.Of<IServiceScopeFactory>(),
+            hubFactory);
+
+    private static OpenVpnProxyTrafficFlowClient CreateTrafficFlowClient(VpnServer server, FakeHubConnectionFactory hubFactory) =>
+        new(
+            server,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<OpenVpnProxyTrafficFlowClient>.Instance,
+            OpenVpnHubTestHelpers.CreateTrafficFlowHubMock(server.Id).Hub.Object,
+            OpenVpnHubTestHelpers.CreateTokenService(),
+            hubFactory);
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlNormalizerTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlNormalizerTests.cs
@@ -18,4 +18,19 @@ public class VpnServerApiUrlNormalizerTests
     {
         Assert.True(VpnServerApiUrlNormalizer.Equals("https://Host.example.com/", "https://host.example.com"));
     }
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    public void Normalize_ReturnsEmpty_ForBlankInput(string? input, string expected)
+    {
+        Assert.Equal(expected, VpnServerApiUrlNormalizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_FallsBack_WhenUrlIsNotAbsolute()
+    {
+        Assert.Equal("not-a-uri", VpnServerApiUrlNormalizer.Normalize("NOT-A-URI"));
+    }
 }

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlNormalizerTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlNormalizerTests.cs
@@ -1,0 +1,21 @@
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager.OpenVpnProxy;
+
+public class VpnServerApiUrlNormalizerTests
+{
+    [Theory]
+    [InlineData("https://A.example.com/", "https://a.example.com")]
+    [InlineData("https://a.example.com", "https://a.example.com")]
+    [InlineData("https://a.example.com/path/", "https://a.example.com/path")]
+    public void Normalize_IsCaseInsensitive_AndTrimsTrailingSlash(string input, string expected)
+    {
+        Assert.Equal(expected, VpnServerApiUrlNormalizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Equals_TreatsEquivalentUrlsAsEqual()
+    {
+        Assert.True(VpnServerApiUrlNormalizer.Equals("https://Host.example.com/", "https://host.example.com"));
+    }
+}

--- a/DataGateMonitor/Controllers/VpnServerEventController.cs
+++ b/DataGateMonitor/Controllers/VpnServerEventController.cs
@@ -1,8 +1,10 @@
 ﻿using Mapster;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerEventLogTable;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Dto;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Responses;
 using DataGateMonitor.SharedModels.Responses;
@@ -14,6 +16,7 @@ namespace DataGateMonitor.Controllers;
 [Authorize(Roles = "Admin,App")]
 public class VpnServerEventController(
     IVpnServerEventLogQueryService openVpnServerEventLogQueryService,
+    IIssuedOvpnFileQueryService issuedOvpnFileQueryService,
     IOpenVpnEventClientFactory eventClientFactory) : BaseController
 {
     /// <summary>
@@ -24,16 +27,44 @@ public class VpnServerEventController(
         [FromQuery] GetVpnServerEventRequest request,
         CancellationToken cancellationToken)
     {
+        var commonNames = await ResolveCommonNamesAsync(request, cancellationToken);
+
         var page = await openVpnServerEventLogQueryService.GetByVpnServerId(
             request.VpnServerId,
             request.Page,
             request.PageSize,
-            cancellationToken);
+            cancellationToken,
+            commonNames);
 
         var dto = page.Adapt<VpnServerEventResponse>();
         return Ok(ApiResponse<VpnServerEventResponse>.SuccessResponse(dto));
     }
-    
+
+    /// <summary>
+    /// Distinct client app versions (IV_GUI_VER) seen on connect events for a user or CN on a server.
+    /// </summary>
+    [HttpGet("app-versions")]
+    public async Task<ActionResult<ApiResponse<IReadOnlyList<VpnClientAppVersionSummaryItemDto>>>> GetAppVersions(
+        [FromQuery] GetVpnClientAppVersionsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var commonNames = await ResolveCommonNamesAsync(
+            request.VpnServerId,
+            request.CommonName,
+            request.ExternalId,
+            cancellationToken);
+
+        if (!string.IsNullOrWhiteSpace(request.ExternalId?.Trim()) && commonNames is not { Count: > 0 })
+            return Ok(ApiResponse<IReadOnlyList<VpnClientAppVersionSummaryItemDto>>.SuccessResponse([]));
+
+        var items = await openVpnServerEventLogQueryService.GetAppVersionSummaryAsync(
+            request.VpnServerId,
+            commonNames,
+            cancellationToken);
+
+        return Ok(ApiResponse<IReadOnlyList<VpnClientAppVersionSummaryItemDto>>.SuccessResponse(items));
+    }
+
     /// <summary>
     /// Returns status snapshots for all cached OpenVPN event clients.
     /// </summary>
@@ -48,7 +79,7 @@ public class VpnServerEventController(
     /// Returns status snapshot for a single server id (404 if not found in cache).
     /// </summary>
     [HttpGet("status/{vpnServerId:int}")]
-    public ActionResult<ApiResponse<ConnectionStatusResponse>> GetClientStatus([FromRoute] 
+    public ActionResult<ApiResponse<ConnectionStatusResponse>> GetClientStatus([FromRoute]
         GetClientStatusRequest request)
     {
         if (eventClientFactory.TryGetClientStatus(request.VpnServerId, out var status) && status is not null)
@@ -56,5 +87,39 @@ public class VpnServerEventController(
 
         return NotFound(ApiResponse<ConnectionStatusResponse>.ErrorResponse(
             $"No cached client found for serverId={request.VpnServerId}"));
+    }
+
+    private Task<IReadOnlyList<string>?> ResolveCommonNamesAsync(
+        GetVpnServerEventRequest request,
+        CancellationToken cancellationToken)
+        => ResolveCommonNamesAsync(
+            request.VpnServerId,
+            request.CommonName,
+            request.ExternalId,
+            cancellationToken);
+
+    private async Task<IReadOnlyList<string>?> ResolveCommonNamesAsync(
+        int vpnServerId,
+        string? commonName,
+        string? externalId,
+        CancellationToken cancellationToken)
+    {
+        var cn = commonName?.Trim();
+        if (!string.IsNullOrWhiteSpace(cn))
+            return [cn!];
+
+        var ext = externalId?.Trim();
+        if (string.IsNullOrWhiteSpace(ext))
+            return null;
+
+        var files = await issuedOvpnFileQueryService.GetAllByExternalId(ext, cancellationToken);
+        var names = files
+            .Where(f => f.VpnServerId == vpnServerId)
+            .Select(f => f.CommonName)
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        return names.Count == 0 ? null : names;
     }
 }

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.58</Version>
-        <AssemblyVersion>1.0.3.58</AssemblyVersion>
-        <FileVersion>1.0.3.58</FileVersion>
+        <Version>1.0.3.60</Version>
+        <AssemblyVersion>1.0.3.60</AssemblyVersion>
+        <FileVersion>1.0.3.60</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.32" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.34" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
@@ -28,11 +28,17 @@ public class OpenVpnEventClient(
     IHubContext<OpenVpnEventHub> eventHub,
     IMicroserviceTokenService tokenService,
     IServiceScopeFactory scopeFactory,
-    IEventHubConnectionFactory? eventHubConnectionFactory = null)
+    IEventHubConnectionFactory? eventHubConnectionFactory = null,
+    TimeSpan? startRetryDelay = null,
+    Func<TimeSpan, CancellationToken, Task>? retryDelayAsync = null)
 {
     private readonly VpnServer _openVpnServer = openVpnServer;
     private readonly IEventHubConnectionFactory _eventHubFactory =
         eventHubConnectionFactory ?? new DefaultEventHubConnectionFactory();
+    private readonly TimeSpan _startRetryDelay =
+        startRetryDelay ?? OpenVpnHubConnectionDefaults.StartFailureRetryDelay;
+    private readonly Func<TimeSpan, CancellationToken, Task> _retryDelayAsync =
+        retryDelayAsync ?? ((delay, ct) => Task.Delay(delay, ct));
 
     public string RegisteredApiUrl { get; } = openVpnServer.ApiUrl;
 
@@ -127,12 +133,20 @@ public class OpenVpnEventClient(
                 logger.LogWarning(
                     "Detected API URL change for server {ServerId}. Recreating SignalR event connection...",
                     _openVpnServer.Id);
+                logger.LogDebug(
+                    "Event hub URL change for server {ServerId}: RegisteredApiUrl={RegisteredApiUrl}, CurrentApiUrl={CurrentApiUrl}",
+                    _openVpnServer.Id, RegisteredApiUrl, _openVpnServer.ApiUrl);
                 await DisposeConnectionAsync();
                 _fullUrl = "";
             }
 
             if (_connection is not null && _connection.State == HubConnectionState.Connected)
+            {
+                logger.LogDebug(
+                    "Event hub already Connected for server {ServerId}, ConnId={ConnId}",
+                    _openVpnServer.Id, _connection.ConnectionId);
                 return _connection;
+            }
 
             if (_connection == null)
             {
@@ -174,6 +188,10 @@ public class OpenVpnEventClient(
                     _connection.OnReconnecting(ex =>
                     {
                         Stamp(HubConnectionState.Reconnecting, ex);
+                        logger.LogDebug(
+                            ex,
+                            "SignalR Reconnecting event (ServerId={ServerId}, State={State}, ConnId={ConnId})",
+                            _openVpnServer.Id, _connection?.State, _connection?.ConnectionId);
                         logger.LogWarning(ex,
                             "SignalR reconnecting (ServerId={ServerId}, Host={Host}, Port={Port})",
                             _openVpnServer.Id, _host, _port);
@@ -182,6 +200,9 @@ public class OpenVpnEventClient(
                     _connection.OnReconnected(connId =>
                     {
                         Stamp(HubConnectionState.Connected);
+                        logger.LogDebug(
+                            "SignalR Reconnected event (ServerId={ServerId}, ConnId={ConnId}, State={State})",
+                            _openVpnServer.Id, connId, _connection?.State);
                         logger.LogInformation(
                             "SignalR reconnected (ServerId={ServerId}, ConnId={ConnId}, Host={Host}, Port={Port})",
                             _openVpnServer.Id, connId, _host, _port);
@@ -190,6 +211,10 @@ public class OpenVpnEventClient(
                     _connection.OnClosed(ex =>
                     {
                         Stamp(HubConnectionState.Disconnected, ex);
+                        logger.LogDebug(
+                            ex,
+                            "SignalR Closed event (ServerId={ServerId}, State={State}) — manual StartAsync required after auto-reconnect gives up",
+                            _openVpnServer.Id, _connection?.State);
                         logger.LogError(ex,
                             "SignalR closed (ServerId={ServerId}, Host={Host}, Port={Port})",
                             _openVpnServer.Id, _host, _port);
@@ -213,10 +238,14 @@ public class OpenVpnEventClient(
                         logger.LogInformation(
                             "Attempting SignalR connect: ServerId={ServerId}, Attempt={Attempt}, Url={Url}, Host={Host}, Port={Port}",
                             _openVpnServer.Id, attempt, _fullUrl, _host, _port);
+                        logger.LogDebug(
+                            "Event hub StartWhenReady: ServerId={ServerId}, Attempt={Attempt}, CurrentState={State}",
+                            _openVpnServer.Id, attempt, _connection.State);
                         await HubConnectionStartup.StartWhenReadyAsync(
                             () => _connection.State,
                             ct => _connection.StartAsync(ct),
-                            cancellationToken);
+                            cancellationToken,
+                            logger: logger);
                         _notifiedEventHubConnectionFailed = false;
                         Stamp(HubConnectionState.Connected);
                         logger.LogInformation(
@@ -228,8 +257,8 @@ public class OpenVpnEventClient(
                     {
                         var innerMsg = ex.InnerException?.Message ?? ex.Message;
                         logger.LogWarning(ex,
-                            "SignalR start failed (attempt {Attempt}) for server {ServerId}, Url={Url}. Inner={Inner}. Retrying in 5s...",
-                            attempt, _openVpnServer.Id, _fullUrl, innerMsg);
+                            "SignalR start failed (attempt {Attempt}) for server {ServerId}, Url={Url}. Inner={Inner}. Retrying in {RetryDelay}s...",
+                            attempt, _openVpnServer.Id, _fullUrl, innerMsg, _startRetryDelay.TotalSeconds);
 
                         if (!_notifiedEventHubConnectionFailed)
                         {
@@ -246,7 +275,7 @@ public class OpenVpnEventClient(
                             }
                         }
 
-                        await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
+                        await _retryDelayAsync(_startRetryDelay, cancellationToken);
                     }
                 }
             }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
@@ -12,6 +12,7 @@ using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
 using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.PiHole.Requests;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.VpnEvent.Requests;
@@ -44,7 +45,7 @@ public class OpenVpnEventClient(
     private string? _lastError;
     private bool _notifiedEventHubConnectionFailed;
 
-    public async Task StartListeningAsync(CancellationToken cancellationToken)
+    public virtual async Task StartListeningAsync(CancellationToken cancellationToken)
     {
         await EnsureConnectionAsync(cancellationToken);
         // var s = GetStatus();
@@ -219,7 +220,10 @@ public class OpenVpnEventClient(
                         logger.LogInformation(
                             "Attempting SignalR connect: ServerId={ServerId}, Attempt={Attempt}, Url={Url}, Host={Host}, Port={Port}",
                             _openVpnServer.Id, attempt, _fullUrl, _host, _port);
-                        await _connection.StartAsync(cancellationToken);
+                        await HubConnectionStartup.StartWhenReadyAsync(
+                            () => _connection.State,
+                            ct => _connection.StartAsync(ct),
+                            cancellationToken);
                         _notifiedEventHubConnectionFailed = false;
                         Stamp(HubConnectionState.Connected);
                         logger.LogInformation(

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClient.cs
@@ -7,12 +7,13 @@ using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
-using DataGateMonitor.Serialization;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.OpenVpnMicroserviceClient;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.PiHole.Requests;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.VpnEvent.Requests;
@@ -26,11 +27,16 @@ public class OpenVpnEventClient(
     ILogger<OpenVpnEventClient> logger,
     IHubContext<OpenVpnEventHub> eventHub,
     IMicroserviceTokenService tokenService,
-    IServiceScopeFactory scopeFactory)
+    IServiceScopeFactory scopeFactory,
+    IEventHubConnectionFactory? eventHubConnectionFactory = null)
 {
     private readonly VpnServer _openVpnServer = openVpnServer;
+    private readonly IEventHubConnectionFactory _eventHubFactory =
+        eventHubConnectionFactory ?? new DefaultEventHubConnectionFactory();
 
-    private HubConnection? _connection;
+    public string RegisteredApiUrl { get; } = openVpnServer.ApiUrl;
+
+    private IHubConnectionProxy? _connection;
     private readonly SemaphoreSlim _connectionLock = new(1, 1);
     private bool _handlersRegistered;
 
@@ -62,10 +68,7 @@ public class OpenVpnEventClient(
         {
             if (_connection is not null)
             {
-                try { await _connection.StopAsync(CancellationToken.None); } catch { /* ignore */ }
-                try { await _connection.DisposeAsync(); } catch { /* ignore */ }
-                _connection = null;
-                _handlersRegistered = false;
+                await DisposeConnectionAsync();
                 logger.LogInformation("Stopped OpenVpnEventClient for server {ServerId}", _openVpnServer.Id);
             }
         }
@@ -113,11 +116,21 @@ public class OpenVpnEventClient(
         if (error != null) _lastClosedUtc = _lastStateChangedUtc;
     }
 
-    private async Task<HubConnection> EnsureConnectionAsync(CancellationToken cancellationToken)
+    private async Task<IHubConnectionProxy> EnsureConnectionAsync(CancellationToken cancellationToken)
     {
         await _connectionLock.WaitAsync(cancellationToken);
         try
         {
+            if (_connection is not null
+                && !VpnServerApiUrlNormalizer.Equals(_openVpnServer.ApiUrl, RegisteredApiUrl))
+            {
+                logger.LogWarning(
+                    "Detected API URL change for server {ServerId}. Recreating SignalR event connection...",
+                    _openVpnServer.Id);
+                await DisposeConnectionAsync();
+                _fullUrl = "";
+            }
+
             if (_connection is not null && _connection.State == HubConnectionState.Connected)
                 return _connection;
 
@@ -128,27 +141,13 @@ public class OpenVpnEventClient(
                     "Creating SignalR connection for server {ServerId} (Url={Url}, Host={Host}, Port={Port})",
                     _openVpnServer.Id, _fullUrl, _host, _port);
 
-                _connection = new HubConnectionBuilder()
-                    .WithUrl(_fullUrl, options =>
-                    {
-                        options.AccessTokenProvider = () =>
-                            Task.FromResult<string?>(tokenService.GenerateToken(
-                                "vpn-cert-issuer", "cert-create", "backend", "DataGateOpenVpnManager"));
-                    })
-                    .AddNewtonsoftJsonProtocol(options => options.PayloadSerializerSettings = ProjectJson.WebSettings)
-                    .WithAutomaticReconnect([
-                        TimeSpan.Zero, TimeSpan.FromSeconds(2),
-                        TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15),
-                        TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60)
-                    ])
-                    .Build();
-
-                _connection.ServerTimeout = TimeSpan.FromSeconds(30);
-                _connection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+                _connection = _eventHubFactory.Create(
+                    _fullUrl,
+                    () => Task.FromResult<string?>(tokenService.GenerateToken(
+                        "vpn-cert-issuer", "cert-create", "backend", "DataGateOpenVpnManager")));
 
                 if (!_handlersRegistered)
                 {
-                    // --- Register all handlers using the new payload type VpnEventRequest ---
                     _connection.On<VpnEventRequest>("ClientConnected",
                         async data => await HandleEvent("ClientConnected", data));
                     _connection.On<VpnEventRequest>("ClientDisconnected",
@@ -157,8 +156,6 @@ public class OpenVpnEventClient(
                         async data => await HandleEvent("ClientAttempted", data));
                     _connection.On<VpnEventRequest>("TlsVerified",
                         async data => await HandleEvent("TlsVerified", data));
-
-                    // New unified/typed error channels
                     _connection.On<VpnEventRequest>("ErrorEvent",
                         async data => await HandleEvent("ErrorEvent", data));
                     _connection.On<VpnEventRequest>("AuthFailed",
@@ -169,44 +166,40 @@ public class OpenVpnEventClient(
                         async data => await HandleEvent("VerifyError", data));
                     _connection.On<VpnEventRequest>("VpnError",
                         async data => await HandleEvent("VpnError", data));
-
                     _connection.On<DnsQueryBatchRequest>("DnsQueriesReceived",
                         async data => await HandleDnsQueriesAsync(data));
-
-                    // Optional: env dumps if you broadcast them
                     _connection.On<object>("EnvDumpReceived",
                         async _ => await Task.CompletedTask);
 
-                    _connection.Reconnecting += ex =>
+                    _connection.OnReconnecting(ex =>
                     {
                         Stamp(HubConnectionState.Reconnecting, ex);
                         logger.LogWarning(ex,
                             "SignalR reconnecting (ServerId={ServerId}, Host={Host}, Port={Port})",
                             _openVpnServer.Id, _host, _port);
                         return Task.CompletedTask;
-                    };
-                    _connection.Reconnected += connId =>
+                    });
+                    _connection.OnReconnected(connId =>
                     {
                         Stamp(HubConnectionState.Connected);
                         logger.LogInformation(
                             "SignalR reconnected (ServerId={ServerId}, ConnId={ConnId}, Host={Host}, Port={Port})",
                             _openVpnServer.Id, connId, _host, _port);
                         return Task.CompletedTask;
-                    };
-                    _connection.Closed += ex =>
+                    });
+                    _connection.OnClosed(ex =>
                     {
                         Stamp(HubConnectionState.Disconnected, ex);
                         logger.LogError(ex,
                             "SignalR closed (ServerId={ServerId}, Host={Host}, Port={Port})",
                             _openVpnServer.Id, _host, _port);
                         return Task.CompletedTask;
-                    };
+                    });
 
                     _handlersRegistered = true;
                 }
             }
 
-            // First connect retry loop
             if (_connection.State != HubConnectionState.Connected)
             {
                 var attempt = 0;
@@ -264,6 +257,17 @@ public class OpenVpnEventClient(
         {
             _connectionLock.Release();
         }
+    }
+
+    private async Task DisposeConnectionAsync()
+    {
+        if (_connection is null)
+            return;
+
+        try { await _connection.StopAsync(CancellationToken.None); } catch { /* ignore */ }
+        try { await _connection.DisposeAsync(); } catch { /* ignore */ }
+        _connection = null;
+        _handlersRegistered = false;
     }
 
     private async Task HandleEvent(string eventType, VpnEventRequest data)

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactory.cs
@@ -4,6 +4,8 @@ using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerEvent.Responses;
 using DataGateMonitor.SharedModels.Enums;
 
@@ -21,15 +23,21 @@ public class OpenVpnEventClientFactory(IServiceProvider rootProvider) : IOpenVpn
                 $"OpenVPN event client is only for OpenVPN servers (server {server.Id} is {server.ServerType}).");
         }
 
-        return _clientCache.GetOrAdd(server.Id, _ =>
-        {
-            var logger       = rootProvider.GetRequiredService<ILogger<OpenVpnEventClient>>();
-            var eventHub     = rootProvider.GetRequiredService<IHubContext<OpenVpnEventHub>>();
-            var tokenService = rootProvider.GetRequiredService<IMicroserviceTokenService>();
-            var scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
+        var normalizedUrl = VpnServerApiUrlNormalizer.Normalize(server.ApiUrl);
 
-            return new OpenVpnEventClient(server, logger, eventHub, tokenService, scopeFactory);
-        });
+        return _clientCache.AddOrUpdate(
+            server.Id,
+            _ => CreateNew(server),
+            (_, existing) =>
+            {
+                if (!VpnServerApiUrlNormalizer.Equals(existing.RegisteredApiUrl, normalizedUrl))
+                {
+                    StopClient(existing, server.Id);
+                    return CreateNew(server);
+                }
+
+                return existing;
+            });
     }
 
     public async Task<OpenVpnEventClient?> TryCreateByServerIdAsync(int serverId, CancellationToken cancellationToken)
@@ -53,21 +61,14 @@ public class OpenVpnEventClientFactory(IServiceProvider rootProvider) : IOpenVpn
     {
         if (!_clientCache.TryRemove(serverId, out var client))
             return false;
-        try
-        {
-            client.StopAsync().GetAwaiter().GetResult();
-        }
-        catch (Exception ex)
-        {
-            // Log but do not rethrow; client is already removed from cache
-            var logger = rootProvider.GetRequiredService<ILogger<OpenVpnEventClientFactory>>();
-            logger.LogWarning(ex, "Error stopping event client for server {ServerId}", serverId);
-        }
+
+        StopClient(client, serverId);
         return true;
     }
-    
+
     public IReadOnlyCollection<OpenVpnEventClient> GetAllClients()
         => _clientCache.Values.ToArray();
+
     public ConnectionStatusesResponse GetAllClientStatuses()
     {
         var items = _clientCache.Values
@@ -87,5 +88,28 @@ public class OpenVpnEventClientFactory(IServiceProvider rootProvider) : IOpenVpn
 
         status = null;
         return false;
+    }
+
+    private OpenVpnEventClient CreateNew(VpnServer server)
+    {
+        var logger = rootProvider.GetRequiredService<ILogger<OpenVpnEventClient>>();
+        var eventHub = rootProvider.GetRequiredService<IHubContext<OpenVpnEventHub>>();
+        var tokenService = rootProvider.GetRequiredService<IMicroserviceTokenService>();
+        var scopeFactory = rootProvider.GetRequiredService<IServiceScopeFactory>();
+        var eventHubConnectionFactory = rootProvider.GetService<IEventHubConnectionFactory>();
+        return new OpenVpnEventClient(server, logger, eventHub, tokenService, scopeFactory, eventHubConnectionFactory);
+    }
+
+    private void StopClient(OpenVpnEventClient client, int serverId)
+    {
+        try
+        {
+            client.StopAsync().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            var logger = rootProvider.GetRequiredService<ILogger<OpenVpnEventClientFactory>>();
+            logger.LogWarning(ex, "Error stopping event client for server {ServerId}", serverId);
+        }
     }
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/Events/OpenVpnEventClientFactory.cs
@@ -15,6 +15,9 @@ public class OpenVpnEventClientFactory(IServiceProvider rootProvider) : IOpenVpn
 {
     private readonly ConcurrentDictionary<int, OpenVpnEventClient> _clientCache = new();
 
+    private ILogger<OpenVpnEventClientFactory> Logger =>
+        rootProvider.GetRequiredService<ILogger<OpenVpnEventClientFactory>>();
+
     public OpenVpnEventClient Create(VpnServer server)
     {
         if (server.ServerType != VpnServerType.OpenVpn)
@@ -27,24 +30,31 @@ public class OpenVpnEventClientFactory(IServiceProvider rootProvider) : IOpenVpn
 
         return _clientCache.AddOrUpdate(
             server.Id,
-            _ => CreateNew(server),
+            _ =>
+            {
+                Logger.LogDebug("Creating new event client for server {ServerId}, ApiUrl={ApiUrl}", server.Id, server.ApiUrl);
+                return CreateNew(server);
+            },
             (_, existing) =>
             {
                 if (!VpnServerApiUrlNormalizer.Equals(existing.RegisteredApiUrl, normalizedUrl))
                 {
+                    Logger.LogDebug(
+                        "Recreating event client for server {ServerId}: RegisteredApiUrl={RegisteredApiUrl} -> ApiUrl={ApiUrl}",
+                        server.Id, existing.RegisteredApiUrl, server.ApiUrl);
                     StopClient(existing, server.Id);
                     return CreateNew(server);
                 }
 
+                Logger.LogDebug(
+                    "Reusing cached event client for server {ServerId}, RegisteredApiUrl={RegisteredApiUrl}",
+                    server.Id, existing.RegisteredApiUrl);
                 return existing;
             });
     }
 
     public async Task<OpenVpnEventClient?> TryCreateByServerIdAsync(int serverId, CancellationToken cancellationToken)
     {
-        if (_clientCache.TryGetValue(serverId, out var cached))
-            return cached;
-
         using var scope = rootProvider.CreateScope();
         var serverQuery = scope.ServiceProvider.GetRequiredService<IVpnServerQueryService>();
         var server = await serverQuery.GetById(serverId, cancellationToken);
@@ -54,6 +64,7 @@ public class OpenVpnEventClientFactory(IServiceProvider rootProvider) : IOpenVpn
         if (server.ServerType != VpnServerType.OpenVpn)
             return null;
 
+        // Always route through Create so URL changes from DB invalidate the cached client.
         return Create(server);
     }
 

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/DefaultEventHubConnectionFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/DefaultEventHubConnectionFactory.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using DataGateMonitor.Serialization;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+
+namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+
+internal sealed class DefaultEventHubConnectionFactory : IEventHubConnectionFactory
+{
+    public IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider)
+    {
+        var connection = new HubConnectionBuilder()
+            .WithUrl(fullUrl, options => { options.AccessTokenProvider = accessTokenProvider; })
+            .AddNewtonsoftJsonProtocol(options => options.PayloadSerializerSettings = ProjectJson.WebSettings)
+            .WithAutomaticReconnect([
+                TimeSpan.Zero, TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15),
+                TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60)
+            ])
+            .Build();
+
+        connection.ServerTimeout = TimeSpan.FromSeconds(30);
+        connection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+        return new HubConnectionProxy(connection);
+    }
+}

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/DefaultEventHubConnectionFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/DefaultEventHubConnectionFactory.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.SignalR.Client;
-using DataGateMonitor.Serialization;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 
 namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
@@ -8,19 +6,7 @@ internal sealed class DefaultEventHubConnectionFactory : IEventHubConnectionFact
 {
     public IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider)
     {
-        var connection = new HubConnectionBuilder()
-            .WithUrl(fullUrl, options => { options.AccessTokenProvider = accessTokenProvider; })
-            .AddNewtonsoftJsonProtocol(options => options.PayloadSerializerSettings = ProjectJson.WebSettings)
-            .WithAutomaticReconnect([
-                TimeSpan.Zero, TimeSpan.FromSeconds(2),
-                TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(15),
-                TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60)
-            ])
-            .Build();
-
-        connection.ServerTimeout = TimeSpan.FromSeconds(30);
-        connection.KeepAliveInterval = TimeSpan.FromSeconds(15);
-
+        var connection = OpenVpnHubConnectionBuilder.Build(fullUrl, accessTokenProvider);
         return new HubConnectionProxy(connection);
     }
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/DefaultHubConnectionFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/DefaultHubConnectionFactory.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.SignalR.Client;
-using DataGateMonitor.Serialization;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 
 namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
@@ -8,15 +6,7 @@ internal sealed class DefaultHubConnectionFactory : IHubConnectionFactory
 {
     public IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider)
     {
-        var connection = new HubConnectionBuilder()
-            .WithUrl(fullUrl, options => { options.AccessTokenProvider = accessTokenProvider; })
-            .AddNewtonsoftJsonProtocol(options => options.PayloadSerializerSettings = ProjectJson.WebSettings)
-            .WithAutomaticReconnect()
-            .ConfigureLogging(logging =>
-            {
-                logging.SetMinimumLevel(LogLevel.Warning);
-            })
-            .Build();
+        var connection = OpenVpnHubConnectionBuilder.Build(fullUrl, accessTokenProvider, suppressSignalRInfoLogs: true);
         return new HubConnectionProxy(connection);
     }
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionProxy.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionProxy.cs
@@ -6,6 +6,7 @@ namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
 internal sealed class HubConnectionProxy(HubConnection inner) : IHubConnectionProxy
 {
     public HubConnectionState State => inner.State;
+    public string? ConnectionId => inner.ConnectionId;
 
     public Task StartAsync(CancellationToken cancellationToken = default)
         => inner.StartAsync(cancellationToken);
@@ -39,4 +40,13 @@ internal sealed class HubConnectionProxy(HubConnection inner) : IHubConnectionPr
             return Task.CompletedTask;
         });
     }
+
+    public void OnReconnecting(Func<Exception?, Task> handler)
+        => inner.Reconnecting += ex => handler(ex);
+
+    public void OnReconnected(Func<string?, Task> handler)
+        => inner.Reconnected += connId => handler(connId);
+
+    public void OnClosed(Func<Exception?, Task> handler)
+        => inner.Closed += ex => handler(ex);
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionStartup.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionStartup.cs
@@ -16,14 +16,21 @@ internal static class HubConnectionStartup
         Func<HubConnectionState> getState,
         Func<CancellationToken, Task> startAsync,
         CancellationToken cancellationToken,
-        TimeSpan? transitionTimeout = null)
-        => StartWhenReadyAsync(getState, startAsync, cancellationToken, transitionTimeout ?? DefaultTransitionTimeout);
+        TimeSpan? transitionTimeout = null,
+        ILogger? logger = null)
+        => StartWhenReadyAsync(
+            getState,
+            startAsync,
+            cancellationToken,
+            transitionTimeout ?? DefaultTransitionTimeout,
+            logger);
 
     private static async Task StartWhenReadyAsync(
         Func<HubConnectionState> getState,
         Func<CancellationToken, Task> startAsync,
         CancellationToken cancellationToken,
-        TimeSpan transitionTimeout)
+        TimeSpan transitionTimeout,
+        ILogger? logger)
     {
         var deadline = DateTime.UtcNow + transitionTimeout;
 
@@ -33,10 +40,18 @@ internal static class HubConnectionStartup
             var state = getState();
 
             if (state == HubConnectionState.Connected)
+            {
+                logger?.LogDebug("HubConnectionStartup: already Connected, skipping StartAsync");
                 return;
+            }
 
             if (state is HubConnectionState.Connecting or HubConnectionState.Reconnecting)
             {
+                logger?.LogDebug(
+                    "HubConnectionStartup: waiting for {State} to finish (deadline in {RemainingMs} ms)",
+                    state,
+                    (deadline - DateTime.UtcNow).TotalMilliseconds);
+
                 if (DateTime.UtcNow >= deadline)
                 {
                     throw new TimeoutException(
@@ -49,9 +64,13 @@ internal static class HubConnectionStartup
 
             if (state == HubConnectionState.Disconnected)
             {
+                logger?.LogDebug("HubConnectionStartup: Disconnected, calling StartAsync");
                 await startAsync(cancellationToken);
+                logger?.LogDebug("HubConnectionStartup: StartAsync completed, state={State}", getState());
                 return;
             }
+
+            logger?.LogDebug("HubConnectionStartup: unexpected state {State}, polling until deadline", state);
 
             if (DateTime.UtcNow >= deadline)
             {

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionStartup.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/HubConnectionStartup.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+
+internal static class HubConnectionStartup
+{
+    private static readonly TimeSpan DefaultPollInterval = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan DefaultTransitionTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// Starts the hub only when <see cref="HubConnectionState.Disconnected"/>.
+    /// Waits while automatic reconnect is in progress (<see cref="HubConnectionState.Connecting"/> /
+    /// <see cref="HubConnectionState.Reconnecting"/>) instead of calling <c>StartAsync</c> and failing.
+    /// </summary>
+    public static Task StartWhenReadyAsync(
+        Func<HubConnectionState> getState,
+        Func<CancellationToken, Task> startAsync,
+        CancellationToken cancellationToken,
+        TimeSpan? transitionTimeout = null)
+        => StartWhenReadyAsync(getState, startAsync, cancellationToken, transitionTimeout ?? DefaultTransitionTimeout);
+
+    private static async Task StartWhenReadyAsync(
+        Func<HubConnectionState> getState,
+        Func<CancellationToken, Task> startAsync,
+        CancellationToken cancellationToken,
+        TimeSpan transitionTimeout)
+    {
+        var deadline = DateTime.UtcNow + transitionTimeout;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var state = getState();
+
+            if (state == HubConnectionState.Connected)
+                return;
+
+            if (state is HubConnectionState.Connecting or HubConnectionState.Reconnecting)
+            {
+                if (DateTime.UtcNow >= deadline)
+                {
+                    throw new TimeoutException(
+                        $"Hub connection remained in {state} for longer than {transitionTimeout}.");
+                }
+
+                await Task.Delay(DefaultPollInterval, cancellationToken);
+                continue;
+            }
+
+            if (state == HubConnectionState.Disconnected)
+            {
+                await startAsync(cancellationToken);
+                return;
+            }
+
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException(
+                    $"Hub connection remained in {state} for longer than {transitionTimeout}.");
+            }
+
+            await Task.Delay(DefaultPollInterval, cancellationToken);
+        }
+    }
+}

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/Interfaces/IEventHubConnectionFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/Interfaces/IEventHubConnectionFactory.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
+
+public interface IEventHubConnectionFactory
+{
+    IHubConnectionProxy Create(string fullUrl, Func<Task<string?>> accessTokenProvider);
+}

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/Interfaces/IHubConnectionProxy.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/Interfaces/IHubConnectionProxy.cs
@@ -5,6 +5,7 @@ namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Inte
 public interface IHubConnectionProxy : IAsyncDisposable
 {
     HubConnectionState State { get; }
+    string? ConnectionId { get; }
     Task StartAsync(CancellationToken cancellationToken = default);
     Task StopAsync(CancellationToken cancellationToken = default);
 
@@ -21,4 +22,7 @@ public interface IHubConnectionProxy : IAsyncDisposable
 
     void On<T>(string methodName, Func<T, Task> handler);
     void On<T1, T2>(string methodName, Action<T1, T2> handler);
+    void OnReconnecting(Func<Exception?, Task> handler);
+    void OnReconnected(Func<string?, Task> handler);
+    void OnClosed(Func<Exception?, Task> handler);
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/OpenVpnHubConnectionBuilder.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/OpenVpnHubConnectionBuilder.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using DataGateMonitor.Serialization;
+
+namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+
+internal static class OpenVpnHubConnectionBuilder
+{
+    internal static HubConnection Build(string fullUrl, Func<Task<string?>> accessTokenProvider, bool suppressSignalRInfoLogs = false)
+    {
+        var builder = new HubConnectionBuilder()
+            .WithUrl(fullUrl, options => { options.AccessTokenProvider = accessTokenProvider; })
+            .AddNewtonsoftJsonProtocol(options => options.PayloadSerializerSettings = ProjectJson.WebSettings)
+            .WithAutomaticReconnect(OpenVpnHubConnectionDefaults.AutomaticReconnectDelays);
+
+        if (suppressSignalRInfoLogs)
+        {
+            builder.ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));
+        }
+
+        var connection = builder.Build();
+        connection.ServerTimeout = OpenVpnHubConnectionDefaults.ServerTimeout;
+        connection.KeepAliveInterval = OpenVpnHubConnectionDefaults.KeepAliveInterval;
+        return connection;
+    }
+}

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/OpenVpnHubConnectionDefaults.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/Hubs/OpenVpnHubConnectionDefaults.cs
@@ -1,0 +1,22 @@
+namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs;
+
+internal static class OpenVpnHubConnectionDefaults
+{
+    /// <summary>
+    /// Shared automatic-reconnect schedule for all OpenVPN SignalR clients.
+    /// Microsoft default is 4 attempts (0, 2, 10, 30 s); we use 6 for longer resilience.
+    /// </summary>
+    public static readonly TimeSpan[] AutomaticReconnectDelays =
+    [
+        TimeSpan.Zero,
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(5),
+        TimeSpan.FromSeconds(15),
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromSeconds(60),
+    ];
+
+    public static readonly TimeSpan ServerTimeout = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan KeepAliveInterval = TimeSpan.FromSeconds(15);
+    public static readonly TimeSpan StartFailureRetryDelay = TimeSpan.FromSeconds(5);
+}

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/IOpenVpnMicroserviceClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/IOpenVpnMicroserviceClient.cs
@@ -2,6 +2,9 @@ namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public interface IOpenVpnMicroserviceClient : IDisposable, IAsyncDisposable
 {
+    /// <summary>ApiUrl snapshot captured when the client instance was created (used for cache invalidation).</summary>
+    string RegisteredApiUrl { get; }
+    /// <summary>Current ApiUrl from the bound <see cref="Models.VpnServer"/> (may change if the entity is mutated).</summary>
     string CurrentApiUrl { get; }
     Task<string> SendCommandWithResponseAsync(string command, CancellationToken cancellationToken);
     Task SendCommandAsync(string command, CancellationToken cancellationToken);

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/IOpenVpnProxyTrafficFlowClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/IOpenVpnProxyTrafficFlowClient.cs
@@ -2,6 +2,7 @@ namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 
 public interface IOpenVpnProxyTrafficFlowClient
 {
+    string RegisteredApiUrl { get; }
     Task StartListeningAsync(CancellationToken cancellationToken);
     Task StopAsync();
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClient.cs
@@ -195,7 +195,10 @@ public class OpenVpnMicroserviceClient(
 
             if (_connection.State != HubConnectionState.Connected)
             {
-                await _connection.StartAsync(cancellationToken);
+                await HubConnectionStartup.StartWhenReadyAsync(
+                    () => _connection.State,
+                    ct => _connection.StartAsync(ct),
+                    cancellationToken);
                 logger.LogInformation("Started SignalR connection for server {ServerId}", server.Id);
             }
 
@@ -212,7 +215,10 @@ public class OpenVpnMicroserviceClient(
         try
         {
             await connection.StopAsync();
-            await connection.StartAsync();
+            await HubConnectionStartup.StartWhenReadyAsync(
+                () => connection.State,
+                ct => connection.StartAsync(ct),
+                CancellationToken.None);
             logger.LogInformation("Reconnected to SignalR for server {ServerId}", server.Id);
         }
         catch (Exception ex)

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClient.cs
@@ -23,7 +23,6 @@ public class OpenVpnMicroserviceClient(
     private IHubConnectionProxy? _connection;
     private readonly SemaphoreSlim _connectionLock = new(1, 1);
     private bool _handlersRegistered = false;
-    private string? _lastApiUrl;
     private bool _disposed;
     public string RegisteredApiUrl { get; } = server.ApiUrl;
     public string CurrentApiUrl => server.ApiUrl;
@@ -151,9 +150,13 @@ public class OpenVpnMicroserviceClient(
         await _connectionLock.WaitAsync(cancellationToken);
         try
         {
-            if (_connection is not null && !VpnServerApiUrlNormalizer.Equals(server.ApiUrl, _lastApiUrl))
+            if (_connection is not null
+                && !VpnServerApiUrlNormalizer.Equals(server.ApiUrl, RegisteredApiUrl))
             {
                 logger.LogWarning("Detected API URL change for server {ServerId}. Recreating SignalR connection...", server.Id);
+                logger.LogDebug(
+                    "Microservice hub URL change for server {ServerId}: RegisteredApiUrl={RegisteredApiUrl}, CurrentApiUrl={CurrentApiUrl}",
+                    server.Id, RegisteredApiUrl, server.ApiUrl);
                 await _connection.DisposeAsync();
                 _connection = null;
                 _handlersRegistered = false;
@@ -165,7 +168,6 @@ public class OpenVpnMicroserviceClient(
                 logger.LogInformation(
                     "Creating SignalR connection for server {ServerId}, Url={Url}",
                     server.Id, fullUrl);
-                _lastApiUrl = server.ApiUrl;
 
                 _connection = _hubFactory.Create(fullUrl, () =>
                     Task.FromResult<string?>(tokenService.GenerateToken("vpn-cert-issuer", "cert-create", "backend", "DataGateOpenVpnManager")));
@@ -196,10 +198,14 @@ public class OpenVpnMicroserviceClient(
 
             if (_connection.State != HubConnectionState.Connected)
             {
+                logger.LogDebug(
+                    "Microservice hub StartWhenReady: ServerId={ServerId}, CurrentState={State}, TargetUrl={Url}",
+                    server.Id, _connection.State, $"{server.ApiUrl.TrimEnd('/')}/hubs/openvpn");
                 await HubConnectionStartup.StartWhenReadyAsync(
                     () => _connection.State,
                     ct => _connection.StartAsync(ct),
-                    cancellationToken);
+                    cancellationToken,
+                    logger: logger);
                 logger.LogInformation("Started SignalR connection for server {ServerId}", server.Id);
             }
 
@@ -216,10 +222,12 @@ public class OpenVpnMicroserviceClient(
         try
         {
             await connection.StopAsync();
+            logger.LogDebug("Microservice hub ReconnectAsync StopAsync completed for server {ServerId}, State={State}", server.Id, connection.State);
             await HubConnectionStartup.StartWhenReadyAsync(
                 () => connection.State,
                 ct => connection.StartAsync(ct),
-                CancellationToken.None);
+                CancellationToken.None,
+                logger: logger);
             logger.LogInformation("Reconnected to SignalR for server {ServerId}", server.Id);
         }
         catch (Exception ex)

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClient.cs
@@ -25,6 +25,7 @@ public class OpenVpnMicroserviceClient(
     private bool _handlersRegistered = false;
     private string? _lastApiUrl;
     private bool _disposed;
+    public string RegisteredApiUrl { get; } = server.ApiUrl;
     public string CurrentApiUrl => server.ApiUrl;
     private readonly IHubConnectionFactory _hubFactory = hubConnectionFactory ?? new DefaultHubConnectionFactory();
 
@@ -150,7 +151,7 @@ public class OpenVpnMicroserviceClient(
         await _connectionLock.WaitAsync(cancellationToken);
         try
         {
-            if (_connection is not null && server.ApiUrl != _lastApiUrl)
+            if (_connection is not null && !VpnServerApiUrlNormalizer.Equals(server.ApiUrl, _lastApiUrl))
             {
                 logger.LogWarning("Detected API URL change for server {ServerId}. Recreating SignalR connection...", server.Id);
                 await _connection.DisposeAsync();

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
@@ -5,6 +5,7 @@ using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 using DataGateMonitor.SharedModels.Enums;
 
 namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
@@ -67,7 +68,8 @@ public class OpenVpnMicroserviceClientFactory(IServiceProvider serviceProvider) 
         var frontendHub = scope.ServiceProvider.GetRequiredService<IHubContext<OpenVpnFrontendHub>>();
         var tokenService = scope.ServiceProvider.GetRequiredService<IMicroserviceTokenService>();
         var scopeFactory = scope.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
-        return new OpenVpnMicroserviceClient(server, logger, frontendHub, tokenService, scopeFactory);
+        var hubConnectionFactory = scope.ServiceProvider.GetService<IHubConnectionFactory>();
+        return new OpenVpnMicroserviceClient(server, logger, frontendHub, tokenService, scopeFactory, hubConnectionFactory);
     }
 
     private static void DisposeClient(IOpenVpnMicroserviceClient client)

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
@@ -14,6 +14,9 @@ public class OpenVpnMicroserviceClientFactory(IServiceProvider serviceProvider) 
 {
     private readonly ConcurrentDictionary<int, IOpenVpnMicroserviceClient> _clientCache = new();
 
+    private ILogger<OpenVpnMicroserviceClientFactory> Logger =>
+        serviceProvider.GetRequiredService<ILogger<OpenVpnMicroserviceClientFactory>>();
+
     public IOpenVpnMicroserviceClient Create(VpnServer server)
     {
         if (server.ServerType != VpnServerType.OpenVpn)
@@ -26,14 +29,25 @@ public class OpenVpnMicroserviceClientFactory(IServiceProvider serviceProvider) 
 
         return _clientCache.AddOrUpdate(
             server.Id,
-            _ => CreateNew(server),
+            _ =>
+            {
+                Logger.LogDebug("Creating new microservice client for server {ServerId}, ApiUrl={ApiUrl}", server.Id, server.ApiUrl);
+                return CreateNew(server);
+            },
             (_, existing) =>
             {
                 if (!VpnServerApiUrlNormalizer.Equals(existing.RegisteredApiUrl, normalizedUrl))
                 {
+                    Logger.LogDebug(
+                        "Recreating microservice client for server {ServerId}: RegisteredApiUrl={RegisteredApiUrl} -> ApiUrl={ApiUrl}",
+                        server.Id, existing.RegisteredApiUrl, server.ApiUrl);
                     DisposeClient(existing);
                     return CreateNew(server);
                 }
+
+                Logger.LogDebug(
+                    "Reusing cached microservice client for server {ServerId}, RegisteredApiUrl={RegisteredApiUrl}",
+                    server.Id, existing.RegisteredApiUrl);
                 return existing;
             });
     }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnMicroserviceClientFactory.cs
@@ -22,15 +22,14 @@ public class OpenVpnMicroserviceClientFactory(IServiceProvider serviceProvider) 
                 $"OpenVPN microservice client is only for OpenVPN servers (server {server.Id} is {server.ServerType}).");
         }
 
-        var normalizedUrl = NormalizeUrl(server.ApiUrl);
+        var normalizedUrl = VpnServerApiUrlNormalizer.Normalize(server.ApiUrl);
 
         return _clientCache.AddOrUpdate(
             server.Id,
             _ => CreateNew(server),
             (_, existing) =>
             {
-                // compare normalized
-                if (!UrlsEqual(existing.CurrentApiUrl, normalizedUrl))
+                if (!VpnServerApiUrlNormalizer.Equals(existing.RegisteredApiUrl, normalizedUrl))
                 {
                     DisposeClient(existing);
                     return CreateNew(server);
@@ -78,21 +77,4 @@ public class OpenVpnMicroserviceClientFactory(IServiceProvider serviceProvider) 
         (client as IAsyncDisposable)?.DisposeAsync().AsTask().GetAwaiter().GetResult();
         (client as IDisposable)?.Dispose();
     }
-
-    private static string NormalizeUrl(string? url)
-    {
-        if (string.IsNullOrWhiteSpace(url)) return string.Empty;
-        try
-        {
-            var uri = new Uri(url, UriKind.Absolute);
-            var left = uri.GetLeftPart(UriPartial.Authority) + uri.AbsolutePath;
-            return left.TrimEnd('/').ToLowerInvariant();
-        }
-        catch
-        {
-            return url.Trim().TrimEnd('/').ToLowerInvariant();
-        }
-    }
-
-    private static bool UrlsEqual(string? a, string? b) => NormalizeUrl(a) == NormalizeUrl(b);
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClient.cs
@@ -81,7 +81,10 @@ public sealed class OpenVpnProxyTrafficFlowClient(
 
             if (_connection.State != HubConnectionState.Connected)
             {
-                await _connection.StartAsync(cancellationToken);
+                await HubConnectionStartup.StartWhenReadyAsync(
+                    () => _connection.State,
+                    ct => _connection.StartAsync(ct),
+                    cancellationToken);
                 logger.LogInformation("Started proxy traffic flow listener for server {ServerId}", server.Id);
             }
 

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClient.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClient.cs
@@ -22,6 +22,8 @@ public sealed class OpenVpnProxyTrafficFlowClient(
     private bool _handlersRegistered;
     private readonly IHubConnectionFactory _hubFactory = hubConnectionFactory ?? new DefaultHubConnectionFactory();
 
+    public string RegisteredApiUrl { get; } = server.ApiUrl;
+
     public async Task StartListeningAsync(CancellationToken cancellationToken)
     {
         await EnsureConnectionAsync(cancellationToken);
@@ -51,8 +53,28 @@ public sealed class OpenVpnProxyTrafficFlowClient(
         await _connectionLock.WaitAsync(cancellationToken);
         try
         {
+            if (_connection is not null
+                && !VpnServerApiUrlNormalizer.Equals(server.ApiUrl, RegisteredApiUrl))
+            {
+                logger.LogWarning(
+                    "Detected API URL change for server {ServerId}. Recreating proxy traffic flow connection...",
+                    server.Id);
+                logger.LogDebug(
+                    "Traffic flow hub URL change for server {ServerId}: RegisteredApiUrl={RegisteredApiUrl}, CurrentApiUrl={CurrentApiUrl}",
+                    server.Id, RegisteredApiUrl, server.ApiUrl);
+                try { await _connection.StopAsync(CancellationToken.None); } catch { /* ignore */ }
+                try { await _connection.DisposeAsync(); } catch { /* ignore */ }
+                _connection = null;
+                _handlersRegistered = false;
+            }
+
             if (_connection is not null && _connection.State == HubConnectionState.Connected)
+            {
+                logger.LogDebug(
+                    "Traffic flow hub already Connected for server {ServerId}, ConnId={ConnId}",
+                    server.Id, _connection.ConnectionId);
                 return _connection;
+            }
 
             if (_connection is null)
             {
@@ -81,10 +103,14 @@ public sealed class OpenVpnProxyTrafficFlowClient(
 
             if (_connection.State != HubConnectionState.Connected)
             {
+                logger.LogDebug(
+                    "Traffic flow hub StartWhenReady: ServerId={ServerId}, CurrentState={State}",
+                    server.Id, _connection.State);
                 await HubConnectionStartup.StartWhenReadyAsync(
                     () => _connection.State,
                     ct => _connection.StartAsync(ct),
-                    cancellationToken);
+                    cancellationToken,
+                    logger: logger);
                 logger.LogInformation("Started proxy traffic flow listener for server {ServerId}", server.Id);
             }
 

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactory.cs
@@ -12,6 +12,9 @@ public sealed class OpenVpnProxyTrafficFlowClientFactory(IServiceProvider rootPr
 {
     private readonly ConcurrentDictionary<int, IOpenVpnProxyTrafficFlowClient> _clientCache = new();
 
+    private ILogger<OpenVpnProxyTrafficFlowClientFactory> Logger =>
+        rootProvider.GetRequiredService<ILogger<OpenVpnProxyTrafficFlowClientFactory>>();
+
     public IOpenVpnProxyTrafficFlowClient Create(VpnServer server)
     {
         if (server.ServerType != VpnServerType.OpenVpn)
@@ -20,20 +23,55 @@ public sealed class OpenVpnProxyTrafficFlowClientFactory(IServiceProvider rootPr
                 $"Proxy traffic flow client is only for OpenVPN servers (server {server.Id} is {server.ServerType}).");
         }
 
-        return _clientCache.GetOrAdd(server.Id, _ =>
-        {
-            var logger = rootProvider.GetRequiredService<ILogger<OpenVpnProxyTrafficFlowClient>>();
-            var trafficHub = rootProvider.GetRequiredService<IHubContext<OpenVpnProxyTrafficFlowHub>>();
-            var tokenService = rootProvider.GetRequiredService<IMicroserviceTokenService>();
-            var hubConnectionFactory = rootProvider.GetService<IHubConnectionFactory>();
-            return new OpenVpnProxyTrafficFlowClient(server, logger, trafficHub, tokenService, hubConnectionFactory);
-        });
+        var normalizedUrl = VpnServerApiUrlNormalizer.Normalize(server.ApiUrl);
+
+        return _clientCache.AddOrUpdate(
+            server.Id,
+            _ =>
+            {
+                Logger.LogDebug("Creating new traffic flow client for server {ServerId}, ApiUrl={ApiUrl}", server.Id, server.ApiUrl);
+                return CreateNew(server);
+            },
+            (_, existing) =>
+            {
+                if (!VpnServerApiUrlNormalizer.Equals(existing.RegisteredApiUrl, normalizedUrl))
+                {
+                    Logger.LogDebug(
+                        "Recreating traffic flow client for server {ServerId}: RegisteredApiUrl={RegisteredApiUrl} -> ApiUrl={ApiUrl}",
+                        server.Id, existing.RegisteredApiUrl, server.ApiUrl);
+                    StopClient(existing, server.Id);
+                    return CreateNew(server);
+                }
+
+                Logger.LogDebug(
+                    "Reusing cached traffic flow client for server {ServerId}, RegisteredApiUrl={RegisteredApiUrl}",
+                    server.Id, existing.RegisteredApiUrl);
+                return existing;
+            });
     }
 
     public bool Remove(int serverId)
     {
         if (!_clientCache.TryRemove(serverId, out var client))
             return false;
+
+        StopClient(client, serverId);
+        return true;
+    }
+
+    public IReadOnlyCollection<IOpenVpnProxyTrafficFlowClient> GetAllClients() => _clientCache.Values.ToArray();
+
+    private IOpenVpnProxyTrafficFlowClient CreateNew(VpnServer server)
+    {
+        var logger = rootProvider.GetRequiredService<ILogger<OpenVpnProxyTrafficFlowClient>>();
+        var trafficHub = rootProvider.GetRequiredService<IHubContext<OpenVpnProxyTrafficFlowHub>>();
+        var tokenService = rootProvider.GetRequiredService<IMicroserviceTokenService>();
+        var hubConnectionFactory = rootProvider.GetService<IHubConnectionFactory>();
+        return new OpenVpnProxyTrafficFlowClient(server, logger, trafficHub, tokenService, hubConnectionFactory);
+    }
+
+    private void StopClient(IOpenVpnProxyTrafficFlowClient client, int serverId)
+    {
         try
         {
             client.StopAsync().GetAwaiter().GetResult();
@@ -43,9 +81,5 @@ public sealed class OpenVpnProxyTrafficFlowClientFactory(IServiceProvider rootPr
             var logger = rootProvider.GetRequiredService<ILogger<OpenVpnProxyTrafficFlowClientFactory>>();
             logger.LogWarning(ex, "Error stopping proxy traffic flow client for server {ServerId}", serverId);
         }
-
-        return true;
     }
-
-    public IReadOnlyCollection<IOpenVpnProxyTrafficFlowClient> GetAllClients() => _clientCache.Values.ToArray();
 }

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactory.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/OpenVpnProxyTrafficFlowClientFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.SignalR;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy.Hubs.Interfaces;
 using DataGateMonitor.SharedModels.Enums;
 
 namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
@@ -24,7 +25,8 @@ public sealed class OpenVpnProxyTrafficFlowClientFactory(IServiceProvider rootPr
             var logger = rootProvider.GetRequiredService<ILogger<OpenVpnProxyTrafficFlowClient>>();
             var trafficHub = rootProvider.GetRequiredService<IHubContext<OpenVpnProxyTrafficFlowHub>>();
             var tokenService = rootProvider.GetRequiredService<IMicroserviceTokenService>();
-            return new OpenVpnProxyTrafficFlowClient(server, logger, trafficHub, tokenService);
+            var hubConnectionFactory = rootProvider.GetService<IHubConnectionFactory>();
+            return new OpenVpnProxyTrafficFlowClient(server, logger, trafficHub, tokenService, hubConnectionFactory);
         });
     }
 

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlNormalizer.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OpenVpnProxy/VpnServerApiUrlNormalizer.cs
@@ -1,0 +1,21 @@
+namespace DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+
+internal static class VpnServerApiUrlNormalizer
+{
+    public static string Normalize(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return string.Empty;
+        try
+        {
+            var uri = new Uri(url, UriKind.Absolute);
+            var left = uri.GetLeftPart(UriPartial.Authority) + uri.AbsolutePath;
+            return left.TrimEnd('/').ToLowerInvariant();
+        }
+        catch
+        {
+            return url.Trim().TrimEnd('/').ToLowerInvariant();
+        }
+    }
+
+    public static bool Equals(string? a, string? b) => Normalize(a) == Normalize(b);
+}

--- a/Schems/swagger.json
+++ b/Schems/swagger.json
@@ -8635,6 +8635,20 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "CommonName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8654,6 +8668,62 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Api.VpnServerEvent.Responses.VpnServerEventResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/open-vpn-events/app-versions": {
+      "get": {
+        "tags": [
+          "VpnServerEvent"
+        ],
+        "parameters": [
+          {
+            "name": "VpnServerId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "CommonName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.Collections.Generic.IReadOnlyList_VpnServerEvent.Dto.VpnClientAppVersionSummaryItemDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.Collections.Generic.IReadOnlyList_VpnServerEvent.Dto.VpnClientAppVersionSummaryItemDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.Collections.Generic.IReadOnlyList_VpnServerEvent.Dto.VpnClientAppVersionSummaryItemDto"
                 }
               }
             }
@@ -11983,6 +12053,26 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/VpnDnsQuery.Dto.VpnDnsProfileSummaryItemDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.System.Collections.Generic.IReadOnlyList_VpnServerEvent.Dto.VpnClientAppVersionSummaryItemDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpnServerEvent.Dto.VpnClientAppVersionSummaryItemDto"
             },
             "nullable": true
           }
@@ -17231,6 +17321,24 @@
           "lastError": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "VpnServerEvent.Dto.VpnClientAppVersionSummaryItemDto": {
+        "type": "object",
+        "properties": {
+          "ivGuiVer": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastConnectedAtUtc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "connectionCount": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Summary
- Add OpenVPN user events filter and client app version summary API (SharedModels 1.0.33–1.0.34).
- Fix SignalR hub startup race (`HubConnectionStartup`) that caused `StartAsync` failures on servers in `Reconnecting` state.
- Harden all three OpenVPN SignalR clients: shared `WithAutomaticReconnect` policy (6 delays), factory URL invalidation via `RegisteredApiUrl`, Debug lifecycle logs, and 114 unit tests.

## Test plan
- [x] `dotnet test` — OpenVPN/SignalR filter (114 tests)
- [ ] Deploy to staging; confirm no `HubConnection cannot be started` on Norway servers 75/77
- [ ] Verify user statistics: events filter, app versions (IvVer fallback), DNS CN filter
- [ ] Enable Debug logging for `DataGateOpenVpnManager` if troubleshooting connection state