### PR TITLE
VPN node PublicIp, free-tier channel compliance, and overview performance

### DIFF
--- a/DataGateMonitor.DataBase/ConfigurationModels/Seeds/LocalizationTextSeedData.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/Seeds/LocalizationTextSeedData.cs
@@ -651,6 +651,25 @@ public static class LocalizationTextSeedData
             Id = 99, Key = "AccountLinkFailed", Language = Language.Russian,
             Text = "Не удалось связать аккаунты. Проверьте код и попробуйте снова."
         },
+
+        new LocalizationText
+        {
+            Id = 100, Key = "VpnServerNotAllowedByQuotaPlan", Language = Language.English,
+            Text =
+                "This VPN server is not available on your current plan. Please choose another server or upgrade your plan."
+        },
+        new LocalizationText
+        {
+            Id = 101, Key = "VpnServerNotAllowedByQuotaPlan", Language = Language.Greek,
+            Text =
+                "Αυτός ο διακομιστής VPN δεν είναι διαθέσιμος στο τρέχον πρόγραμμά σας. Επιλέξτε άλλον διακομιστή ή αναβαθμίστε το πρόγραμμα."
+        },
+        new LocalizationText
+        {
+            Id = 102, Key = "VpnServerNotAllowedByQuotaPlan", Language = Language.Russian,
+            Text =
+                "Этот VPN-сервер недоступен на вашем текущем тарифе. Выберите другой сервер или обновите план."
+        },
     };
 
 }

--- a/DataGateMonitor.DataBase/ConfigurationModels/TvLoginSessionConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/TvLoginSessionConfiguration.cs
@@ -40,5 +40,12 @@ public class TvLoginSessionConfiguration : BaseEntityConfiguration<TvLoginSessio
         entity.HasIndex(e => e.ApprovedUserId);
         entity.HasIndex(e => new { e.UserCode, e.Status });
         entity.HasIndex(e => new { e.ApprovedUserId, e.Status });
+
+        // At most one open (Pending/Viewed) session may share a user code.
+        entity.HasIndex(e => e.UserCode)
+            .IsUnique()
+            .HasDatabaseName("IX_TvLoginSessions_UserCode_Open")
+            .HasFilter(
+                $"\"Status\" IN ({(int)TvLoginSessionStatus.Pending}, {(int)TvLoginSessionStatus.Viewed})");
     }
 }

--- a/DataGateMonitor.DataBase/ConfigurationModels/TvLoginSessionConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/TvLoginSessionConfiguration.cs
@@ -37,6 +37,8 @@ public class TvLoginSessionConfiguration : BaseEntityConfiguration<TvLoginSessio
         entity.HasIndex(e => e.UserCode);
         entity.HasIndex(e => e.Status);
         entity.HasIndex(e => e.ExpiresAt);
+        entity.HasIndex(e => e.ApprovedUserId);
         entity.HasIndex(e => new { e.UserCode, e.Status });
+        entity.HasIndex(e => new { e.ApprovedUserId, e.Status });
     }
 }

--- a/DataGateMonitor.DataBase/ConfigurationModels/TvLoginSessionConfiguration.cs
+++ b/DataGateMonitor.DataBase/ConfigurationModels/TvLoginSessionConfiguration.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.ConfigurationModels;
+
+public class TvLoginSessionConfiguration : BaseEntityConfiguration<TvLoginSession, Guid>
+{
+    public override void Configure(EntityTypeBuilder<TvLoginSession> entity)
+    {
+        base.Configure(entity);
+
+        entity.ToTable("TvLoginSessions");
+
+        entity.Property(e => e.UserCode)
+            .IsRequired()
+            .HasMaxLength(16);
+
+        entity.Property(e => e.Status)
+            .IsRequired();
+
+        entity.Property(e => e.DeviceName)
+            .HasMaxLength(128);
+
+        entity.Property(e => e.Client)
+            .HasMaxLength(64);
+
+        entity.Property(e => e.ExpiresAt)
+            .IsRequired();
+
+        entity.Property(e => e.DeviceId)
+            .HasMaxLength(128);
+
+        entity.Property(e => e.UserAgent)
+            .HasMaxLength(512);
+
+        entity.HasIndex(e => e.UserCode);
+        entity.HasIndex(e => e.Status);
+        entity.HasIndex(e => e.ExpiresAt);
+        entity.HasIndex(e => new { e.UserCode, e.Status });
+    }
+}

--- a/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
+++ b/DataGateMonitor.DataBase/Contexts/ApplicationDbContext.cs
@@ -63,6 +63,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<MobileCrashReport> MobileCrashReports { get; set; } = null!;
     public DbSet<WindowsCrashReport> WindowsCrashReports { get; set; } = null!;
     public DbSet<FreeTierDisconnectLog> FreeTierDisconnectLogs { get; set; } = null!;
+    public DbSet<TvLoginSession> TvLoginSessions { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -112,6 +113,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.ApplyConfiguration(new UserRefreshTokenConfiguration());
         modelBuilder.ApplyConfiguration(new UserPasswordHistoryConfiguration());
         modelBuilder.ApplyConfiguration(new FreeTierDisconnectLogConfiguration());
+        modelBuilder.ApplyConfiguration(new TvLoginSessionConfiguration());
     }
     
     private void UpdateTimestamps()

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.44" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
+++ b/DataGateMonitor.DataBase/DataGateMonitor.DataBase.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.50" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.9" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />

--- a/DataGateMonitor.DataBase/Migrations/20260721194410_TvLoginSession_Init.Designer.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260721194410_TvLoginSession_Init.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataGateMonitor.DataBase.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataGateMonitor.DataBase.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721194410_TvLoginSession_Init")]
+    partial class TvLoginSession_Init
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataGateMonitor.DataBase/Migrations/20260721194410_TvLoginSession_Init.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260721194410_TvLoginSession_Init.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class TvLoginSession_Init : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TvLoginSessions",
+                schema: "xgb_dashopnvpn",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserCode = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    DeviceName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    Client = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ApprovedUserId = table.Column<int>(type: "integer", nullable: true),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeviceId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    CreateDate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                    LastUpdate = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TvLoginSessions", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TvLoginSessions_ExpiresAt",
+                schema: "xgb_dashopnvpn",
+                table: "TvLoginSessions",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TvLoginSessions_Status",
+                schema: "xgb_dashopnvpn",
+                table: "TvLoginSessions",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TvLoginSessions_UserCode",
+                schema: "xgb_dashopnvpn",
+                table: "TvLoginSessions",
+                column: "UserCode");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TvLoginSessions_UserCode_Status",
+                schema: "xgb_dashopnvpn",
+                table: "TvLoginSessions",
+                columns: new[] { "UserCode", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TvLoginSessions",
+                schema: "xgb_dashopnvpn");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260721203000_TvLoginSession_ApprovedUserIndexes.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260721203000_TvLoginSession_ApprovedUserIndexes.cs
@@ -1,0 +1,42 @@
+using DataGateMonitor.DataBase.Contexts;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations;
+
+[DbContext(typeof(ApplicationDbContext))]
+[Migration("20260721203000_TvLoginSession_ApprovedUserIndexes")]
+public partial class TvLoginSession_ApprovedUserIndexes : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateIndex(
+            name: "IX_TvLoginSessions_ApprovedUserId",
+            schema: "xgb_dashopnvpn",
+            table: "TvLoginSessions",
+            column: "ApprovedUserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_TvLoginSessions_ApprovedUserId_Status",
+            schema: "xgb_dashopnvpn",
+            table: "TvLoginSessions",
+            columns: new[] { "ApprovedUserId", "Status" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_TvLoginSessions_ApprovedUserId_Status",
+            schema: "xgb_dashopnvpn",
+            table: "TvLoginSessions");
+
+        migrationBuilder.DropIndex(
+            name: "IX_TvLoginSessions_ApprovedUserId",
+            schema: "xgb_dashopnvpn",
+            table: "TvLoginSessions");
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260721210000_TvLoginSession_OpenUserCodeUnique.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260721210000_TvLoginSession_OpenUserCodeUnique.cs
@@ -1,0 +1,33 @@
+using DataGateMonitor.DataBase.Contexts;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations;
+
+[DbContext(typeof(ApplicationDbContext))]
+[Migration("20260721210000_TvLoginSession_OpenUserCodeUnique")]
+public partial class TvLoginSession_OpenUserCodeUnique : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateIndex(
+            name: "IX_TvLoginSessions_UserCode_Open",
+            schema: "xgb_dashopnvpn",
+            table: "TvLoginSessions",
+            column: "UserCode",
+            unique: true,
+            filter: "\"Status\" IN (0, 5)");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_TvLoginSessions_UserCode_Open",
+            schema: "xgb_dashopnvpn",
+            table: "TvLoginSessions");
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260721220000_Localization_VpnServerNotAllowedByQuotaPlan.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260721220000_Localization_VpnServerNotAllowedByQuotaPlan.cs
@@ -1,0 +1,67 @@
+using DataGateMonitor.DataBase.Contexts;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20260721220000_Localization_VpnServerNotAllowedByQuotaPlan")]
+    public partial class Localization_VpnServerNotAllowedByQuotaPlan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                columns: new[] { "Id", "Key", "Language", "Text" },
+                values: new object[,]
+                {
+                    {
+                        100,
+                        "VpnServerNotAllowedByQuotaPlan",
+                        1,
+                        "This VPN server is not available on your current plan. Please choose another server or upgrade your plan."
+                    },
+                    {
+                        101,
+                        "VpnServerNotAllowedByQuotaPlan",
+                        2,
+                        "Αυτός ο διακομιστής VPN δεν είναι διαθέσιμος στο τρέχον πρόγραμμά σας. Επιλέξτε άλλον διακομιστή ή αναβαθμίστε το πρόγραμμα."
+                    },
+                    {
+                        102,
+                        "VpnServerNotAllowedByQuotaPlan",
+                        3,
+                        "Этот VPN-сервер недоступен на вашем текущем тарифе. Выберите другой сервер или обновите план."
+                    }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 100);
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 101);
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 102);
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260721220000_Localization_VpnServerNotAllowedByQuotaPlan.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260721220000_Localization_VpnServerNotAllowedByQuotaPlan.cs
@@ -8,6 +8,10 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace DataGateMonitor.DataBase.Migrations
 {
+    /// <summary>
+    /// Designer-less data migration: columnTypes are required so EF can generate SQL
+    /// without a BuildTargetModel that maps LocalizationTexts.
+    /// </summary>
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20260721220000_Localization_VpnServerNotAllowedByQuotaPlan")]
     public partial class Localization_VpnServerNotAllowedByQuotaPlan : Migration
@@ -39,7 +43,8 @@ namespace DataGateMonitor.DataBase.Migrations
                         3,
                         "Этот VPN-сервер недоступен на вашем текущем тарифе. Выберите другой сервер или обновите план."
                     }
-                });
+                },
+                columnTypes: new[] { "integer", "character varying(255)", "integer", "text" });
         }
 
         /// <inheritdoc />
@@ -49,19 +54,22 @@ namespace DataGateMonitor.DataBase.Migrations
                 schema: "xgb_dashopnvpn",
                 table: "LocalizationTexts",
                 keyColumn: "Id",
-                keyValue: 100);
+                keyValue: 100,
+                keyColumnType: "integer");
 
             migrationBuilder.DeleteData(
                 schema: "xgb_dashopnvpn",
                 table: "LocalizationTexts",
                 keyColumn: "Id",
-                keyValue: 101);
+                keyValue: 101,
+                keyColumnType: "integer");
 
             migrationBuilder.DeleteData(
                 schema: "xgb_dashopnvpn",
                 table: "LocalizationTexts",
                 keyColumn: "Id",
-                keyValue: 102);
+                keyValue: 102,
+                keyColumnType: "integer");
         }
     }
 }

--- a/DataGateMonitor.DataBase/Migrations/20260809190000_FreeTierChannelSubscriptionNotificationSettings.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260809190000_FreeTierChannelSubscriptionNotificationSettings.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Designer-less data migration: columnTypes required so EF can generate SQL
+    /// without a BuildTargetModel that maps Settings.
+    /// </remarks>
+    public partial class FreeTierChannelSubscriptionNotificationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                columns: new[] { "Id", "BoolValue", "DateTimeValue", "DoubleValue", "IntValue", "Key", "StringValue", "ValueType" },
+                values: new object[,]
+                {
+                    { 202, true, null, null, null, "FreeTier_Send_Unsubscribed_User_Reminders", null, "bool" },
+                    { 203, null, null, null, null, "FreeTier_Send_Unsubscribed_User_Reminders_Type", "bool", "string" },
+                    { 204, true, null, null, null, "FreeTier_Daily_Unsubscribed_Admin_Digest", null, "bool" },
+                    { 205, null, null, null, null, "FreeTier_Daily_Unsubscribed_Admin_Digest_Type", "bool", "string" }
+                },
+                columnTypes: new[]
+                {
+                    "integer",
+                    "boolean",
+                    "timestamp with time zone",
+                    "double precision",
+                    "integer",
+                    "character varying(255)",
+                    "character varying(255)",
+                    "character varying(50)"
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 202,
+                keyColumnType: "integer");
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 203,
+                keyColumnType: "integer");
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 204,
+                keyColumnType: "integer");
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "Settings",
+                keyColumn: "Id",
+                keyValue: 205,
+                keyColumnType: "integer");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260809193000_Localization_FreeTierChannelSubscribeReminder.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260809193000_Localization_FreeTierChannelSubscribeReminder.cs
@@ -1,0 +1,74 @@
+using DataGateMonitor.DataBase.Contexts;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <summary>
+    /// Localized Free/Default channel-subscribe reminder (en / el / ru) with {channel} and {channelUrl}.
+    /// </summary>
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20260809193000_Localization_FreeTierChannelSubscribeReminder")]
+    public partial class Localization_FreeTierChannelSubscribeReminder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                columns: new[] { "Id", "Key", "Language", "Text" },
+                values: new object[,]
+                {
+                    {
+                        103,
+                        "FreeTierChannelSubscribeReminder",
+                        1,
+                        "📢 Please subscribe to our Telegram channel to keep using Free/Default VPN access.\n\nChannel: {channel}\n{channelUrl}"
+                    },
+                    {
+                        104,
+                        "FreeTierChannelSubscribeReminder",
+                        2,
+                        "📢 Παρακαλούμε εγγραφείτε στο κανάλι μας στο Telegram για να συνεχίσετε να χρησιμοποιείτε το Free/Default VPN.\n\nΚανάλι: {channel}\n{channelUrl}"
+                    },
+                    {
+                        105,
+                        "FreeTierChannelSubscribeReminder",
+                        3,
+                        "📢 Пожалуйста, подпишитесь на наш Telegram-канал, чтобы продолжать пользоваться VPN на тарифе Free/Default.\n\nКанал: {channel}\n{channelUrl}"
+                    }
+                },
+                columnTypes: new[] { "integer", "character varying(255)", "integer", "text" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 103,
+                keyColumnType: "integer");
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 104,
+                keyColumnType: "integer");
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 105,
+                keyColumnType: "integer");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260809194500_Localization_FreeTierAccessDenied.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260809194500_Localization_FreeTierAccessDenied.cs
@@ -1,0 +1,74 @@
+using DataGateMonitor.DataBase.Contexts;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <summary>
+    /// Localized Free/Default VPN access-denied message (en / el / ru) with {channel} and {channelUrl}.
+    /// </summary>
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20260809194500_Localization_FreeTierAccessDenied")]
+    public partial class Localization_FreeTierAccessDenied : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                columns: new[] { "Id", "Key", "Language", "Text" },
+                values: new object[,]
+                {
+                    {
+                        106,
+                        "FreeTierAccessDenied",
+                        1,
+                        "Free/Default access requires subscription to {channel}.\n{channelUrl}\nPlease subscribe to the channel and try again."
+                    },
+                    {
+                        107,
+                        "FreeTierAccessDenied",
+                        2,
+                        "Η πρόσβαση Free/Default απαιτεί συνδρομή στο κανάλι {channel}.\n{channelUrl}\nΠαρακαλούμε εγγραφείτε στο κανάλι και δοκιμάστε ξανά."
+                    },
+                    {
+                        108,
+                        "FreeTierAccessDenied",
+                        3,
+                        "Для тарифа Free/Default нужна подписка на канал {channel}.\n{channelUrl}\nПодпишитесь на канал и повторите запрос."
+                    }
+                },
+                columnTypes: new[] { "integer", "character varying(255)", "integer", "text" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 106,
+                keyColumnType: "integer");
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 107,
+                keyColumnType: "integer");
+
+            migrationBuilder.DeleteData(
+                schema: "xgb_dashopnvpn",
+                table: "LocalizationTexts",
+                keyColumn: "Id",
+                keyValue: 108,
+                keyColumnType: "integer");
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/20260809200000_SeedFreeTierChannelSubscribeReminderEmailTemplate.cs
+++ b/DataGateMonitor.DataBase/Migrations/20260809200000_SeedFreeTierChannelSubscribeReminderEmailTemplate.cs
@@ -1,0 +1,44 @@
+using DataGateMonitor.Models.EmailTemplates;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataGateMonitor.DataBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedFreeTierChannelSubscribeReminderEmailTemplate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var epoch = new DateTimeOffset(2026, 8, 9, 0, 0, 0, TimeSpan.Zero);
+
+            migrationBuilder.InsertData(
+                schema: "xgb_dashopnvpn",
+                table: "EmailBroadcastTemplates",
+                columns: ["Name", "Description", "Subject", "BodyHtml", "CreatedByUserId", "CreateDate", "LastUpdate"],
+                values: new object[,]
+                {
+                    {
+                        SystemEmailTemplateNames.FreeTierChannelSubscribeReminder,
+                        "Built-in: admin force email remind to subscribe to Telegram channel. Placeholders: {{DISPLAY_NAME}}, {{REQUIRED_CHANNEL}}, {{CHANNEL_URL}}",
+                        TransactionalEmailHtml.DefaultFreeTierChannelSubscribeReminderSubject,
+                        TransactionalEmailHtml.BuildFreeTierChannelSubscribeReminderWithPlaceholders(),
+                        null,
+                        epoch,
+                        epoch
+                    }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                DELETE FROM xgb_dashopnvpn."EmailBroadcastTemplates"
+                WHERE "Name" = 'system.free_tier_channel_subscribe_reminder';
+                """);
+        }
+    }
+}

--- a/DataGateMonitor.DataBase/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DataGateMonitor.DataBase/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2535,6 +2535,11 @@ namespace DataGateMonitor.DataBase.Migrations
 
                     b.HasIndex("UserCode", "Status");
 
+                    b.HasIndex("UserCode")
+                        .IsUnique()
+                        .HasDatabaseName("IX_TvLoginSessions_UserCode_Open")
+                        .HasFilter("\"Status\" IN (0, 5)");
+
                     b.ToTable("TvLoginSessions", "xgb_dashopnvpn");
                 });
 

--- a/DataGateMonitor.DataBase/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DataGateMonitor.DataBase/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1465,6 +1465,33 @@ namespace DataGateMonitor.DataBase.Migrations
                             Language = 3,
                             LastUpdate = new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
                             Text = "Не удалось связать аккаунты. Проверьте код и попробуйте снова."
+                        },
+                        new
+                        {
+                            Id = 100,
+                            CreateDate = new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Key = "VpnServerNotAllowedByQuotaPlan",
+                            Language = 1,
+                            LastUpdate = new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Text = "This VPN server is not available on your current plan. Please choose another server or upgrade your plan."
+                        },
+                        new
+                        {
+                            Id = 101,
+                            CreateDate = new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Key = "VpnServerNotAllowedByQuotaPlan",
+                            Language = 2,
+                            LastUpdate = new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Text = "Αυτός ο διακομιστής VPN δεν είναι διαθέσιμος στο τρέχον πρόγραμμά σας. Επιλέξτε άλλον διακομιστή ή αναβαθμίστε το πρόγραμμα."
+                        },
+                        new
+                        {
+                            Id = 102,
+                            CreateDate = new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Key = "VpnServerNotAllowedByQuotaPlan",
+                            Language = 3,
+                            LastUpdate = new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                            Text = "Этот VPN-сервер недоступен на вашем текущем тарифе. Выберите другой сервер или обновите план."
                         });
                 });
 

--- a/DataGateMonitor.DataBase/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/DataGateMonitor.DataBase/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -2523,11 +2523,15 @@ namespace DataGateMonitor.DataBase.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("ApprovedUserId");
+
                     b.HasIndex("ExpiresAt");
 
                     b.HasIndex("Status");
 
                     b.HasIndex("UserCode");
+
+                    b.HasIndex("ApprovedUserId", "Status");
 
                     b.HasIndex("UserCode", "Status");
 

--- a/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IIssuedOvpnFileQueryService.cs
@@ -9,6 +9,16 @@ public interface IIssuedOvpnFileQueryService
     Task<List<IssuedOvpnFile>> GetAllByVpnServerId(int vpnServerId, CancellationToken ct);
     Task<List<IssuedOvpnFile>> GetAllByExternalId(string externalId, CancellationToken ct);
 
+    /// <summary>Batch lookup by external id (ordinal, trimmed non-empty keys).</summary>
+    Task<IReadOnlyDictionary<string, List<IssuedOvpnFile>>> GetAllByExternalIds(
+        IReadOnlyCollection<string> externalIds,
+        CancellationToken ct);
+
+    /// <summary>Active (non-revoked) files matching any of the server/common-name pairs.</summary>
+    Task<List<IssuedOvpnFile>> GetActiveByServerAndCommonNames(
+        IReadOnlyCollection<(int VpnServerId, string CommonName)> pairs,
+        CancellationToken ct);
+
     Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAndIsRevoked(int vpnServerId, bool isRevoked, CancellationToken ct);
     Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAndExternalIdAndIsRevoked(int vpnServerId, string externalId,
         bool isRevoked, CancellationToken ct);

--- a/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/IssuedOvpnFileTable/IssuedOvpnFileQueryService.cs
@@ -15,6 +15,58 @@ public class IssuedOvpnFileQueryService(IQueryService<IssuedOvpnFile, int> q) : 
     public Task<List<IssuedOvpnFile>> GetAllByExternalId(string externalId, CancellationToken ct)
         => q.Where(x => x.ExternalId == externalId, ct: ct);
 
+    public async Task<IReadOnlyDictionary<string, List<IssuedOvpnFile>>> GetAllByExternalIds(
+        IReadOnlyCollection<string> externalIds,
+        CancellationToken ct)
+    {
+        var ids = externalIds
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (ids.Count == 0)
+            return new Dictionary<string, List<IssuedOvpnFile>>(StringComparer.Ordinal);
+
+        var files = await q.Query()
+            .AsNoTracking()
+            .Where(x => ids.Contains(x.ExternalId))
+            .ToListAsync(ct);
+
+        return files
+            .GroupBy(x => x.ExternalId, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+    }
+
+    public async Task<List<IssuedOvpnFile>> GetActiveByServerAndCommonNames(
+        IReadOnlyCollection<(int VpnServerId, string CommonName)> pairs,
+        CancellationToken ct)
+    {
+        if (pairs.Count == 0)
+            return [];
+
+        var serverIds = pairs.Select(p => p.VpnServerId).Distinct().ToList();
+        var commonNames = pairs
+            .Select(p => p.CommonName)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (serverIds.Count == 0 || commonNames.Count == 0)
+            return [];
+
+        var pairSet = pairs
+            .Where(p => !string.IsNullOrWhiteSpace(p.CommonName))
+            .ToHashSet();
+
+        var candidates = await q.Query()
+            .AsNoTracking()
+            .Where(x => !x.IsRevoked && serverIds.Contains(x.VpnServerId) && commonNames.Contains(x.CommonName))
+            .ToListAsync(ct);
+
+        return candidates
+            .Where(x => pairSet.Contains((x.VpnServerId, x.CommonName)))
+            .ToList();
+    }
+
     public Task<List<IssuedOvpnFile>> GetAllByVpnServerIdAndIsRevoked(int vpnServerId, bool isRevoked, 
         CancellationToken ct)
         => q.Where(x => x.VpnServerId == vpnServerId && x.IsRevoked == isRevoked, ct: ct);

--- a/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/ITvLoginSessionQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/ITvLoginSessionQueryService.cs
@@ -8,4 +8,15 @@ public interface ITvLoginSessionQueryService
     Task<TvLoginSession?> GetActiveByUserCode(string normalizedUserCode, CancellationToken ct);
     Task<TvLoginSession?> GetLatestByUserCode(string normalizedUserCode, CancellationToken ct);
     Task<bool> AnyActiveByUserCode(string normalizedUserCode, CancellationToken ct);
+
+    Task<(IReadOnlyList<TvLoginSession> Items, int TotalCount)> ListAsync(
+        int? approvedUserId,
+        TvLoginSessionStatus? status,
+        int skip,
+        int take,
+        CancellationToken ct);
+
+    Task<TvLoginSession?> GetLatestApprovedOrConsumedForUserAsync(int userId, CancellationToken ct);
+
+    Task<int> CountApprovedOrConsumedForUserAsync(int userId, CancellationToken ct);
 }

--- a/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/ITvLoginSessionQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/ITvLoginSessionQueryService.cs
@@ -1,0 +1,11 @@
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+
+public interface ITvLoginSessionQueryService
+{
+    Task<TvLoginSession?> GetById(Guid id, CancellationToken ct);
+    Task<TvLoginSession?> GetActiveByUserCode(string normalizedUserCode, CancellationToken ct);
+    Task<TvLoginSession?> GetLatestByUserCode(string normalizedUserCode, CancellationToken ct);
+    Task<bool> AnyActiveByUserCode(string normalizedUserCode, CancellationToken ct);
+}

--- a/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryService.cs
@@ -14,7 +14,7 @@ public class TvLoginSessionQueryService(IQueryService<TvLoginSession, Guid> q) :
         return q.Query()
             .Where(x =>
                 x.UserCode == normalizedUserCode
-                && x.Status == TvLoginSessionStatus.Pending
+                && (x.Status == TvLoginSessionStatus.Pending || x.Status == TvLoginSessionStatus.Viewed)
                 && x.ExpiresAt > now)
             .OrderByDescending(x => x.CreateDate)
             .FirstOrDefaultAsync(ct);
@@ -33,7 +33,7 @@ public class TvLoginSessionQueryService(IQueryService<TvLoginSession, Guid> q) :
             .AnyAsync(
                 x =>
                     x.UserCode == normalizedUserCode
-                    && x.Status == TvLoginSessionStatus.Pending
+                    && (x.Status == TvLoginSessionStatus.Pending || x.Status == TvLoginSessionStatus.Viewed)
                     && x.ExpiresAt > now,
                 ct);
     }

--- a/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryService.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using DataGateMonitor.Models;
+
+namespace DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+
+public class TvLoginSessionQueryService(IQueryService<TvLoginSession, Guid> q) : ITvLoginSessionQueryService
+{
+    public Task<TvLoginSession?> GetById(Guid id, CancellationToken ct)
+        => q.FindById(id, ct: ct);
+
+    public Task<TvLoginSession?> GetActiveByUserCode(string normalizedUserCode, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return q.Query()
+            .Where(x =>
+                x.UserCode == normalizedUserCode
+                && x.Status == TvLoginSessionStatus.Pending
+                && x.ExpiresAt > now)
+            .OrderByDescending(x => x.CreateDate)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    public Task<TvLoginSession?> GetLatestByUserCode(string normalizedUserCode, CancellationToken ct)
+        => q.Query()
+            .Where(x => x.UserCode == normalizedUserCode)
+            .OrderByDescending(x => x.CreateDate)
+            .FirstOrDefaultAsync(ct);
+
+    public Task<bool> AnyActiveByUserCode(string normalizedUserCode, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return q.Query()
+            .AnyAsync(
+                x =>
+                    x.UserCode == normalizedUserCode
+                    && x.Status == TvLoginSessionStatus.Pending
+                    && x.ExpiresAt > now,
+                ct);
+    }
+}

--- a/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryService.cs
@@ -37,4 +37,47 @@ public class TvLoginSessionQueryService(IQueryService<TvLoginSession, Guid> q) :
                     && x.ExpiresAt > now,
                 ct);
     }
+
+    public async Task<(IReadOnlyList<TvLoginSession> Items, int TotalCount)> ListAsync(
+        int? approvedUserId,
+        TvLoginSessionStatus? status,
+        int skip,
+        int take,
+        CancellationToken ct)
+    {
+        skip = Math.Max(0, skip);
+        take = Math.Clamp(take <= 0 ? 50 : take, 1, 200);
+
+        var query = q.Query().AsNoTracking();
+        if (approvedUserId is int userId)
+            query = query.Where(x => x.ApprovedUserId == userId);
+        if (status is TvLoginSessionStatus st)
+            query = query.Where(x => x.Status == st);
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .OrderByDescending(x => x.CreateDate)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(ct);
+
+        return (items, total);
+    }
+
+    public Task<TvLoginSession?> GetLatestApprovedOrConsumedForUserAsync(int userId, CancellationToken ct)
+        => q.Query()
+            .AsNoTracking()
+            .Where(x =>
+                x.ApprovedUserId == userId
+                && (x.Status == TvLoginSessionStatus.Approved || x.Status == TvLoginSessionStatus.Consumed))
+            .OrderByDescending(x => x.CompletedAt ?? x.CreateDate)
+            .FirstOrDefaultAsync(ct);
+
+    public Task<int> CountApprovedOrConsumedForUserAsync(int userId, CancellationToken ct)
+        => q.Query()
+            .CountAsync(
+                x =>
+                    x.ApprovedUserId == userId
+                    && (x.Status == TvLoginSessionStatus.Approved || x.Status == TvLoginSessionStatus.Consumed),
+                ct);
 }

--- a/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/IUserIdentityLinkQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/IUserIdentityLinkQueryService.cs
@@ -10,6 +10,12 @@ public interface IUserIdentityLinkQueryService
     Task<UserIdentityLink?> GetByProviderAndExternalId(string provider, string externalId, CancellationToken ct);
     public Task<UserIdentityLink?> GetByExternalId(string externalId, CancellationToken ct);
     Task<UserIdentityLink?> GetByUserId(int userId, CancellationToken ct);
+    /// <summary>
+    /// First identity link per user (lowest <see cref="UserIdentityLink.Id"/>), matching <see cref="GetByUserId"/>.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, UserIdentityLink>> GetFirstByUserIds(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken ct);
     Task<List<UserIdentityLink>> GetListByUserId(int userId, CancellationToken ct);
     Task<bool> AnyByUserId(int userId, CancellationToken ct);
 

--- a/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/IUserIdentityLinkQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/IUserIdentityLinkQueryService.cs
@@ -17,6 +17,12 @@ public interface IUserIdentityLinkQueryService
         IReadOnlyCollection<int> userIds,
         CancellationToken ct);
     Task<List<UserIdentityLink>> GetListByUserId(int userId, CancellationToken ct);
+
+    /// <summary>All identity links for the given users, grouped by <see cref="UserIdentityLink.UserId"/>.</summary>
+    Task<IReadOnlyDictionary<int, List<UserIdentityLink>>> GetListByUserIds(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken ct);
+
     Task<bool> AnyByUserId(int userId, CancellationToken ct);
 
     Task<IPagedResult<UserIdentityLink>> GetPage(int page, int pageSize, CancellationToken ct);

--- a/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
@@ -23,7 +23,26 @@ public class UserIdentityLinkQueryService(IQueryService<UserIdentityLink, int> q
 
     public Task<UserIdentityLink?> GetByUserId(int userId, CancellationToken ct)
         => q.Query()
-            .FirstOrDefaultAsync(x => x.UserId == userId, ct);
+            .Where(x => x.UserId == userId)
+            .OrderBy(x => x.Id)
+            .FirstOrDefaultAsync(ct);
+
+    public async Task<IReadOnlyDictionary<int, UserIdentityLink>> GetFirstByUserIds(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken ct)
+    {
+        if (userIds.Count == 0)
+            return new Dictionary<int, UserIdentityLink>();
+
+        var links = await q.Query()
+            .Where(x => userIds.Contains(x.UserId))
+            .OrderBy(x => x.Id)
+            .ToListAsync(ct);
+
+        return links
+            .GroupBy(x => x.UserId)
+            .ToDictionary(g => g.Key, g => g.First());
+    }
 
     public Task<List<UserIdentityLink>> GetListByUserId(int userId, CancellationToken ct)
         => q.Query()

--- a/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryService.cs
@@ -49,6 +49,27 @@ public class UserIdentityLinkQueryService(IQueryService<UserIdentityLink, int> q
             .Where(x => x.UserId == userId)
             .ToListAsync(ct);
 
+    public async Task<IReadOnlyDictionary<int, List<UserIdentityLink>>> GetListByUserIds(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken ct)
+    {
+        if (userIds.Count == 0)
+            return new Dictionary<int, List<UserIdentityLink>>();
+
+        var ids = userIds.Where(id => id > 0).Distinct().ToList();
+        if (ids.Count == 0)
+            return new Dictionary<int, List<UserIdentityLink>>();
+
+        var links = await q.Query()
+            .AsNoTracking()
+            .Where(x => ids.Contains(x.UserId))
+            .ToListAsync(ct);
+
+        return links
+            .GroupBy(x => x.UserId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+    }
+
     public Task<bool> AnyByUserId(int userId, CancellationToken ct)
         => q.Any(x => x.UserId == userId, ct: ct);
 

--- a/DataGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
@@ -11,6 +11,12 @@ public interface IUserQueryService
     Task<User?> GetByEmail(string email, CancellationToken ct);
     Task<bool> AnyByEmail(string email, CancellationToken ct);
     Task<User?> GetById(int id, CancellationToken ct);
+
+    /// <summary>Batch lookup by primary key.</summary>
+    Task<IReadOnlyDictionary<int, User>> GetByIds(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken ct);
+
     Task<User?> GetByExternalId(string externalId, CancellationToken ct);
 
     /// <summary>

--- a/DataGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserTable/IUserQueryService.cs
@@ -12,6 +12,15 @@ public interface IUserQueryService
     Task<bool> AnyByEmail(string email, CancellationToken ct);
     Task<User?> GetById(int id, CancellationToken ct);
     Task<User?> GetByExternalId(string externalId, CancellationToken ct);
+
+    /// <summary>
+    /// Batch lookup by external id (one links query + one users query).
+    /// When multiple links share an external id, the lowest link Id wins (stable).
+    /// </summary>
+    Task<IReadOnlyDictionary<string, User>> GetByExternalIds(
+        IReadOnlyCollection<string> externalIds,
+        CancellationToken ct);
+
     Task<IPagedResult<User>> GetPage(int page, int pageSize, CancellationToken ct);
     Task<IPagedResult<User>> GetPage(GetAllUsersRequest request, CancellationToken ct);
     public Task<List<User>> Search(

--- a/DataGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
@@ -19,6 +19,21 @@ public class UserQueryService(
     public Task<User?> GetById(int id, CancellationToken ct)
         => q.FindById(id, ct: ct);
 
+    public async Task<IReadOnlyDictionary<int, User>> GetByIds(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken ct)
+    {
+        var ids = userIds.Where(id => id > 0).Distinct().ToList();
+        if (ids.Count == 0)
+            return new Dictionary<int, User>();
+
+        var users = await q.Where(
+            predicate: x => ids.Contains(x.Id),
+            asNoTracking: true,
+            ct: ct);
+        return users.ToDictionary(u => u.Id);
+    }
+
     public async Task<User?> GetByEmail(string email, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(email))

--- a/DataGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/UserTable/UserQueryService.cs
@@ -43,20 +43,55 @@ public class UserQueryService(
 
     public async Task<User?> GetByExternalId(string externalId, CancellationToken ct)
     {
-        var link = await qUserIdentityLink.FirstOrDefault(
-            predicate: x => x.ExternalId == externalId,
-            asNoTracking: true,
-            ct: ct
-        );
-
-        if (link is null)
+        if (string.IsNullOrWhiteSpace(externalId))
             return null;
 
-        return await q.FirstOrDefault(
-            predicate: x => x.Id == link.UserId,
+        var map = await GetByExternalIds([externalId], ct);
+        return map.TryGetValue(externalId, out var user) ? user : null;
+    }
+
+    public async Task<IReadOnlyDictionary<string, User>> GetByExternalIds(
+        IReadOnlyCollection<string> externalIds,
+        CancellationToken ct)
+    {
+        var ids = externalIds
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (ids.Count == 0)
+            return new Dictionary<string, User>(StringComparer.Ordinal);
+
+        var links = await qUserIdentityLink.Where(
+            predicate: x => ids.Contains(x.ExternalId),
+            orderBy: qy => qy.OrderBy(x => x.Id),
             asNoTracking: true,
-            ct: ct
-        );
+            ct: ct);
+
+        var firstLinkByExternalId = new Dictionary<string, UserIdentityLink>(StringComparer.Ordinal);
+        foreach (var link in links)
+        {
+            if (!firstLinkByExternalId.ContainsKey(link.ExternalId))
+                firstLinkByExternalId[link.ExternalId] = link;
+        }
+
+        if (firstLinkByExternalId.Count == 0)
+            return new Dictionary<string, User>(StringComparer.Ordinal);
+
+        var userIds = firstLinkByExternalId.Values.Select(l => l.UserId).Distinct().ToList();
+        var users = await q.Where(
+            predicate: x => userIds.Contains(x.Id),
+            asNoTracking: true,
+            ct: ct);
+        var usersById = users.ToDictionary(u => u.Id);
+
+        var result = new Dictionary<string, User>(StringComparer.Ordinal);
+        foreach (var (externalId, link) in firstLinkByExternalId)
+        {
+            if (usersById.TryGetValue(link.UserId, out var user))
+                result[externalId] = user;
+        }
+
+        return result;
     }
 
     public Task<IPagedResult<User>> GetPage(int page, int pageSize, CancellationToken ct)

--- a/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryService.cs
@@ -134,13 +134,32 @@ public class VpnDnsQueryLogQueryService(IQueryService<VpnDnsQueryLog, int> q) : 
         if (request.ToUtc.HasValue)
             query = query.Where(x => x.QueriedAtUtc <= request.ToUtc.Value);
 
-        return await query
-            .GroupBy(x => x.Domain.ToLower())
+        // Two-phase aggregation: (domain, user) then roll up. Same numbers as
+        // COUNT(DISTINCT COALESCE(ExternalId, ClientIp)) but prefers HashAggregate
+        // over a large Sort for DISTINCT, which spills to disk under default work_mem.
+        var projected = query.Select(x => new
+        {
+            DomainKey = x.Domain.ToLower(),
+            x.Domain,
+            UserKey = x.ExternalId ?? x.ClientIp
+        });
+
+        var perUser = projected
+            .GroupBy(x => new { x.DomainKey, x.UserKey })
+            .Select(g => new
+            {
+                g.Key.DomainKey,
+                Domain = g.Max(x => x.Domain),
+                QueryCount = g.Count()
+            });
+
+        return await perUser
+            .GroupBy(x => x.DomainKey)
             .Select(g => new VpnDnsTopDomainDto
             {
-                Domain = g.Max(x => x.Domain),
-                UniqueUsersCount = g.Select(x => x.ExternalId ?? x.ClientIp).Distinct().Count(),
-                QueryCount = g.Count()
+                Domain = g.Max(x => x.Domain) ?? string.Empty,
+                UniqueUsersCount = g.Count(),
+                QueryCount = g.Sum(x => x.QueryCount)
             })
             .OrderByDescending(x => x.UniqueUsersCount)
             .ThenByDescending(x => x.QueryCount)

--- a/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnDnsQueryLogTable/VpnDnsQueryLogQueryService.cs
@@ -105,13 +105,20 @@ public class VpnDnsQueryLogQueryService(IQueryService<VpnDnsQueryLog, int> q) : 
         if (vpnServerId <= 0)
             return (0, null);
 
-        var query = q.Query().Where(x => x.VpnServerId == vpnServerId);
-        var totalCount = await query.CountAsync(ct);
-        if (totalCount == 0)
+        var summary = await q.Query()
+            .Where(x => x.VpnServerId == vpnServerId)
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                TotalCount = g.Count(),
+                LastQueriedAtUtc = (DateTimeOffset?)g.Max(x => x.QueriedAtUtc)
+            })
+            .FirstOrDefaultAsync(ct);
+
+        if (summary is null || summary.TotalCount == 0)
             return (0, null);
 
-        var lastAt = await query.MaxAsync(x => x.QueriedAtUtc, ct);
-        return (totalCount, lastAt);
+        return (summary.TotalCount, summary.LastQueriedAtUtc);
     }
 
     public async Task<IReadOnlyList<VpnDnsTopDomainDto>> GetTopDomainsAsync(

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnGeoQueryService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnGeoQueryService.cs
@@ -21,8 +21,13 @@ public sealed class OpenVpnGeoQueryService(IUnitOfWork uow) : IOpenVpnGeoQuerySe
         bool onlyWithCoordinates = true,
         CancellationToken ct = default)
     {
-        // Normalize bounds (inclusive start, exclusive end).
+        // Normalize bounds (inclusive start, exclusive end) and clamp future To (apps send month-end).
         if (toUtc < fromUtc) (fromUtc, toUtc) = (toUtc, fromUtc);
+        var utcNow = DateTimeOffset.UtcNow;
+        if (fromUtc > utcNow)
+            fromUtc = toUtc = utcNow;
+        else if (toUtc > utcNow)
+            toUtc = utcNow;
 
         // Base query
         var q = uow.GetQuery<VpnServerClient>().AsQueryable();

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQuery.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQuery.cs
@@ -13,7 +13,7 @@ public sealed class OpenVpnOverviewTotalsQuery(
     IUnitOfWork uow,
     IOverviewTrafficAggregator trafficAggregator) : IOpenVpnOverviewTotalsQuery
 {
-    public async Task<OverviewTotalsResponse> GetOverviewTotalsAsync(
+    public Task<OverviewTotalsResponse> GetOverviewTotalsAsync(
         DateTimeOffset fromUtc,
         DateTimeOffset toUtc,
         int? vpnServerId,
@@ -22,6 +22,26 @@ public sealed class OpenVpnOverviewTotalsQuery(
     {
         if (toUtc < fromUtc) (fromUtc, toUtc) = (toUtc, fromUtc);
 
+        var key = string.Join('|',
+            "overview-summary",
+            fromUtc.UtcTicks,
+            toUtc.UtcTicks,
+            vpnServerId?.ToString() ?? "-",
+            externalId ?? "-");
+
+        return OverviewTrafficResultCache.GetOrCreateAsync(
+            key,
+            token => BuildOverviewTotalsAsync(fromUtc, toUtc, vpnServerId, externalId, token),
+            ct);
+    }
+
+    private async Task<OverviewTotalsResponse> BuildOverviewTotalsAsync(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        int? vpnServerId,
+        string? externalId,
+        CancellationToken ct)
+    {
         var sessionsQ = uow.GetQuery<VpnServerClient>().AsQueryable();
 
         if (vpnServerId.HasValue)

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQuery.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OpenVpnOverviewTotalsQuery.cs
@@ -34,13 +34,22 @@ public sealed class OpenVpnOverviewTotalsQuery(
             .Where(x => x.ConnectedSince >= fromUtc && x.ConnectedSince < toUtc)
             .AsNoTracking();
 
-        var sessionsCount = await sessionsQ.LongCountAsync(ct);
+        // One round-trip: sessions + distinct users (same filters as before).
+        var sessionAgg = await sessionsQ
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                SessionsCount = g.LongCount(),
+                UsersCount = g
+                    .Where(x => x.ExternalId != null && x.ExternalId != "")
+                    .Select(x => x.ExternalId)
+                    .Distinct()
+                    .LongCount()
+            })
+            .FirstOrDefaultAsync(ct);
 
-        var usersCount = await sessionsQ
-            .Select(x => x.ExternalId)
-            .Where(x => x != null && x != "")
-            .Distinct()
-            .LongCountAsync(ct);
+        var sessionsCount = sessionAgg?.SessionsCount ?? 0L;
+        var usersCount = sessionAgg?.UsersCount ?? 0L;
 
         var trafficTotals = await trafficAggregator.GetTrafficTotalsAsync(
             fromUtc, toUtc, vpnServerId, externalId, ct);

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficAggregator.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficAggregator.cs
@@ -22,11 +22,18 @@ public sealed class OverviewTrafficAggregator(
         int? vpnServerId,
         string? externalId,
         CancellationToken ct = default)
-        => UsePostgresAsync(ct)
-            ? QueryPostgresAsync(ct, ctx => QueryTrafficSeriesHybridAsync(
-                ctx, fromUtc, toUtc, grouping, vpnServerId, externalId, ct))
-            : Task.FromResult<IReadOnlyList<OverviewTrafficBucketRow>>(
+    {
+        if (!UsePostgresAsync(ct))
+            return Task.FromResult<IReadOnlyList<OverviewTrafficBucketRow>>(
                 AggregateTrafficSeriesBucketsInMemory(fromUtc, toUtc, grouping, vpnServerId, externalId));
+
+        var key = CacheKey("series", fromUtc, toUtc, grouping, vpnServerId, externalId);
+        return OverviewTrafficResultCache.GetOrCreateAsync(
+            key,
+            token => QueryPostgresAsync(token, ctx => QueryTrafficSeriesHybridAsync(
+                ctx, fromUtc, toUtc, grouping, vpnServerId, externalId, token)),
+            ct);
+    }
 
     public Task<IReadOnlyList<OverviewUsersSeriesBucketRow>> GetUsersSeriesBucketsAsync(
         DateTimeOffset fromUtc,
@@ -35,11 +42,18 @@ public sealed class OverviewTrafficAggregator(
         int? vpnServerId,
         string? externalId,
         CancellationToken ct = default)
-        => UsePostgresAsync(ct)
-            ? QueryPostgresAsync(ct, ctx => QueryUsersSeriesHybridAsync(
-                ctx, fromUtc, toUtc, grouping, vpnServerId, externalId, ct))
-            : Task.FromResult<IReadOnlyList<OverviewUsersSeriesBucketRow>>(
+    {
+        if (!UsePostgresAsync(ct))
+            return Task.FromResult<IReadOnlyList<OverviewUsersSeriesBucketRow>>(
                 AggregateUsersSeriesBucketsInMemory(fromUtc, toUtc, grouping, vpnServerId, externalId));
+
+        var key = CacheKey("users-series", fromUtc, toUtc, grouping, vpnServerId, externalId);
+        return OverviewTrafficResultCache.GetOrCreateAsync(
+            key,
+            token => QueryPostgresAsync(token, ctx => QueryUsersSeriesHybridAsync(
+                ctx, fromUtc, toUtc, grouping, vpnServerId, externalId, token)),
+            ct);
+    }
 
     public async Task<OverviewTrafficTotalsRow> GetTrafficTotalsAsync(
         DateTimeOffset fromUtc,
@@ -48,11 +62,15 @@ public sealed class OverviewTrafficAggregator(
         string? externalId,
         CancellationToken ct = default)
     {
-        if (UsePostgresAsync(ct))
-            return await QueryPostgresAsync(ct, ctx => QueryTrafficTotalsHybridAsync(
-                ctx, fromUtc, toUtc, vpnServerId, externalId, ct));
+        if (!UsePostgresAsync(ct))
+            return AggregateTrafficTotalsInMemory(fromUtc, toUtc, vpnServerId, externalId);
 
-        return AggregateTrafficTotalsInMemory(fromUtc, toUtc, vpnServerId, externalId);
+        var key = CacheKey("totals", fromUtc, toUtc, grouping: null, vpnServerId, externalId);
+        return await OverviewTrafficResultCache.GetOrCreateAsync(
+            key,
+            token => QueryPostgresAsync(token, ctx => QueryTrafficTotalsHybridAsync(
+                ctx, fromUtc, toUtc, vpnServerId, externalId, token)),
+            ct);
     }
 
     public Task<IReadOnlyList<OverviewUserTrafficRow>> GetUserTrafficRowsAsync(
@@ -61,11 +79,33 @@ public sealed class OverviewTrafficAggregator(
         int? vpnServerId,
         string? externalId,
         CancellationToken ct = default)
-        => UsePostgresAsync(ct)
-            ? QueryPostgresAsync(ct, ctx => QueryUserTrafficHybridAsync(
-                ctx, fromUtc, toUtc, vpnServerId, externalId, ct))
-            : Task.FromResult<IReadOnlyList<OverviewUserTrafficRow>>(
+    {
+        if (!UsePostgresAsync(ct))
+            return Task.FromResult<IReadOnlyList<OverviewUserTrafficRow>>(
                 AggregateUserTrafficRowsInMemory(fromUtc, toUtc, vpnServerId, externalId));
+
+        var key = CacheKey("users", fromUtc, toUtc, grouping: null, vpnServerId, externalId);
+        return OverviewTrafficResultCache.GetOrCreateAsync(
+            key,
+            token => QueryPostgresAsync(token, ctx => QueryUserTrafficHybridAsync(
+                ctx, fromUtc, toUtc, vpnServerId, externalId, token)),
+            ct);
+    }
+
+    private static string CacheKey(
+        string kind,
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        OverviewGrouping? grouping,
+        int? vpnServerId,
+        string? externalId)
+        => string.Join('|',
+            kind,
+            fromUtc.UtcTicks,
+            toUtc.UtcTicks,
+            grouping?.ToString() ?? "-",
+            vpnServerId?.ToString() ?? "-",
+            externalId ?? "-");
 
     private bool UsePostgresAsync(CancellationToken ct) => dbContextFactory is not null;
 
@@ -79,7 +119,7 @@ public sealed class OverviewTrafficAggregator(
 
         // Keep hash/sort aggregates in memory for multi-day windows; LOCAL scopes to this tx only.
         await using var tx = await ctx.Database.BeginTransactionAsync(ct);
-        await ctx.Database.ExecuteSqlRawAsync("SET LOCAL work_mem = '64MB'", ct);
+        await ctx.Database.ExecuteSqlRawAsync("SET LOCAL work_mem = '128MB'", ct);
         var result = await query(ctx);
         await tx.CommitAsync(ct);
         return result;

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficAggregator.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficAggregator.cs
@@ -97,11 +97,18 @@ public sealed class OverviewTrafficAggregator(
         string? externalId)
         => OverviewTrafficPostgresSql.BuildFilterParams(fromUtc, toUtc, offset, vpnServerId, externalId);
 
-    private static string BuildFilteredTrafficCte(string table)
-        => OverviewTrafficPostgresSql.BuildFilteredTrafficCte(table);
+    private static string BuildFilteredTrafficCte(string table, int? vpnServerId, string? externalId)
+        => OverviewTrafficPostgresSql.BuildFilteredTrafficCte(table, vpnServerId, externalId);
+
+    private static string BuildBaselinesCte(string table, int? vpnServerId, string? externalId)
+        => OverviewTrafficPostgresSql.BuildBaselinesCte(table, vpnServerId, externalId);
 
     private static string BucketStartSql(OverviewGrouping grouping)
         => OverviewTrafficPostgresSql.BucketStartSql(grouping);
+
+    private static void NormalizeTrafficRange(ref DateTimeOffset fromUtc, ref DateTimeOffset toUtc)
+        => (fromUtc, toUtc) = OverviewTrafficPostgresSql.NormalizeTrafficRange(
+            fromUtc, toUtc, DateTimeOffset.UtcNow);
 
     private async Task<IReadOnlyList<OverviewTrafficBucketRow>> QueryTrafficSeriesHybridAsync(
         ApplicationDbContext ctx,
@@ -112,6 +119,8 @@ public sealed class OverviewTrafficAggregator(
         string? externalId,
         CancellationToken ct)
     {
+        NormalizeTrafficRange(ref fromUtc, ref toUtc);
+
         if (!OverviewTrafficDailyQueries.SupportsDailyGrouping(grouping))
             return await QueryTrafficSeriesBucketsPostgresAsync(ctx, fromUtc, toUtc, grouping, vpnServerId, externalId, ct);
 
@@ -142,6 +151,8 @@ public sealed class OverviewTrafficAggregator(
         string? externalId,
         CancellationToken ct)
     {
+        NormalizeTrafficRange(ref fromUtc, ref toUtc);
+
         if (!OverviewTrafficDailyQueries.SupportsDailyGrouping(grouping))
             return await QueryUsersSeriesBucketsPostgresAsync(ctx, fromUtc, toUtc, grouping, vpnServerId, externalId, ct);
 
@@ -171,6 +182,8 @@ public sealed class OverviewTrafficAggregator(
         string? externalId,
         CancellationToken ct)
     {
+        NormalizeTrafficRange(ref fromUtc, ref toUtc);
+
         var split = OverviewTrafficDailyQueries.SplitRange(fromUtc, toUtc);
         var hasDaily = await OverviewTrafficDailyQueries.HasDailyRowsAsync(ctx, split.DailyFrom, split.DailyToExclusive, ct);
         if (!hasDaily)
@@ -203,6 +216,8 @@ public sealed class OverviewTrafficAggregator(
         string? externalId,
         CancellationToken ct)
     {
+        NormalizeTrafficRange(ref fromUtc, ref toUtc);
+
         var split = OverviewTrafficDailyQueries.SplitRange(fromUtc, toUtc);
         var hasDaily = await OverviewTrafficDailyQueries.HasDailyRowsAsync(ctx, split.DailyFrom, split.DailyToExclusive, ct);
         if (!hasDaily)
@@ -236,7 +251,7 @@ public sealed class OverviewTrafficAggregator(
         var table = ResolveTrafficTable(ctx);
         var bucketExpr = BucketStartSql(grouping);
         var sql = $"""
-                   WITH {BuildFilteredTrafficCte(table)},
+                   WITH {BuildFilteredTrafficCte(table, vpnServerId, externalId)},
                    with_prev AS (
                        SELECT
                            f."SessionId",
@@ -297,7 +312,7 @@ public sealed class OverviewTrafficAggregator(
         var table = ResolveTrafficTable(ctx);
         var bucketExpr = BucketStartSql(grouping);
         var sql = $"""
-                   WITH {BuildFilteredTrafficCte(table)},
+                   WITH {BuildFilteredTrafficCte(table, vpnServerId, externalId)},
                    bucketed AS (
                        SELECT
                            {bucketExpr.Replace("\"MeasuredAt\"", "f.\"MeasuredAt\"")} AS bucket_ts,
@@ -333,18 +348,8 @@ public sealed class OverviewTrafficAggregator(
 
         var table = ResolveTrafficTable(ctx);
         var sql = $"""
-                   WITH {BuildFilteredTrafficCte(table)},
-                   baselines AS (
-                       SELECT DISTINCT ON (t."SessionId")
-                           t."SessionId",
-                           t."BytesReceived" AS baseline_in,
-                           t."BytesSent" AS baseline_out
-                       FROM {table} t
-                       WHERE t."MeasuredAt" < @from
-                         AND {OverviewTrafficPostgresSql.VpnServerFilterSql}
-                         AND {OverviewTrafficPostgresSql.ExternalIdFilterSql}
-                       ORDER BY t."SessionId", t."MeasuredAt" DESC
-                   ),
+                   WITH {BuildFilteredTrafficCte(table, vpnServerId, externalId)},
+                   {BuildBaselinesCte(table, vpnServerId, externalId)},
                    with_prev AS (
                        SELECT
                            f."SessionId",
@@ -412,7 +417,7 @@ public sealed class OverviewTrafficAggregator(
 
         var table = ResolveTrafficTable(ctx);
         var sql = $"""
-                   WITH {BuildFilteredTrafficCte(table)},
+                   WITH {BuildFilteredTrafficCte(table, vpnServerId, externalId)},
                    with_prev AS (
                        SELECT
                            f."ExternalId",

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficAggregator.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficAggregator.cs
@@ -77,7 +77,12 @@ public sealed class OverviewTrafficAggregator(
         if (!ctx.Database.IsNpgsql())
             throw new InvalidOperationException("PostgreSQL aggregation requires Npgsql provider.");
 
-        return await query(ctx);
+        // Keep hash/sort aggregates in memory for multi-day windows; LOCAL scopes to this tx only.
+        await using var tx = await ctx.Database.BeginTransactionAsync(ct);
+        await ctx.Database.ExecuteSqlRawAsync("SET LOCAL work_mem = '64MB'", ct);
+        var result = await query(ctx);
+        await tx.CommitAsync(ct);
+        return result;
     }
 
     private static string ResolveTrafficTable(ApplicationDbContext ctx)

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficDailyRollupService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficDailyRollupService.cs
@@ -176,19 +176,34 @@ public sealed class OverviewTrafficDailyRollupService(
         var trafficTable = ResolveTable<VpnServerClientTraffic>(ctx);
         var dailyTable = ResolveTable<VpnServerClientTrafficDaily>(ctx);
 
+        // Same set as DISTINCT date_trunc(MeasuredAt) anti-join dailies, without scanning all traffic rows:
+        // calendar days from first sample through @throughDay that have traffic but no daily rollup
+        // (including gaps in the middle). Uses IX_ClientTraffic_At + IX_ClientTrafficDaily_Day_*.
         var sql = $"""
-                   SELECT r.day_utc AS "Value"
-                   FROM (
-                       SELECT DISTINCT (date_trunc('day', t."MeasuredAt" AT TIME ZONE 'UTC'))::date AS day_utc
+                   WITH bounds AS (
+                       SELECT ("MeasuredAt" AT TIME ZONE 'UTC')::date AS mn
+                       FROM {trafficTable}
+                       ORDER BY "MeasuredAt"
+                       LIMIT 1
+                   ),
+                   cand AS (
+                       SELECT gs::date AS day_utc
+                       FROM bounds b
+                       CROSS JOIN LATERAL generate_series(b.mn, @throughDay, interval '1 day') AS gs
+                       WHERE b.mn <= @throughDay
+                   )
+                   SELECT c.day_utc AS "Value"
+                   FROM cand c
+                   WHERE NOT EXISTS (
+                       SELECT 1 FROM {dailyTable} d WHERE d."DayUtc" = c.day_utc
+                   )
+                     AND EXISTS (
+                       SELECT 1
                        FROM {trafficTable} t
-                   ) r
-                   LEFT JOIN (
-                       SELECT DISTINCT d."DayUtc" AS day_utc
-                       FROM {dailyTable} d
-                   ) d ON d.day_utc = r.day_utc
-                   WHERE r.day_utc <= @throughDay
-                     AND d.day_utc IS NULL
-                   ORDER BY r.day_utc
+                       WHERE t."MeasuredAt" >= (c.day_utc::timestamp AT TIME ZONE 'UTC')
+                         AND t."MeasuredAt" <  ((c.day_utc + 1)::timestamp AT TIME ZONE 'UTC')
+                   )
+                   ORDER BY c.day_utc
                    """;
 
         return await ctx.Database

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficDailyRollupService.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficDailyRollupService.cs
@@ -57,6 +57,7 @@ public sealed class OverviewTrafficDailyRollupService(
                                t."BytesSent" AS baseline_out
                            FROM {trafficTable} t
                            WHERE t."MeasuredAt" < @dayStart
+                             AND t."SessionId" IN (SELECT DISTINCT f."SessionId" FROM filtered f)
                            ORDER BY t."SessionId", t."MeasuredAt" DESC
                        ),
                        with_prev AS (

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSql.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSql.cs
@@ -96,6 +96,8 @@ public static class OverviewTrafficPostgresSql
             measuredFromParam: "@baselineFrom",
             measuredToExclusiveParam: "@from");
 
+        // Only sessions that appear in the filtered window need a baseline. Without this,
+        // a global lookback (no ExternalId) DISTINCT ON-scans every session in the window.
         return $"""
                baselines AS (
                    SELECT DISTINCT ON (t."SessionId")
@@ -104,6 +106,7 @@ public static class OverviewTrafficPostgresSql
                        t."BytesSent" AS baseline_out
                    FROM {table} t
                    WHERE {predicates}
+                     AND t."SessionId" IN (SELECT DISTINCT f."SessionId" FROM filtered f)
                    ORDER BY t."SessionId", t."MeasuredAt" DESC
                )
                """;

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSql.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSql.cs
@@ -10,8 +10,37 @@ namespace DataGateMonitor.DataBase.Services.Query.VpnServerClientTable;
 /// </summary>
 public static class OverviewTrafficPostgresSql
 {
+    /// <summary>
+    /// How far before <c>@from</c> to search for per-session byte baselines.
+    /// Polling is frequent; 2 days covers overnight sessions without scanning full history
+    /// (heavy ExternalId users can have 100k+ rows).
+    /// </summary>
+    public const int BaselineLookbackDays = 2;
+
     public const string VpnServerFilterSql = """(@vpnServerId IS NULL OR t."VpnServerId" = @vpnServerId)""";
     public const string ExternalIdFilterSql = """(@externalId IS NULL OR t."ExternalId" = @externalId)""";
+
+    /// <summary>
+    /// Swap inverted bounds and clamp <paramref name="toUtc"/> to <paramref name="utcNow"/>
+    /// (apps often send month-end <c>To</c>; there is no traffic in the future).
+    /// </summary>
+    public static (DateTimeOffset FromUtc, DateTimeOffset ToUtc) NormalizeTrafficRange(
+        DateTimeOffset fromUtc,
+        DateTimeOffset toUtc,
+        DateTimeOffset utcNow)
+    {
+        if (toUtc < fromUtc)
+            (fromUtc, toUtc) = (toUtc, fromUtc);
+
+        // No samples exist in the future — collapse to an empty window at "now".
+        if (fromUtc > utcNow)
+            return (utcNow, utcNow);
+
+        if (toUtc > utcNow)
+            toUtc = utcNow;
+
+        return (fromUtc, toUtc);
+    }
 
     public static NpgsqlParameter[] BuildFilterParams(
         DateTimeOffset fromUtc,
@@ -20,33 +49,83 @@ public static class OverviewTrafficPostgresSql
         int? vpnServerId,
         string? externalId)
     {
+        var baselineFrom = fromUtc.UtcDateTime.AddDays(-BaselineLookbackDays);
         return
         [
             new("from", NpgsqlDbType.TimestampTz) { Value = fromUtc.UtcDateTime },
             new("to", NpgsqlDbType.TimestampTz) { Value = toUtc.UtcDateTime },
+            new("baselineFrom", NpgsqlDbType.TimestampTz) { Value = baselineFrom },
             new("offset", NpgsqlDbType.Interval) { Value = offset },
             new("vpnServerId", NpgsqlDbType.Integer) { Value = (object?)vpnServerId ?? DBNull.Value },
             new("externalId", NpgsqlDbType.Text) { Value = (object?)externalId ?? DBNull.Value },
         ];
     }
 
+    public static string BuildFilteredTrafficCte(string table, int? vpnServerId, string? externalId)
+    {
+        var predicates = BuildEqualityAndRangePredicates(
+            vpnServerId,
+            externalId,
+            measuredFromParam: "@from",
+            measuredToExclusiveParam: "@to");
+
+        return $"""
+               filtered AS (
+                   SELECT
+                       t."SessionId",
+                       t."ExternalId",
+                       t."VpnServerId",
+                       t."MeasuredAt",
+                       t."BytesReceived",
+                       t."BytesSent"
+                   FROM {table} t
+                   WHERE {predicates}
+               )
+               """;
+    }
+
+    /// <summary>Backward-compatible overload (optional filters as OR-NULL).</summary>
     public static string BuildFilteredTrafficCte(string table)
-        => $"""
-           filtered AS (
-               SELECT
-                   t."SessionId",
-                   t."ExternalId",
-                   t."VpnServerId",
-                   t."MeasuredAt",
-                   t."BytesReceived",
-                   t."BytesSent"
-               FROM {table} t
-               WHERE t."MeasuredAt" >= @from
-                 AND t."MeasuredAt" < @to
-                 AND {VpnServerFilterSql}
-                 AND {ExternalIdFilterSql}
-           )
-           """;
+        => BuildFilteredTrafficCte(table, vpnServerId: null, externalId: null);
+
+    public static string BuildBaselinesCte(string table, int? vpnServerId, string? externalId)
+    {
+        var predicates = BuildEqualityAndRangePredicates(
+            vpnServerId,
+            externalId,
+            measuredFromParam: "@baselineFrom",
+            measuredToExclusiveParam: "@from");
+
+        return $"""
+               baselines AS (
+                   SELECT DISTINCT ON (t."SessionId")
+                       t."SessionId",
+                       t."BytesReceived" AS baseline_in,
+                       t."BytesSent" AS baseline_out
+                   FROM {table} t
+                   WHERE {predicates}
+                   ORDER BY t."SessionId", t."MeasuredAt" DESC
+               )
+               """;
+    }
+
+    private static string BuildEqualityAndRangePredicates(
+        int? vpnServerId,
+        string? externalId,
+        string measuredFromParam,
+        string measuredToExclusiveParam)
+    {
+        // Equality first when present so the planner prefers IX_ClientTraffic_External_At /
+        // server+time indexes instead of a wide MeasuredAt scan + filter.
+        var parts = new List<string>(4);
+        if (!string.IsNullOrWhiteSpace(externalId))
+            parts.Add("""t."ExternalId" = @externalId""");
+        if (vpnServerId.HasValue)
+            parts.Add("""t."VpnServerId" = @vpnServerId""");
+        parts.Add($"""t."MeasuredAt" >= {measuredFromParam}""");
+        parts.Add($"""t."MeasuredAt" < {measuredToExclusiveParam}""");
+        return string.Join("\n                     AND ", parts);
+    }
 
     public static string BucketStartSql(OverviewGrouping grouping)
     {

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSql.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSql.cs
@@ -12,10 +12,10 @@ public static class OverviewTrafficPostgresSql
 {
     /// <summary>
     /// How far before <c>@from</c> to search for per-session byte baselines.
-    /// Polling is frequent; 2 days covers overnight sessions without scanning full history
-    /// (heavy ExternalId users can have 100k+ rows).
+    /// Polling is frequent; 1 day covers overnight sessions without scanning a wide
+    /// history window (verified equivalent to 2-day lookback on prod dump samples).
     /// </summary>
-    public const int BaselineLookbackDays = 2;
+    public const int BaselineLookbackDays = 1;
 
     public const string VpnServerFilterSql = """(@vpnServerId IS NULL OR t."VpnServerId" = @vpnServerId)""";
     public const string ExternalIdFilterSql = """(@externalId IS NULL OR t."ExternalId" = @externalId)""";

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficResultCache.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/OverviewTrafficResultCache.cs
@@ -1,0 +1,57 @@
+using System.Collections.Concurrent;
+
+namespace DataGateMonitor.DataBase.Services.Query.VpnServerClientTable;
+
+/// <summary>
+/// Short-lived single-flight cache for overview traffic SQL.
+/// Dashboard refresh storms (summary+users+series) share one DB round-trip per key.
+/// </summary>
+internal static class OverviewTrafficResultCache
+{
+    public static readonly TimeSpan Ttl = TimeSpan.FromSeconds(5);
+
+    private static readonly ConcurrentDictionary<string, CacheEntry> Entries = new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> Gates = new(StringComparer.Ordinal);
+
+    public static async Task<T> GetOrCreateAsync<T>(string key, Func<CancellationToken, Task<T>> factory, CancellationToken ct)
+    {
+        if (TryGet(key, out T hit))
+            return hit;
+
+        var gate = Gates.GetOrAdd(key, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (TryGet(key, out hit))
+                return hit;
+
+            var value = await factory(ct).ConfigureAwait(false);
+            Entries[key] = new CacheEntry(value!, DateTimeOffset.UtcNow.Add(Ttl));
+            return value;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private static bool TryGet<T>(string key, out T value)
+    {
+        value = default!;
+        if (!Entries.TryGetValue(key, out var entry))
+            return false;
+        if (entry.ExpiresAtUtc <= DateTimeOffset.UtcNow)
+        {
+            Entries.TryRemove(key, out _);
+            return false;
+        }
+
+        if (entry.Value is not T typed)
+            return false;
+
+        value = typed;
+        return true;
+    }
+
+    private readonly record struct CacheEntry(object Value, DateTimeOffset ExpiresAtUtc);
+}

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/VpnServerClientOverviewQuery.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerClientTable/VpnServerClientOverviewQuery.cs
@@ -102,31 +102,27 @@ public class VpnServerClientOverviewQuery(
         };
     }
 
-    // Helper: enrich page items with User.DisplayName by ExternalId
+    // Helper: enrich page items with User.DisplayName by ExternalId (batched)
     private async Task EnrichWithUsersAsync(List<VpnClientInfoDto> items, CancellationToken ct)
     {
         var externalIds = items
             .Select(c => c.ExternalId)
             .Where(id => !string.IsNullOrWhiteSpace(id))
-            .Distinct()
+            .Select(id => id!)
+            .Distinct(StringComparer.Ordinal)
             .ToList();
 
         if (externalIds.Count == 0)
             return;
 
-        var users = new Dictionary<string, User?>();
-        foreach (var extId in externalIds)
-        {
-            var user = await userQueryService.GetByExternalId(extId, ct);
-            users[extId] = user;
-        }
+        var users = await userQueryService.GetByExternalIds(externalIds, ct);
 
         foreach (var client in items)
         {
             if (string.IsNullOrWhiteSpace(client.ExternalId))
                 continue;
 
-            if (users.TryGetValue(client.ExternalId, out var user) && user is not null)
+            if (users.TryGetValue(client.ExternalId, out var user))
             {
                 client.DisplayName = user.DisplayName;
                 client.AvatarUrl = string.IsNullOrWhiteSpace(user.AvatarUrl) ? null : user.AvatarUrl;

--- a/DataGateMonitor.DataBase/Services/Query/VpnServerTable/VpnServerOverviewQuery.cs
+++ b/DataGateMonitor.DataBase/Services/Query/VpnServerTable/VpnServerOverviewQuery.cs
@@ -9,7 +9,7 @@ namespace DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 
 public class VpnServerOverviewQuery(IUnitOfWork uow) : IVpnServerOverviewQuery
 {
-    // Single roundtrip with correlated subqueries
+    // Set-based aggregates (same fields/semantics as former correlated subqueries)
     public async Task<List<VpnServerWithStatusDto>> GetAllVpnServersWithStatusAsync(
         bool includeDeleted = false,
         bool requireQuotaPlanAssignment = false,
@@ -28,87 +28,25 @@ public class VpnServerOverviewQuery(IUnitOfWork uow) : IVpnServerOverviewQuery
             var allowed = uow.GetQuery<QuotaPlanAllowedServer>().AsQueryable();
             servers = servers.Where(s => allowed.Any(a => a.VpnServerId == s.Id));
         }
-        var clients = uow.GetQuery<VpnServerClient>().AsQueryable();
-        var logs = uow.GetQuery<VpnServerStatusLog>().AsQueryable();
 
-        var query =
-            from s in servers
-            orderby s.Id
-            select new VpnServerWithStatusDto
-            {
-                VpnServerResponses = new VpnServerResponse
-                {
-                    VpnServer = s.Adapt<VpnServerDto>(),
-                },
+        var serverList = await servers.AsNoTracking().OrderBy(s => s.Id).ToListAsync(ct);
+        if (serverList.Count == 0)
+            return [];
 
-                CountConnectedClients = clients.Count(c => c.VpnServerId == s.Id && c.IsConnected),
-                CountSessions = clients.Count(c => c.VpnServerId == s.Id),
-
-                VpnServerStatusLogResponse =
-                    logs.Where(l => l.VpnServerId == s.Id)
-                        .OrderByDescending(l => l.Id) // or by CreateDate
-                        .Select(l => new VpnServerStatusLogResponse
-                        {
-                            VpnServerId = l.VpnServerId,
-                            SessionId = l.SessionId,
-                            UpSince = l.UpSince,
-                            ServerLocalIp = l.ServerLocalIp,
-                            ServerRemoteIp = l.ServerRemoteIp,
-                            BytesIn = l.BytesIn,
-                            BytesOut = l.BytesOut,
-                            Version = l.Version
-                        })
-                        .FirstOrDefault(),
-
-                TotalBytesIn = logs.Where(l => l.VpnServerId == s.Id).Sum(l => (long?)l.BytesIn) ?? 0L,
-                TotalBytesOut = logs.Where(l => l.VpnServerId == s.Id).Sum(l => (long?)l.BytesOut) ?? 0L
-            };
-
-        return await query.AsNoTracking().ToListAsync(ct);
+        return await ComposeWithStatusAsync(serverList, ct);
     }
 
     // Single server variant; throws if not found
     public async Task<VpnServerWithStatusDto> GetVpnServerWithStatusAsync(int vpnServerId, CancellationToken ct)
     {
-        var servers = uow.GetQuery<VpnServer>().AsQueryable();
-        var clients = uow.GetQuery<VpnServerClient>().AsQueryable();
-        var logs = uow.GetQuery<VpnServerStatusLog>().AsQueryable();
+        var server = await uow.GetQuery<VpnServer>().AsQueryable()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == vpnServerId, ct);
+        if (server is null)
+            throw new NullReferenceException("OpenVPN Server not found");
 
-        var query =
-            from s in servers
-            where s.Id == vpnServerId
-            select new VpnServerWithStatusDto
-            {
-                VpnServerResponses = new VpnServerResponse
-                {
-                    VpnServer = s.Adapt<VpnServerDto>(),
-                },
-                CountConnectedClients = clients.Count(c => c.VpnServerId == s.Id && c.IsConnected),
-                CountSessions = clients.Count(c => c.VpnServerId == s.Id),
-
-                VpnServerStatusLogResponse =
-                    logs.Where(l => l.VpnServerId == s.Id)
-                        .OrderByDescending(l => l.Id)
-                        .Select(l => new VpnServerStatusLogResponse
-                        {
-                            VpnServerId = l.VpnServerId,
-                            SessionId = l.SessionId,
-                            UpSince = l.UpSince,
-                            ServerLocalIp = l.ServerLocalIp,
-                            ServerRemoteIp = l.ServerRemoteIp,
-                            BytesIn = l.BytesIn,
-                            BytesOut = l.BytesOut,
-                            Version = l.Version
-                        })
-                        .FirstOrDefault(),
-
-                TotalBytesIn = logs.Where(l => l.VpnServerId == s.Id).Sum(l => (long?)l.BytesIn) ?? 0L,
-                TotalBytesOut = logs.Where(l => l.VpnServerId == s.Id).Sum(l => (long?)l.BytesOut) ?? 0L
-            };
-
-        var result = await query.AsNoTracking().FirstOrDefaultAsync(ct);
-        if (result is null) throw new NullReferenceException("OpenVPN Server not found");
-        return result;
+        var list = await ComposeWithStatusAsync([server], ct);
+        return list[0];
     }
 
     public async Task<(int CountConnectedClients, int CountSessions)> GetClientCountersAsync(
@@ -130,5 +68,91 @@ public class VpnServerOverviewQuery(IUnitOfWork uow) : IVpnServerOverviewQuery
         return counters is null
             ? (0, 0)
             : (counters.CountConnectedClients, counters.CountSessions);
+    }
+
+    private async Task<List<VpnServerWithStatusDto>> ComposeWithStatusAsync(
+        List<VpnServer> serverList,
+        CancellationToken ct)
+    {
+        var serverIds = serverList.Select(s => s.Id).ToList();
+        var clients = uow.GetQuery<VpnServerClient>().AsQueryable();
+        var logs = uow.GetQuery<VpnServerStatusLog>().AsQueryable();
+
+        var clientAggs = await clients
+            .AsNoTracking()
+            .Where(c => serverIds.Contains(c.VpnServerId))
+            .GroupBy(c => c.VpnServerId)
+            .Select(g => new
+            {
+                VpnServerId = g.Key,
+                CountConnectedClients = g.Count(c => c.IsConnected),
+                CountSessions = g.Count()
+            })
+            .ToListAsync(ct);
+
+        var logTotals = await logs
+            .AsNoTracking()
+            .Where(l => serverIds.Contains(l.VpnServerId))
+            .GroupBy(l => l.VpnServerId)
+            .Select(g => new
+            {
+                VpnServerId = g.Key,
+                TotalBytesIn = g.Sum(l => (long?)l.BytesIn) ?? 0L,
+                TotalBytesOut = g.Sum(l => (long?)l.BytesOut) ?? 0L
+            })
+            .ToListAsync(ct);
+
+        var latestLogIds = await logs
+            .AsNoTracking()
+            .Where(l => serverIds.Contains(l.VpnServerId))
+            .GroupBy(l => l.VpnServerId)
+            .Select(g => g.Max(l => l.Id))
+            .ToListAsync(ct);
+
+        var latestLogs = latestLogIds.Count == 0
+            ? []
+            : await logs
+                .AsNoTracking()
+                .Where(l => latestLogIds.Contains(l.Id))
+                .ToListAsync(ct);
+
+        var clientsByServer = clientAggs.ToDictionary(x => x.VpnServerId);
+        var totalsByServer = logTotals.ToDictionary(x => x.VpnServerId);
+        var latestByServer = latestLogs.ToDictionary(l => l.VpnServerId);
+
+        var result = new List<VpnServerWithStatusDto>(serverList.Count);
+        foreach (var s in serverList)
+        {
+            clientsByServer.TryGetValue(s.Id, out var clientAgg);
+            totalsByServer.TryGetValue(s.Id, out var totals);
+            latestByServer.TryGetValue(s.Id, out var latest);
+
+            result.Add(new VpnServerWithStatusDto
+            {
+                VpnServerResponses = new VpnServerResponse
+                {
+                    VpnServer = s.Adapt<VpnServerDto>(),
+                },
+                CountConnectedClients = clientAgg?.CountConnectedClients ?? 0,
+                CountSessions = clientAgg?.CountSessions ?? 0,
+                TotalBytesIn = totals?.TotalBytesIn ?? 0L,
+                TotalBytesOut = totals?.TotalBytesOut ?? 0L,
+                VpnServerStatusLogResponse = latest is null
+                    ? null
+                    : new VpnServerStatusLogResponse
+                    {
+                        VpnServerId = latest.VpnServerId,
+                        SessionId = latest.SessionId,
+                        UpSince = latest.UpSince,
+                        ServerLocalIp = latest.ServerLocalIp,
+                        ServerRemoteIp = latest.ServerRemoteIp,
+                        BytesIn = latest.BytesIn,
+                        BytesOut = latest.BytesOut,
+                        Version = latest.Version
+                    }
+            });
+        }
+
+        return result;
     }
 }

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.44" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.50" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
+++ b/DataGateMonitor.Mapping/DataGateMonitor.Mapping.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
       <PackageReference Include="Mapster" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.44" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.50" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/DataGateMonitor.Models.csproj
+++ b/DataGateMonitor.Models/DataGateMonitor.Models.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
       <!-- SharedModels: NuGet only (never ProjectReference). Publish new package version to nuget.org after DTO changes. -->
-      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+      <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>

--- a/DataGateMonitor.Models/EmailTemplates/SystemEmailTemplateNames.cs
+++ b/DataGateMonitor.Models/EmailTemplates/SystemEmailTemplateNames.cs
@@ -6,4 +6,5 @@ public static class SystemEmailTemplateNames
     public const string EmailConfirmation = "system.email_confirmation";
     public const string AdminPasswordReset = "system.admin_password_reset";
     public const string FreeTierGraceDisconnected = "system.free_tier_grace_disconnected";
+    public const string FreeTierChannelSubscribeReminder = "system.free_tier_channel_subscribe_reminder";
 }

--- a/DataGateMonitor.Models/EmailTemplates/TransactionalEmailHtml.cs
+++ b/DataGateMonitor.Models/EmailTemplates/TransactionalEmailHtml.cs
@@ -13,6 +13,7 @@ public static class TransactionalEmailHtml
     public const string DefaultConfirmationSubject = "Confirm your email — DataGate";
     public const string DefaultAdminPasswordResetSubject = "Administrator password reset — DataGate";
     public const string DefaultFreeTierGraceDisconnectedSubject = "You were disconnected from the VPN — DataGate";
+    public const string DefaultFreeTierChannelSubscribeReminderSubject = "Please subscribe to our Telegram channel — DataGate";
     public const string DefaultConfirmEmailPageUrl = "https://datagateapp.com/confirm-email";
 
     private const string MailVersionLabel = "1.0.3";
@@ -131,6 +132,53 @@ public static class TransactionalEmailHtml
         => bodyHtml
             .Replace("{{PLAN_NAME}}", Escape(planName), StringComparison.Ordinal)
             .Replace("{{REQUIRED_CHANNEL}}", Escape(requiredChannel), StringComparison.Ordinal);
+
+    public static string BuildFreeTierChannelSubscribeReminder(string displayName, string requiredChannel, string channelUrl)
+        => BuildDocument(
+            pageTitle: "DataGate — subscribe to Telegram channel",
+            emailTitle: "Please subscribe to our channel",
+            emailTagline: "Free/Default VPN access requires an active Telegram channel subscription.",
+            includeDownloadButton: false,
+            emailLead: string.IsNullOrWhiteSpace(displayName) ? "Hello," : $"Hello {Escape(displayName)},",
+            bodyParagraphs:
+            [
+                "To keep using Free/Default VPN access, please subscribe to our official Telegram channel.",
+                $"Channel: <strong>{Escape(requiredChannel)}</strong><br/><a href=\"{Escape(channelUrl)}\" target=\"_blank\" rel=\"noopener noreferrer\">{Escape(channelUrl)}</a>",
+                "After you subscribe, reconnect to the VPN if you were disconnected.",
+                "If you need help: <a href=\"https://t.me/KolganovIvan\" target=\"_blank\" rel=\"noopener noreferrer\"><b>@KolganovIvan</b></a>",
+            ],
+            codeLabel: "Required channel",
+            codeValueHtml: Escape(requiredChannel),
+            signoff: "— The DataGate team",
+            actionButtonHref: channelUrl,
+            actionButtonLabel: "Open Telegram channel");
+
+    public static string BuildFreeTierChannelSubscribeReminderWithPlaceholders()
+        => BuildDocument(
+            pageTitle: "DataGate — subscribe to Telegram channel",
+            emailTitle: "Please subscribe to our channel",
+            emailTagline: "Free/Default VPN access requires an active Telegram channel subscription.",
+            includeDownloadButton: false,
+            emailLead: "Hello {{DISPLAY_NAME}},",
+            bodyParagraphs:
+            [
+                "To keep using Free/Default VPN access, please subscribe to our official Telegram channel.",
+                "Channel: <strong>{{REQUIRED_CHANNEL}}</strong><br/><a href=\"{{CHANNEL_URL}}\" target=\"_blank\" rel=\"noopener noreferrer\">{{CHANNEL_URL}}</a>",
+                "After you subscribe, reconnect to the VPN if you were disconnected.",
+                "If you need help: <a href=\"https://t.me/KolganovIvan\" target=\"_blank\" rel=\"noopener noreferrer\"><b>@KolganovIvan</b></a>",
+            ],
+            codeLabel: "Required channel",
+            codeValueHtml: "{{REQUIRED_CHANNEL}}",
+            signoff: "— The DataGate team",
+            actionButtonHref: "{{CHANNEL_URL}}",
+            actionButtonLabel: "Open Telegram channel");
+
+    public static string ApplyFreeTierChannelSubscribeReminderPlaceholders(
+        string bodyHtml, string displayName, string requiredChannel, string channelUrl)
+        => bodyHtml
+            .Replace("{{DISPLAY_NAME}}", Escape(displayName), StringComparison.Ordinal)
+            .Replace("{{REQUIRED_CHANNEL}}", Escape(requiredChannel), StringComparison.Ordinal)
+            .Replace("{{CHANNEL_URL}}", Escape(channelUrl), StringComparison.Ordinal);
 
     public static string ApplyConfirmationPlaceholders(string bodyHtml, string code, int ttlMinutes)
     {

--- a/DataGateMonitor.Models/Helpers/TelegramChannelSettings.cs
+++ b/DataGateMonitor.Models/Helpers/TelegramChannelSettings.cs
@@ -23,4 +23,7 @@ public sealed class TelegramChannelSettings
 
     public string RequiredChannelChatId =>
         $"@{RequiredChannelUsername.Trim().TrimStart('@')}";
+
+    public string RequiredChannelUrl =>
+        $"https://t.me/{RequiredChannelUsername.Trim().TrimStart('@')}";
 }

--- a/DataGateMonitor.Models/TvLoginSession.cs
+++ b/DataGateMonitor.Models/TvLoginSession.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DataGateMonitor.Models;
+
+/// <summary>
+/// Short-lived TV device-linking login session. Tokens are issued lazily on the first successful
+/// poll after <see cref="TvLoginSessionStatus.Approved"/>, then the row becomes <see cref="TvLoginSessionStatus.Consumed"/>.
+/// </summary>
+public class TvLoginSession : BaseEntity<Guid>
+{
+    /// <summary>Normalized 8-char code without hyphen (e.g. ABCD1234).</summary>
+    [Required, MaxLength(16)]
+    public string UserCode { get; set; } = null!;
+
+    public TvLoginSessionStatus Status { get; set; } = TvLoginSessionStatus.Pending;
+
+    [MaxLength(128)]
+    public string? DeviceName { get; set; }
+
+    [MaxLength(64)]
+    public string? Client { get; set; }
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    public int? ApprovedUserId { get; set; }
+
+    public DateTimeOffset? CompletedAt { get; set; }
+
+    /// <summary>Optional TV client device id from create request headers.</summary>
+    [MaxLength(128)]
+    public string? DeviceId { get; set; }
+
+    [MaxLength(512)]
+    public string? UserAgent { get; set; }
+}

--- a/DataGateMonitor.Models/TvLoginSessionStatus.cs
+++ b/DataGateMonitor.Models/TvLoginSessionStatus.cs
@@ -1,0 +1,11 @@
+namespace DataGateMonitor.Models;
+
+/// <summary>Lifecycle of a Netflix-style TV / device-linking login session.</summary>
+public enum TvLoginSessionStatus
+{
+    Pending = 0,
+    Approved = 1,
+    Denied = 2,
+    Expired = 3,
+    Consumed = 4,
+}

--- a/DataGateMonitor.Models/TvLoginSessionStatus.cs
+++ b/DataGateMonitor.Models/TvLoginSessionStatus.cs
@@ -8,4 +8,6 @@ public enum TvLoginSessionStatus
     Denied = 2,
     Expired = 3,
     Consumed = 4,
+    /// <summary>Phone opened / looked up the code; waiting for approve or deny.</summary>
+    Viewed = 5,
 }

--- a/DataGateMonitor.Models/VpnServerOvpnFileConfig.cs
+++ b/DataGateMonitor.Models/VpnServerOvpnFileConfig.cs
@@ -19,7 +19,7 @@ public class VpnServerOvpnFileConfig : BaseEntity<int>
     public string ConfigTemplate { get; set; } = @"setenv FRIENDLY_NAME ""{{friendly_name}}""
 client
 dev tun
-proto udp
+proto tcp
 remote {{server_ip}} {{server_port}}
 resolv-retry infinite
 nobind
@@ -49,7 +49,7 @@ verb 3
         ConfigTemplate = @"setenv FRIENDLY_NAME ""{{friendly_name}}""
 client
 dev tun
-proto udp
+proto tcp
 remote {{server_ip}} {{server_port}}
 resolv-retry infinite
 nobind

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.44</Version>
-        <AssemblyVersion>1.0.44.0</AssemblyVersion>
-        <FileVersion>1.0.44.0</FileVersion>
+        <Version>1.0.45</Version>
+        <AssemblyVersion>1.0.45.0</AssemblyVersion>
+        <FileVersion>1.0.45.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.45</Version>
-        <AssemblyVersion>1.0.45.0</AssemblyVersion>
-        <FileVersion>1.0.45.0</FileVersion>
+        <Version>1.0.46</Version>
+        <AssemblyVersion>1.0.46.0</AssemblyVersion>
+        <FileVersion>1.0.46.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.46</Version>
-        <AssemblyVersion>1.0.46.0</AssemblyVersion>
-        <FileVersion>1.0.46.0</FileVersion>
+        <Version>1.0.47</Version>
+        <AssemblyVersion>1.0.47.0</AssemblyVersion>
+        <FileVersion>1.0.47.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.49</Version>
-        <AssemblyVersion>1.0.49.0</AssemblyVersion>
-        <FileVersion>1.0.49.0</FileVersion>
+        <Version>1.0.50</Version>
+        <AssemblyVersion>1.0.50.0</AssemblyVersion>
+        <FileVersion>1.0.50.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.47</Version>
-        <AssemblyVersion>1.0.47.0</AssemblyVersion>
-        <FileVersion>1.0.47.0</FileVersion>
+        <Version>1.0.48</Version>
+        <AssemblyVersion>1.0.48.0</AssemblyVersion>
+        <FileVersion>1.0.48.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
+++ b/DataGateMonitor.SharedModels/DataGateMonitor.SharedModels.csproj
@@ -22,9 +22,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <!-- Backend consumes this library via NuGet (PackageReference) only. Bump <Version>, publish, then bump PackageReference in consuming projects. -->
-        <Version>1.0.48</Version>
-        <AssemblyVersion>1.0.48.0</AssemblyVersion>
-        <FileVersion>1.0.48.0</FileVersion>
+        <Version>1.0.49</Version>
+        <AssemblyVersion>1.0.49.0</AssemblyVersion>
+        <FileVersion>1.0.49.0</FileVersion>
         <PackageIcon>favicon.png</PackageIcon>
 
         <Deterministic>true</Deterministic>

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Requests/ApproveTvLoginSessionRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Requests/ApproveTvLoginSessionRequest.cs
@@ -1,0 +1,10 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+
+/// <summary>Phone/web confirms a pending TV login session (provide sessionId and/or userCode).</summary>
+public sealed class ApproveTvLoginSessionRequest
+{
+    public Guid? SessionId { get; set; }
+
+    /// <summary>Human-readable code shown on the TV (hyphens/spaces optional).</summary>
+    public string? UserCode { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Requests/CreateTvLoginSessionRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Requests/CreateTvLoginSessionRequest.cs
@@ -1,0 +1,11 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+
+/// <summary>Optional metadata when a TV (or similar device) starts a device-linking login session.</summary>
+public sealed class CreateTvLoginSessionRequest
+{
+    /// <summary>Human-readable device label, e.g. "Living Room TV".</summary>
+    public string? DeviceName { get; set; }
+
+    /// <summary>Client identifier, e.g. "android-tv".</summary>
+    public string? Client { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Requests/DenyTvLoginSessionRequest.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Requests/DenyTvLoginSessionRequest.cs
@@ -1,0 +1,10 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+
+/// <summary>Phone/web denies a pending TV login session (provide sessionId and/or userCode).</summary>
+public sealed class DenyTvLoginSessionRequest
+{
+    public Guid? SessionId { get; set; }
+
+    /// <summary>Human-readable code shown on the TV (hyphens/spaces optional).</summary>
+    public string? UserCode { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/AdminTvLoginSessionDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/AdminTvLoginSessionDto.cs
@@ -1,0 +1,34 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+/// <summary>Admin view of a TV device-linking session row.</summary>
+public sealed class AdminTvLoginSessionDto
+{
+    public Guid SessionId { get; set; }
+
+    /// <summary>6-digit user code shown on the TV.</summary>
+    public string UserCode { get; set; } = null!;
+
+    /// <summary>
+    /// Lowercase status: pending, viewed, approved, denied, expired, consumed.
+    /// </summary>
+    public string Status { get; set; } = null!;
+
+    public string? DeviceName { get; set; }
+    public string? Client { get; set; }
+    public string? DeviceId { get; set; }
+    public string? UserAgent { get; set; }
+
+    public int? ApprovedUserId { get; set; }
+    public string? ApprovedUserEmail { get; set; }
+    public string? ApprovedUserDisplayName { get; set; }
+
+    public DateTimeOffset CreateDate { get; set; }
+    public DateTimeOffset ExpiresAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+}
+
+public sealed class GetAdminTvLoginSessionsResponse
+{
+    public IReadOnlyList<AdminTvLoginSessionDto> Sessions { get; set; } = [];
+    public int TotalCount { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/CreateTvLoginSessionResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/CreateTvLoginSessionResponse.cs
@@ -1,0 +1,21 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+/// <summary>Payload returned when a TV creates a short-lived login session (QR + user code).</summary>
+public sealed class CreateTvLoginSessionResponse
+{
+    public Guid SessionId { get; set; }
+
+    /// <summary>8-character code, uppercase, hyphenated (e.g. ABCD-1234).</summary>
+    public string UserCode { get; set; } = null!;
+
+    /// <summary>Landing page for phone users (without code query).</summary>
+    public string VerificationUrl { get; set; } = null!;
+
+    /// <summary>Exact string to encode in the QR code (verification URL with code query).</summary>
+    public string QrPayload { get; set; } = null!;
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    /// <summary>Suggested poll interval for GET /api/auth/tv/session/{sessionId}.</summary>
+    public int PollIntervalSeconds { get; set; } = 2;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/CreateTvLoginSessionResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/CreateTvLoginSessionResponse.cs
@@ -5,7 +5,7 @@ public sealed class CreateTvLoginSessionResponse
 {
     public Guid SessionId { get; set; }
 
-    /// <summary>8-character code, uppercase, hyphenated (e.g. ABCD-1234).</summary>
+    /// <summary>6-digit numeric code shown on the TV (e.g. 482913). Also embedded in <see cref="QrPayload"/>.</summary>
     public string UserCode { get; set; } = null!;
 
     /// <summary>Landing page for phone users (without code query).</summary>
@@ -16,6 +16,9 @@ public sealed class CreateTvLoginSessionResponse
 
     public DateTimeOffset ExpiresAt { get; set; }
 
-    /// <summary>Suggested poll interval for GET /api/auth/tv/session/{sessionId}.</summary>
+    /// <summary>Suggested poll interval for GET /api/auth/tv/session/{sessionId} when SignalR is unavailable.</summary>
     public int PollIntervalSeconds { get; set; } = 2;
+
+    /// <summary>Anonymous SignalR hub path; call WatchSession(sessionId) and listen for TvLoginSessionStatusChanged.</summary>
+    public string SignalRHubPath { get; set; } = "/api/hubs/tv-login";
 }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionActionResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionActionResponse.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+/// <summary>Result of approve/deny on a TV login session.</summary>
+public sealed class TvLoginSessionActionResponse
+{
+    /// <summary>approved | denied</summary>
+    public string Status { get; set; } = null!;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionPollResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionPollResponse.cs
@@ -6,7 +6,7 @@ namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
 /// </summary>
 public sealed class TvLoginSessionPollResponse
 {
-    /// <summary>pending | approved | denied | expired | consumed</summary>
+    /// <summary>pending | viewed | approved | denied | expired | consumed</summary>
     public string Status { get; set; } = null!;
 
     public DateTimeOffset ExpiresAt { get; set; }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionPollResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionPollResponse.cs
@@ -1,0 +1,24 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+/// <summary>
+/// TV poll payload. While pending/denied/expired/consumed, only <see cref="Status"/> and <see cref="ExpiresAt"/> are set.
+/// When <see cref="Status"/> is <c>approved</c>, login token fields match <see cref="LoginResponse"/> (one-time delivery).
+/// </summary>
+public sealed class TvLoginSessionPollResponse
+{
+    /// <summary>pending | approved | denied | expired | consumed</summary>
+    public string Status { get; set; } = null!;
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    public int UserId { get; set; }
+    public string? DisplayName { get; set; }
+    public string? Email { get; set; }
+    public string? Token { get; set; }
+    public DateTimeOffset Expiration { get; set; }
+    public string? RefreshToken { get; set; }
+    public DateTimeOffset? RefreshExpiration { get; set; }
+    public bool RequiresTotp { get; set; }
+    public string? LoginChallengeId { get; set; }
+    public bool RequiresTotpSetup { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionPreviewResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionPreviewResponse.cs
@@ -1,0 +1,17 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+/// <summary>Authenticated phone/web preview of a pending TV login session by user code.</summary>
+public sealed class TvLoginSessionPreviewResponse
+{
+    public Guid SessionId { get; set; }
+
+    /// <summary>Formatted user code (e.g. ABCD-1234).</summary>
+    public string UserCode { get; set; } = null!;
+
+    public string? DeviceName { get; set; }
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    /// <summary>Expected value for approve UI: pending</summary>
+    public string Status { get; set; } = null!;
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionStatusEvent.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/TvLoginSessionStatusEvent.cs
@@ -1,0 +1,12 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+/// <summary>SignalR payload for <c>TvLoginSessionStatusChanged</c> on /api/hubs/tv-login.</summary>
+public sealed class TvLoginSessionStatusEvent
+{
+    public Guid SessionId { get; set; }
+
+    /// <summary>pending | viewed | approved | denied | expired | consumed</summary>
+    public string Status { get; set; } = null!;
+
+    public DateTimeOffset ExpiresAt { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/UserTvLoginSummaryResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Auth/Responses/UserTvLoginSummaryResponse.cs
@@ -1,0 +1,16 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+/// <summary>Per-user summary of TV device-linking usage (admin).</summary>
+public sealed class UserTvLoginSummaryResponse
+{
+    /// <summary>True if the user ever approved a TV login session (Approved or Consumed).</summary>
+    public bool HasUsedTvLogin { get; set; }
+
+    public int ApprovedOrConsumedCount { get; set; }
+
+    public DateTimeOffset? LastUsedAt { get; set; }
+
+    public string? LastDeviceName { get; set; }
+
+    public string? LastClient { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Dto/FreeTierEnforcementCandidateDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Dto/FreeTierEnforcementCandidateDto.cs
@@ -16,6 +16,9 @@ public sealed class FreeTierEnforcementCandidateDto
     public bool IsMergedAccount { get; set; }
     public bool IsChannelSubscribed { get; set; }
 
+    /// <summary>Identity link providers for this user (e.g. google, local, telegram), lower-case.</summary>
+    public List<string> IdentityProviders { get; set; } = [];
+
     public bool IsConnected { get; set; }
     public int? VpnServerId { get; set; }
     public string? VpnServerName { get; set; }

--- a/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Enums/FreeTierChannelSubscribeRemindChannel.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Enums/FreeTierChannelSubscribeRemindChannel.cs
@@ -1,0 +1,8 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+
+/// <summary>Admin-triggered channel-subscribe reminder delivery channel.</summary>
+public enum FreeTierChannelSubscribeRemindChannel
+{
+    Telegram = 1,
+    Email = 2,
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Responses/FreeTierChannelSubscribeRemindResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Responses/FreeTierChannelSubscribeRemindResponse.cs
@@ -1,0 +1,45 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+
+/// <summary>Result of an admin force channel-subscribe reminder (Telegram DM or email).</summary>
+public sealed class FreeTierChannelSubscribeRemindResponse
+{
+    public bool Success { get; set; }
+
+    public string Message { get; set; } = string.Empty;
+
+    public FreeTierChannelSubscribeRemindChannel Channel { get; set; }
+
+    public int? UserId { get; set; }
+
+    public long? TelegramId { get; set; }
+
+    public string? Email { get; set; }
+
+    public static FreeTierChannelSubscribeRemindResponse Ok(
+        FreeTierChannelSubscribeRemindChannel channel,
+        string message,
+        int? userId = null,
+        long? telegramId = null,
+        string? email = null)
+        => new()
+        {
+            Success = true,
+            Message = message,
+            Channel = channel,
+            UserId = userId,
+            TelegramId = telegramId,
+            Email = email,
+        };
+
+    public static FreeTierChannelSubscribeRemindResponse Fail(
+        FreeTierChannelSubscribeRemindChannel channel,
+        string message)
+        => new()
+        {
+            Success = false,
+            Message = message,
+            Channel = channel,
+        };
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Responses/FreeTierUnsubscribedVpnDigestResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/FreeTierEnforcement/Responses/FreeTierUnsubscribedVpnDigestResponse.cs
@@ -1,0 +1,13 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+
+namespace DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+
+/// <summary>
+/// Preformatted admin Telegram digest plus structured candidates (for inline email buttons, etc.).
+/// </summary>
+public sealed class FreeTierUnsubscribedVpnDigestResponse
+{
+    public string Text { get; set; } = string.Empty;
+
+    public List<FreeTierEnforcementCandidateDto> Candidates { get; set; } = [];
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceDbQueriesResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceDbQueriesResponse.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Performance;
+
+public class PerformanceDbQueriesResponse
+{
+    public List<PerformanceDbQueryEntryDto> Items { get; set; } = [];
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceDbQueryEntryDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceDbQueryEntryDto.cs
@@ -1,0 +1,18 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Performance;
+
+public class PerformanceDbQueryEntryDto
+{
+    public DateTimeOffset TimestampUtc { get; set; }
+
+    public string? RequestId { get; set; }
+
+    public long DurationMs { get; set; }
+
+    public string CommandType { get; set; } = string.Empty;
+
+    public string Sql { get; set; } = string.Empty;
+
+    public bool Succeeded { get; set; }
+
+    public string? ExceptionMessage { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceHttpRequestEntryDto.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceHttpRequestEntryDto.cs
@@ -1,0 +1,20 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Performance;
+
+public class PerformanceHttpRequestEntryDto
+{
+    public DateTimeOffset TimestampUtc { get; set; }
+
+    public string RequestId { get; set; } = string.Empty;
+
+    public string Method { get; set; } = string.Empty;
+
+    public string Path { get; set; } = string.Empty;
+
+    public int StatusCode { get; set; }
+
+    public long DurationMs { get; set; }
+
+    public string? UserName { get; set; }
+
+    public string? TraceId { get; set; }
+}

--- a/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceHttpRequestsResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateMonitor/Performance/PerformanceHttpRequestsResponse.cs
@@ -1,0 +1,6 @@
+namespace DataGateMonitor.SharedModels.DataGateMonitor.Performance;
+
+public class PerformanceHttpRequestsResponse
+{
+    public List<PerformanceHttpRequestEntryDto> Items { get; set; } = [];
+}

--- a/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Info/RootOpenVpnInfoResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateOpenVpnManager/Info/RootOpenVpnInfoResponse.cs
@@ -6,5 +6,7 @@ public class RootOpenVpnInfoResponse
     public string Environment { get; set; } = string.Empty;
     public string Application { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+    /// <summary>Public WAN IP as seen from the node (best-effort).</summary>
+    public string? PublicIp { get; set; }
     public ConfigInfoResponse Config { get; set; } = new();
 }

--- a/DataGateMonitor.SharedModels/DataGateXRayManager/Info/RootXrayInfoResponse.cs
+++ b/DataGateMonitor.SharedModels/DataGateXRayManager/Info/RootXrayInfoResponse.cs
@@ -6,5 +6,7 @@ public class RootXrayInfoResponse
     public string Environment { get; set; } = string.Empty;
     public string Application { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+    /// <summary>Public WAN IP as seen from the node (best-effort).</summary>
+    public string? PublicIp { get; set; }
     public ConfigInfoResponse Config { get; set; } = new();
 }

--- a/DataGateMonitor.Tests/Configuration/LocalizationTextSeedDataTests.cs
+++ b/DataGateMonitor.Tests/Configuration/LocalizationTextSeedDataTests.cs
@@ -41,6 +41,17 @@ public class LocalizationTextSeedDataTests
         Assert.Contains("{accountLabel}", text);
     }
 
+    [Theory]
+    [InlineData(Language.English)]
+    [InlineData(Language.Greek)]
+    [InlineData(Language.Russian)]
+    public void VpnServerNotAllowedByQuotaPlan_exists_for_each_language(Language language)
+    {
+        var text = GetText("VpnServerNotAllowedByQuotaPlan", language);
+
+        Assert.False(string.IsNullOrWhiteSpace(text));
+    }
+
     [Fact]
     public void Seed_has_unique_ids()
     {

--- a/DataGateMonitor.Tests/Configurations/MiddlewareConfigurationTests.cs
+++ b/DataGateMonitor.Tests/Configurations/MiddlewareConfigurationTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using DataGateMonitor.Configurations;
+using DataGateMonitor.Services.Performance;
+using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace DataGateMonitor.Tests.Configurations;
@@ -12,6 +15,9 @@ public class MiddlewareConfigurationTests
     {
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddRouting();
+        builder.Services.AddLogging();
+        builder.Services.AddSingleton(Mock.Of<IPerformanceSampleStore>());
+        builder.Services.AddSingleton(Options.Create(new PerformanceMonitoringOptions()));
         var app = builder.Build();
         app.UseRouting();
 

--- a/DataGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
+++ b/DataGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
@@ -4,6 +4,7 @@ using DataGateMonitor.Configurations;
 using DataGateMonitor.Services.Api.Interfaces;
 using DataGateMonitor.Services.BackgroundServices.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
 using DataGateMonitor.Services.QuotaPlans;
@@ -43,6 +44,8 @@ public class ServiceConfigurationTests
         AssertRegistered(services, typeof(IOpenVpnBackgroundService));
         AssertRegistered(services, typeof(IVpnServerOvpnFileConfigService));
         AssertRegistered(services, typeof(IExternalIpAddressService));
+        AssertRegistered(services, typeof(IVpnNodePublicIpLookup));
+        AssertRegistered(services, typeof(IVpnServerClientPresenceService));
         AssertRegistered(services, typeof(IUserService));
         AssertRegistered(services, typeof(IQuotaPlanService));
         AssertRegistered(services, typeof(IUserRoleManagementService));

--- a/DataGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
+++ b/DataGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
@@ -56,6 +56,8 @@ public class ServiceConfigurationTests
         AssertRegistered(services, typeof(IOpenVpnProxyTrafficFlowSupportChecker));
         AssertRegistered(services, typeof(IOpenVpnProxyTrafficFlowClientFactory));
         AssertRegistered(services, typeof(IStatusCacheGenerationService));
+        AssertRegistered(services, typeof(IRedisDatabaseProvider));
+        AssertRegistered(services, typeof(IConnectedClientsCounterStore));
         AssertRegistered(services, typeof(IStatusStreamLogStore));
     }
 

--- a/DataGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
+++ b/DataGateMonitor.Tests/Configurations/ServiceConfigurationTests.cs
@@ -15,6 +15,8 @@ using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.StatusStreamLogs;
+using DataGateMonitor.Services.Performance;
+using DataGateMonitor.Data.Interceptors;
 using DataGateMonitor.Services.XrayNode;
 using Xunit;
 
@@ -59,6 +61,8 @@ public class ServiceConfigurationTests
         AssertRegistered(services, typeof(IRedisDatabaseProvider));
         AssertRegistered(services, typeof(IConnectedClientsCounterStore));
         AssertRegistered(services, typeof(IStatusStreamLogStore));
+        AssertRegistered(services, typeof(IPerformanceSampleStore));
+        AssertRegistered(services, typeof(SlowDbCommandInterceptor));
     }
 
     private static void AssertRegistered(IServiceCollection services, Type serviceType)

--- a/DataGateMonitor.Tests/Controllers/AdminEmailBroadcastControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/AdminEmailBroadcastControllerTests.cs
@@ -1,0 +1,205 @@
+using System.Security.Claims;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses;
+using DataGateMonitor.SharedModels.DataGateMonitor.EmailBroadcast.Responses.Dto;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class AdminEmailBroadcastControllerTests
+{
+    [Fact]
+    public async Task GetHistory_ReturnsPagedPayload()
+    {
+        var request = new GetSentEmailHistoryRequest { Page = 1, PageSize = 20 };
+        var broadcast = new Mock<IAdminEmailBroadcastService>();
+        broadcast.Setup(s => s.GetHistoryAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetSentEmailHistoryResponse
+            {
+                Page = 1,
+                PageSize = 20,
+                TotalCount = 1,
+                Items = [new SentEmailLogDto { Id = 3, Subject = "Hello" }]
+            });
+
+        var controller = CreateController(broadcast.Object, Mock.Of<IAdminEmailTemplateService>());
+        var result = await controller.GetHistory(request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<GetSentEmailHistoryResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal(3, Assert.Single(payload.Data!.Items).Id);
+    }
+
+    [Fact]
+    public async Task Send_PassesCurrentUserId_AndReturnsOk()
+    {
+        var request = new SendAdminEmailRequest { Subject = "Subj", HtmlBody = "<p>Hi</p>" };
+        var broadcast = new Mock<IAdminEmailBroadcastService>();
+        broadcast.Setup(s => s.SendAsync(request, 77, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SendAdminEmailResponse { Attempted = 2, Succeeded = 2, Failed = 0 });
+
+        var controller = CreateController(broadcast.Object, Mock.Of<IAdminEmailTemplateService>(), userId: 77);
+        var result = await controller.Send(request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<SendAdminEmailResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal(2, payload.Data!.Succeeded);
+        broadcast.Verify(s => s.SendAsync(request, 77, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Send_WhenArgumentException_ReturnsBadRequest()
+    {
+        var request = new SendAdminEmailRequest { Subject = "", HtmlBody = "" };
+        var broadcast = new Mock<IAdminEmailBroadcastService>();
+        broadcast.Setup(s => s.SendAsync(request, It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("Subject is required."));
+
+        var controller = CreateController(broadcast.Object, Mock.Of<IAdminEmailTemplateService>());
+        var result = await controller.Send(request, CancellationToken.None);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<SendAdminEmailResponse>>(bad.Value);
+        Assert.False(payload.Success);
+        Assert.Equal("Subject is required.", payload.Message);
+    }
+
+    [Fact]
+    public async Task ListTemplates_ReturnsSummaries()
+    {
+        var templates = new Mock<IAdminEmailTemplateService>();
+        templates.Setup(s => s.ListSummariesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetEmailTemplatesResponse
+            {
+                Items = [new EmailBroadcastTemplateSummaryDto { Id = 1, Name = "Welcome", Subject = "Hi" }]
+            });
+
+        var controller = CreateController(Mock.Of<IAdminEmailBroadcastService>(), templates.Object);
+        var result = await controller.ListTemplates(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<GetEmailTemplatesResponse>>(ok.Value);
+        Assert.Equal("Welcome", Assert.Single(payload.Data!.Items).Name);
+    }
+
+    [Fact]
+    public async Task GetTemplate_WhenMissing_ReturnsNotFound()
+    {
+        var templates = new Mock<IAdminEmailTemplateService>();
+        templates.Setup(s => s.GetByIdAsync(9, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EmailBroadcastTemplateDto?)null);
+
+        var controller = CreateController(Mock.Of<IAdminEmailBroadcastService>(), templates.Object);
+        var result = await controller.GetTemplate(9, CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GetTemplate_WhenFound_ReturnsOk()
+    {
+        var templates = new Mock<IAdminEmailTemplateService>();
+        templates.Setup(s => s.GetByIdAsync(4, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EmailBroadcastTemplateDto { Id = 4, Name = "Promo", Subject = "Deal" });
+
+        var controller = CreateController(Mock.Of<IAdminEmailBroadcastService>(), templates.Object);
+        var result = await controller.GetTemplate(4, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<EmailBroadcastTemplateDto>>(ok.Value);
+        Assert.Equal(4, payload.Data!.Id);
+    }
+
+    [Fact]
+    public async Task CreateTemplate_PassesCreatedByUserId()
+    {
+        var request = new CreateEmailTemplateRequest
+        {
+            Name = "N",
+            Subject = "S",
+            HtmlBody = "<b>x</b>"
+        };
+        var templates = new Mock<IAdminEmailTemplateService>();
+        templates.Setup(s => s.CreateAsync(request, 12, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EmailBroadcastTemplateDto { Id = 8, Name = "N", CreatedByUserId = 12 });
+
+        var controller = CreateController(Mock.Of<IAdminEmailBroadcastService>(), templates.Object, userId: 12);
+        var result = await controller.CreateTemplate(request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<EmailBroadcastTemplateDto>>(ok.Value);
+        Assert.Equal(8, payload.Data!.Id);
+        templates.Verify(s => s.CreateAsync(request, 12, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateTemplate_WhenNotFound_ReturnsNotFound()
+    {
+        var request = new UpdateEmailTemplateRequest { Name = "N", Subject = "S", HtmlBody = "H" };
+        var templates = new Mock<IAdminEmailTemplateService>();
+        templates.Setup(s => s.UpdateAsync(3, request, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("Template not found."));
+
+        var controller = CreateController(Mock.Of<IAdminEmailBroadcastService>(), templates.Object);
+        var result = await controller.UpdateTemplate(3, request, CancellationToken.None);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<EmailBroadcastTemplateDto>>(notFound.Value);
+        Assert.False(payload.Success);
+    }
+
+    [Fact]
+    public async Task DeleteTemplate_DelegatesAndReturnsOk()
+    {
+        var templates = new Mock<IAdminEmailTemplateService>();
+        templates.Setup(s => s.DeleteAsync(6, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        var controller = CreateController(Mock.Of<IAdminEmailBroadcastService>(), templates.Object);
+        var result = await controller.DeleteTemplate(6, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<bool>>(ok.Value);
+        Assert.True(payload.Data);
+        templates.Verify(s => s.DeleteAsync(6, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteTemplate_WhenMissing_ReturnsNotFound()
+    {
+        var templates = new Mock<IAdminEmailTemplateService>();
+        templates.Setup(s => s.DeleteAsync(6, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("gone"));
+
+        var controller = CreateController(Mock.Of<IAdminEmailBroadcastService>(), templates.Object);
+        var result = await controller.DeleteTemplate(6, CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    private static AdminEmailBroadcastController CreateController(
+        IAdminEmailBroadcastService broadcast,
+        IAdminEmailTemplateService templates,
+        int? userId = null)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.Role, "Admin") };
+        if (userId is int id)
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, id.ToString()));
+
+        var controller = new AdminEmailBroadcastController(broadcast, templates);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "mock"))
+            }
+        };
+        return controller;
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/AuthControllerSessionAndTotpTests.cs
+++ b/DataGateMonitor.Tests/Controllers/AuthControllerSessionAndTotpTests.cs
@@ -1,0 +1,256 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+using DataGateMonitor.Services.Api.Auth.ForgotPassword;
+using DataGateMonitor.Services.Api.Auth.Login;
+using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.Api.Auth.TelegramLogin;
+using DataGateMonitor.Services.Api.Auth.Totp;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+using DataGateMonitor.Services.Api.CurrentUser.Interfaces;
+using DataGateMonitor.Services.Users.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.Extensions.Configuration;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class AuthControllerSessionAndTotpTests
+{
+    private readonly Mock<IApplicationService> _appService = new();
+    private readonly Mock<IMicroserviceTokenService> _microserviceTokenService = new();
+    private readonly Mock<IUserRegistrationService> _userRegistrationService = new();
+    private readonly Mock<IUserLoginService> _userLoginService = new();
+    private readonly Mock<IUserQueryService> _userQueryService = new();
+    private readonly Mock<IEmailConfirmationService> _emailConfirmationService = new();
+    private readonly Mock<ITelegramAccountLinkService> _telegramAccountLinkService = new();
+    private readonly Mock<IFreeTierAccessComplianceService> _freeTierComplianceService = new();
+    private readonly Mock<IGoogleAuthCodeExchangeService> _exchange = new();
+    private readonly Mock<ITokenService> _tokenService = new();
+    private readonly Mock<IAdminForgotPasswordService> _adminForgotPasswordService = new();
+    private readonly Mock<ITelegramLoginCodeService> _telegramLoginCodeService = new();
+    private readonly Mock<ITvLoginSessionService> _tvLoginSessionService = new();
+    private readonly Mock<IAdminTotpService> _adminTotpService = new();
+    private readonly Mock<ICurrentUserService> _currentUserService = new();
+    private readonly Mock<IAdminIdleSessionTracker> _adminIdleSessionTracker = new();
+    private readonly Mock<IUserSessionService> _userSessionService = new();
+
+    private AuthController CreateController(HttpContext? httpContext = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = "VeryStrongTestSecretKey1234567890",
+                ["Jwt:AdminIdleTimeoutMinutes"] = "20",
+            })
+            .Build();
+
+        var controller = new AuthController(
+            config,
+            _appService.Object,
+            _microserviceTokenService.Object,
+            _userRegistrationService.Object,
+            _userLoginService.Object,
+            _userQueryService.Object,
+            _emailConfirmationService.Object,
+            _telegramAccountLinkService.Object,
+            _freeTierComplianceService.Object,
+            _exchange.Object,
+            _tokenService.Object,
+            _adminForgotPasswordService.Object,
+            _telegramLoginCodeService.Object,
+            _tvLoginSessionService.Object,
+            _adminTotpService.Object,
+            _currentUserService.Object,
+            _adminIdleSessionTracker.Object,
+            _userSessionService.Object);
+
+        if (httpContext != null)
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        return controller;
+    }
+
+    [Fact]
+    public async Task ForgotPassword_DelegatesWithClientIp()
+    {
+        var http = new DefaultHttpContext();
+        http.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.10");
+        _adminForgotPasswordService
+            .Setup(s => s.RequestResetCodeAsync(
+                It.Is<AdminForgotPasswordRequest>(r => r.LoginOrEmail == "admin"),
+                "203.0.113.10",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AdminForgotPasswordResponse { Message = "sent" });
+
+        var controller = CreateController(http);
+        var result = await controller.ForgotPassword(
+            new AdminForgotPasswordRequest { LoginOrEmail = "admin" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<AdminForgotPasswordResponse>>(ok.Value);
+        Assert.Equal("sent", payload.Data!.Message);
+    }
+
+    [Fact]
+    public async Task ResetPassword_DelegatesToService()
+    {
+        _adminForgotPasswordService
+            .Setup(s => s.ResetPasswordAsync(
+                It.Is<AdminResetPasswordRequest>(r => r.Code == "ABC" && r.NewPassword == "n"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AdminResetPasswordResponse { Success = true, Message = "ok" });
+
+        var result = await CreateController().ResetPassword(
+            new AdminResetPasswordRequest { Code = "ABC", NewPassword = "n", ConfirmPassword = "n" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<ApiResponse<AdminResetPasswordResponse>>(ok.Value).Data!.Success);
+    }
+
+    [Fact]
+    public async Task TelegramCodeLogin_DelegatesToService()
+    {
+        _telegramLoginCodeService
+            .Setup(s => s.LoginWithCodeAsync(
+                It.Is<TelegramCodeLoginRequest>(r => r.Code == "ABCD1234"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LoginResponse { Token = "t" });
+
+        var result = await CreateController().TelegramCodeLogin(
+            new TelegramCodeLoginRequest { Code = "ABCD1234" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("t", Assert.IsType<ApiResponse<LoginResponse>>(ok.Value).Data!.Token);
+    }
+
+    [Fact]
+    public async Task Refresh_MapsTokenServiceResult()
+    {
+        var expires = DateTimeOffset.UtcNow.AddHours(1);
+        var refreshExpires = DateTimeOffset.UtcNow.AddDays(7);
+        _tokenService
+            .Setup(s => s.RefreshAsync("old-r", "dev", "ua", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair("access", expires, "new-r", refreshExpires));
+
+        var result = await CreateController().Refresh(
+            new RefreshRequest { RefreshToken = "old-r", DeviceId = "dev", UserAgent = "ua" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var data = Assert.IsType<ApiResponse<RefreshResponse>>(ok.Value).Data!;
+        Assert.Equal("access", data.Token);
+        Assert.Equal("new-r", data.RefreshToken);
+        Assert.Equal(expires, data.Expiration);
+    }
+
+    [Fact]
+    public async Task Logout_WithRefreshToken_RevokesAndReturnsOk()
+    {
+        var auth = new Mock<IAuthenticationService>();
+        auth.Setup(a => a.SignOutAsync(It.IsAny<HttpContext>(), "UserCookie", null))
+            .Returns(Task.CompletedTask);
+        var services = new ServiceCollection();
+        services.AddSingleton(auth.Object);
+        var http = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+
+        _userSessionService
+            .Setup(s => s.RevokeByRefreshTokenAsync("rt", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateController(http).Logout(
+            new RefreshRequest { RefreshToken = "rt" },
+            CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
+        _userSessionService.Verify(s => s.RevokeByRefreshTokenAsync("rt", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RevokeSession_ReturnsNoContent()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(5);
+        _userSessionService
+            .Setup(s => s.RevokeSessionAsync(5, 99, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateController().RevokeSession(99, CancellationToken.None);
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public async Task RevokeOtherSessions_PassesKeepRefreshToken()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(5);
+        _userSessionService
+            .Setup(s => s.RevokeSessionsAsync(5, "keep-me", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var result = await CreateController().RevokeOtherSessions(
+            new RevokeUserSessionsRequest { KeepRefreshToken = "keep-me" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(3, Assert.IsType<ApiResponse<int>>(ok.Value).Data);
+    }
+
+    [Fact]
+    public async Task GetSessions_UsesXRefreshTokenHeader()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(5);
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Refresh-Token"] = "hdr-rt";
+        _userSessionService
+            .Setup(s => s.GetActiveSessionsAsync(5, "hdr-rt", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetUserSessionsResponse { Sessions = [] });
+
+        var result = await CreateController(http).GetSessions(CancellationToken.None);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<ApiResponse<GetUserSessionsResponse>>(ok.Value).Success);
+    }
+
+    [Fact]
+    public async Task VerifyTotpLogin_DelegatesToAdminTotp()
+    {
+        _adminTotpService
+            .Setup(s => s.VerifyLoginChallengeAsync(
+                It.Is<TotpVerifyLoginRequest>(r => r.LoginChallengeId == "c1" && r.Code == "123456"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LoginResponse { Token = "totp-t" });
+
+        var result = await CreateController().VerifyTotpLogin(
+            new TotpVerifyLoginRequest { LoginChallengeId = "c1", Code = "123456" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("totp-t", Assert.IsType<ApiResponse<LoginResponse>>(ok.Value).Data!.Token);
+    }
+
+    [Fact]
+    public async Task BeginTotpSetup_ReturnsSetupForCurrentUser()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(5);
+        _adminTotpService
+            .Setup(s => s.BeginSetupAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TotpSetupResponse
+            {
+                SharedSecret = "sec",
+                OtpAuthUri = "otpauth://",
+                Issuer = "DataGate",
+                AccountName = "admin"
+            });
+
+        var result = await CreateController().BeginTotpSetup(CancellationToken.None);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("sec", Assert.IsType<ApiResponse<TotpSetupResponse>>(ok.Value).Data!.SharedSecret);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/AuthControllerSessionAndTotpTests.cs
+++ b/DataGateMonitor.Tests/Controllers/AuthControllerSessionAndTotpTests.cs
@@ -253,4 +253,104 @@ public class AuthControllerSessionAndTotpTests
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal("sec", Assert.IsType<ApiResponse<TotpSetupResponse>>(ok.Value).Data!.SharedSecret);
     }
+
+    [Fact]
+    public async Task Register_DelegatesToUserRegistrationService()
+    {
+        _userRegistrationService
+            .Setup(s => s.RegisterAsync(
+                It.Is<RegisterUserRequest>(r => r.Login == "newuser"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RegisterUserResponse
+            {
+                UserId = 11,
+                DisplayName = "New",
+                Email = "n@ex.com",
+                HasDashboardAccess = true
+            });
+
+        var result = await CreateController().Register(
+            new RegisterUserRequest
+            {
+                DisplayName = "New",
+                Email = "n@ex.com",
+                Login = "newuser",
+                Password = "p",
+                ConfirmPassword = "p"
+            },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal(11, Assert.IsType<ApiResponse<RegisterUserResponse>>(ok.Value).Data!.UserId);
+    }
+
+    [Fact]
+    public async Task GoogleCodeLogin_WhenRequestNull_ReturnsBadRequest()
+    {
+        var result = await CreateController().GoogleCodeLogin(null!, CancellationToken.None);
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task GoogleCodeLogin_ExchangesCodeThenLogsIn()
+    {
+        _exchange
+            .Setup(e => e.ExchangeCodeForIdTokenAsync("code", "verifier", "https://app/cb", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("id-token");
+        _userLoginService
+            .Setup(s => s.LoginWithGoogleAsync("id-token", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GoogleLoginResponse { Token = "g-tok", UserId = 3 });
+
+        var result = await CreateController().GoogleCodeLogin(
+            new GoogleCodeLoginRequest
+            {
+                Code = "code",
+                CodeVerifier = "verifier",
+                RedirectUri = "https://app/cb"
+            },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("g-tok", Assert.IsType<ApiResponse<GoogleLoginResponse>>(ok.Value).Data!.Token);
+        _exchange.VerifyAll();
+        _userLoginService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ConfirmTotpSetup_DelegatesForCurrentUser()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(5);
+        _adminTotpService
+            .Setup(s => s.ConfirmSetupAsync(
+                5,
+                It.Is<TotpConfirmRequest>(r => r.Code == "123456"),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateController().ConfirmTotpSetup(
+            new TotpConfirmRequest { Code = "123456" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Contains("enabled", Assert.IsType<ApiResponse<string>>(ok.Value).Data);
+    }
+
+    [Fact]
+    public async Task DisableTotp_DelegatesForCurrentUser()
+    {
+        _currentUserService.Setup(s => s.UserId).Returns(5);
+        _adminTotpService
+            .Setup(s => s.DisableAsync(
+                5,
+                It.Is<TotpDisableRequest>(r => r.Code == "123456" && r.Password == "pw"),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await CreateController().DisableTotp(
+            new TotpDisableRequest { Code = "123456", Password = "pw" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Contains("disabled", Assert.IsType<ApiResponse<string>>(ok.Value).Data);
+    }
 }

--- a/DataGateMonitor.Tests/Controllers/AuthControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/AuthControllerTests.cs
@@ -8,6 +8,7 @@ using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.TelegramLogin;
 using DataGateMonitor.Services.Api.Auth.Totp;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
 using DataGateMonitor.Services.Api.CurrentUser.Interfaces;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -33,6 +34,7 @@ public class AuthControllerTests
     private readonly Mock<ITokenService> _tokenService = new();
     private readonly Mock<IAdminForgotPasswordService> _adminForgotPasswordService = new();
     private readonly Mock<ITelegramLoginCodeService> _telegramLoginCodeService = new();
+    private readonly Mock<ITvLoginSessionService> _tvLoginSessionService = new();
     private readonly Mock<IAdminTotpService> _adminTotpService = new();
     private readonly Mock<ICurrentUserService> _currentUserService = new();
     private readonly Mock<IAdminIdleSessionTracker> _adminIdleSessionTracker = new();
@@ -62,6 +64,7 @@ public class AuthControllerTests
             _tokenService.Object,
             _adminForgotPasswordService.Object,
             _telegramLoginCodeService.Object,
+            _tvLoginSessionService.Object,
             _adminTotpService.Object,
             _currentUserService.Object,
             _adminIdleSessionTracker.Object,

--- a/DataGateMonitor.Tests/Controllers/AuthControllerTvLoginTests.cs
+++ b/DataGateMonitor.Tests/Controllers/AuthControllerTvLoginTests.cs
@@ -1,0 +1,164 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+/// <summary>TV device-linking endpoints on <see cref="AuthController"/>.</summary>
+public class AuthControllerTvLoginTests
+{
+    private readonly Mock<ITvLoginSessionService> _tv = new();
+
+    private AuthController CreateController()
+    {
+        // Reuse the full AuthController constructor via AuthControllerTests helpers would be heavy;
+        // build a minimal controller through the existing test factory pattern.
+        return AuthControllerTvTestFactory.Create(_tv);
+    }
+
+    [Fact]
+    public async Task CreateTvLoginSession_NullBody_UsesEmptyRequest_AndReturnsOk()
+    {
+        var created = new CreateTvLoginSessionResponse
+        {
+            SessionId = Guid.NewGuid(),
+            UserCode = "123456",
+            VerificationUrl = "https://dash.datagateapp.com/tv/link",
+            QrPayload = "https://dash.datagateapp.com/tv/link?code=123456",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            PollIntervalSeconds = 2,
+            SignalRHubPath = "/api/hubs/tv-login",
+        };
+        _tv.Setup(s => s.CreateSessionAsync(
+                It.IsAny<CreateTvLoginSessionRequest>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(created);
+
+        var controller = CreateController();
+        var result = await controller.CreateTvLoginSession(null, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var envelope = Assert.IsType<ApiResponse<CreateTvLoginSessionResponse>>(ok.Value);
+        Assert.True(envelope.Success);
+        Assert.Equal("123456", envelope.Data!.UserCode);
+        Assert.Equal("/api/hubs/tv-login", envelope.Data.SignalRHubPath);
+    }
+
+    [Fact]
+    public async Task PollTvLoginSession_ReturnsStatusEnvelope()
+    {
+        var sessionId = Guid.NewGuid();
+        _tv.Setup(s => s.PollSessionAsync(sessionId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TvLoginSessionPollResponse
+            {
+                Status = "viewed",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(3),
+            });
+
+        var controller = CreateController();
+        var result = await controller.PollTvLoginSession(sessionId, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var envelope = Assert.IsType<ApiResponse<TvLoginSessionPollResponse>>(ok.Value);
+        Assert.Equal("viewed", envelope.Data!.Status);
+    }
+
+    [Fact]
+    public async Task GetTvLoginSessionByCode_WhenOk_ReturnsPreview()
+    {
+        _tv.Setup(s => s.GetByUserCodeAsync("123456", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TvLoginSessionPreviewResponse
+            {
+                SessionId = Guid.NewGuid(),
+                UserCode = "123456",
+                Status = "pending",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(2),
+            });
+
+        var controller = CreateController();
+        var result = await controller.GetTvLoginSessionByCode("123456", CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(((ApiResponse<TvLoginSessionPreviewResponse>)ok.Value!).Success);
+    }
+
+    [Fact]
+    public async Task GetTvLoginSessionByCode_WhenNotFound_Returns404()
+    {
+        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(TvLoginSessionService.SessionNotFoundMessage));
+
+        var controller = CreateController();
+        var result = await controller.GetTvLoginSessionByCode("000000", CancellationToken.None);
+
+        var notFound = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.False(((ApiResponse<TvLoginSessionPreviewResponse>)notFound.Value!).Success);
+    }
+
+    [Fact]
+    public async Task GetTvLoginSessionByCode_WhenExpired_Returns410()
+    {
+        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(TvLoginSessionService.SessionExpiredMessage));
+
+        var controller = CreateController();
+        var result = await controller.GetTvLoginSessionByCode("111111", CancellationToken.None);
+
+        var gone = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status410Gone, gone.StatusCode);
+    }
+
+    [Fact]
+    public async Task ApproveTvLoginSession_DelegatesToService()
+    {
+        _tv.Setup(s => s.ApproveAsync(
+                It.IsAny<ApproveTvLoginSessionRequest>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TvLoginSessionActionResponse { Status = "approved" });
+
+        var controller = CreateController();
+        AuthControllerTvTestFactory.SetCurrentUserId(controller, 42);
+
+        var result = await controller.ApproveTvLoginSession(
+            new ApproveTvLoginSessionRequest { UserCode = "123456" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("approved", ((ApiResponse<TvLoginSessionActionResponse>)ok.Value!).Data!.Status);
+        _tv.Verify(s => s.ApproveAsync(
+            It.Is<ApproveTvLoginSessionRequest>(r => r.UserCode == "123456"),
+            42,
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DenyTvLoginSession_DelegatesToService()
+    {
+        _tv.Setup(s => s.DenyAsync(
+                It.IsAny<DenyTvLoginSessionRequest>(),
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TvLoginSessionActionResponse { Status = "denied" });
+
+        var controller = CreateController();
+        AuthControllerTvTestFactory.SetCurrentUserId(controller, 7);
+
+        var result = await controller.DenyTvLoginSession(
+            new DenyTvLoginSessionRequest { SessionId = Guid.NewGuid() },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("denied", ((ApiResponse<TvLoginSessionActionResponse>)ok.Value!).Data!.Status);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/AuthControllerTvLoginTests.cs
+++ b/DataGateMonitor.Tests/Controllers/AuthControllerTvLoginTests.cs
@@ -29,8 +29,8 @@ public class AuthControllerTvLoginTests
         {
             SessionId = Guid.NewGuid(),
             UserCode = "123456",
-            VerificationUrl = "https://dash.datagateapp.com/tv/link",
-            QrPayload = "https://dash.datagateapp.com/tv/link?code=123456",
+            VerificationUrl = "https://tv-link.test/tv/link",
+            QrPayload = "https://tv-link.test/tv/link?code=123456",
             ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
             PollIntervalSeconds = 2,
             SignalRHubPath = "/api/hubs/tv-login",

--- a/DataGateMonitor.Tests/Controllers/AuthControllerTvLoginTests.cs
+++ b/DataGateMonitor.Tests/Controllers/AuthControllerTvLoginTests.cs
@@ -73,7 +73,7 @@ public class AuthControllerTvLoginTests
     [Fact]
     public async Task GetTvLoginSessionByCode_WhenOk_ReturnsPreview()
     {
-        _tv.Setup(s => s.GetByUserCodeAsync("123456", It.IsAny<CancellationToken>()))
+        _tv.Setup(s => s.GetByUserCodeAsync("123456", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TvLoginSessionPreviewResponse
             {
                 SessionId = Guid.NewGuid(),
@@ -92,7 +92,7 @@ public class AuthControllerTvLoginTests
     [Fact]
     public async Task GetTvLoginSessionByCode_WhenNotFound_Returns404()
     {
-        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException(TvLoginSessionService.SessionNotFoundMessage));
 
         var controller = CreateController();
@@ -105,7 +105,7 @@ public class AuthControllerTvLoginTests
     [Fact]
     public async Task GetTvLoginSessionByCode_WhenExpired_Returns410()
     {
-        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException(TvLoginSessionService.SessionExpiredMessage));
 
         var controller = CreateController();
@@ -160,5 +160,80 @@ public class AuthControllerTvLoginTests
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
         Assert.Equal("denied", ((ApiResponse<TvLoginSessionActionResponse>)ok.Value!).Data!.Status);
+    }
+
+    [Fact]
+    public async Task GetTvLoginSessionByCode_WhenDenied_Returns410()
+    {
+        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(TvLoginSessionService.SessionDeniedMessage));
+
+        var controller = CreateController();
+        var result = await controller.GetTvLoginSessionByCode("111111", CancellationToken.None);
+
+        var gone = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status410Gone, gone.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTvLoginSessionByCode_WhenRateLimited_Returns429()
+    {
+        _tv.Setup(s => s.GetByUserCodeAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(TvLoginSessionService.RateLimitMessage));
+
+        var controller = CreateController();
+        var result = await controller.GetTvLoginSessionByCode("111111", CancellationToken.None);
+
+        var tooMany = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, tooMany.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateTvLoginSession_ForwardsRemoteIpAddress()
+    {
+        _tv.Setup(s => s.CreateSessionAsync(
+                It.IsAny<CreateTvLoginSessionRequest>(),
+                "203.0.113.10",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateTvLoginSessionResponse
+            {
+                SessionId = Guid.NewGuid(),
+                UserCode = "123456",
+                VerificationUrl = "https://tv-link.test/tv/link",
+                QrPayload = "https://tv-link.test/tv/link?code=123456",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            });
+
+        var controller = CreateController();
+        controller.HttpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.10");
+
+        await controller.CreateTvLoginSession(new CreateTvLoginSessionRequest(), CancellationToken.None);
+
+        _tv.Verify(s => s.CreateSessionAsync(
+            It.IsAny<CreateTvLoginSessionRequest>(),
+            "203.0.113.10",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void TvLoginEndpoints_HaveExpectedAuthAttributes()
+    {
+        var type = typeof(AuthController);
+
+        Assert.NotNull(type.GetMethod(nameof(AuthController.CreateTvLoginSession))!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute), true)
+            .FirstOrDefault());
+        Assert.NotNull(type.GetMethod(nameof(AuthController.PollTvLoginSession))!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute), true)
+            .FirstOrDefault());
+        Assert.NotNull(type.GetMethod(nameof(AuthController.GetTvLoginSessionByCode))!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), true)
+            .FirstOrDefault());
+        Assert.NotNull(type.GetMethod(nameof(AuthController.ApproveTvLoginSession))!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), true)
+            .FirstOrDefault());
+        Assert.NotNull(type.GetMethod(nameof(AuthController.DenyTvLoginSession))!
+            .GetCustomAttributes(typeof(Microsoft.AspNetCore.Authorization.AuthorizeAttribute), true)
+            .FirstOrDefault());
     }
 }

--- a/DataGateMonitor.Tests/Controllers/AuthControllerTvTestFactory.cs
+++ b/DataGateMonitor.Tests/Controllers/AuthControllerTvTestFactory.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+using DataGateMonitor.Services.Api.Auth.ForgotPassword;
+using DataGateMonitor.Services.Api.Auth.Login;
+using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.Api.Auth.TelegramLogin;
+using DataGateMonitor.Services.Api.Auth.Totp;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+using DataGateMonitor.Services.Api.CurrentUser.Interfaces;
+using DataGateMonitor.Services.Users.Interfaces;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+internal static class AuthControllerTvTestFactory
+{
+    public static AuthController Create(Mock<ITvLoginSessionService> tvLogin)
+    {
+        var currentUser = new Mock<ICurrentUserService>();
+        currentUser.SetupGet(c => c.UserId).Returns(1);
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = "VeryStrongTestSecretKey1234567890",
+                ["Jwt:AdminIdleTimeoutMinutes"] = "20",
+            })
+            .Build();
+
+        var controller = new AuthController(
+            config,
+            Mock.Of<IApplicationService>(),
+            Mock.Of<IMicroserviceTokenService>(),
+            Mock.Of<IUserRegistrationService>(),
+            Mock.Of<IUserLoginService>(),
+            Mock.Of<IUserQueryService>(),
+            Mock.Of<IEmailConfirmationService>(),
+            Mock.Of<ITelegramAccountLinkService>(),
+            Mock.Of<IFreeTierAccessComplianceService>(),
+            Mock.Of<IGoogleAuthCodeExchangeService>(),
+            Mock.Of<ITokenService>(),
+            Mock.Of<IAdminForgotPasswordService>(),
+            Mock.Of<ITelegramLoginCodeService>(),
+            tvLogin.Object,
+            Mock.Of<IAdminTotpService>(),
+            currentUser.Object,
+            Mock.Of<IAdminIdleSessionTracker>(),
+            Mock.Of<IUserSessionService>());
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
+
+        // Stash current-user mock for SetCurrentUserId
+        controller.HttpContext.Items["__currentUserMock"] = currentUser;
+        return controller;
+    }
+
+    public static void SetCurrentUserId(AuthController controller, int userId)
+    {
+        var mock = (Mock<ICurrentUserService>)controller.HttpContext.Items["__currentUserMock"]!;
+        mock.SetupGet(c => c.UserId).Returns(userId);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
@@ -11,6 +11,13 @@ namespace DataGateMonitor.Tests.Controllers;
 
 public class FreeTierEnforcementControllerTests
 {
+    private static FreeTierEnforcementController CreateController(
+        Mock<IFreeTierEnforcementOverviewService> overview,
+        Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>? digest = null)
+        => new(
+            overview.Object,
+            (digest ?? new Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>()).Object);
+
     [Fact]
     public async Task GetCandidates_ReturnsServicePayload()
     {
@@ -32,7 +39,7 @@ public class FreeTierEnforcementControllerTests
                 ]
             });
 
-        var controller = new FreeTierEnforcementController(overview.Object);
+        var controller = CreateController(overview);
         var result = await controller.GetCandidates(CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
@@ -41,6 +48,23 @@ public class FreeTierEnforcementControllerTests
         Assert.Equal(1, payload.Data!.TotalCount);
         Assert.Equal(42, Assert.Single(payload.Data.Candidates).UserId);
         overview.Verify(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUnsubscribedVpnDigest_ReturnsDigestText()
+    {
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        var digest = new Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>();
+        digest.Setup(s => s.BuildDigestTextAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("digest-body");
+
+        var controller = CreateController(overview, digest);
+        var result = await controller.GetUnsubscribedVpnDigest(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<string>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal("digest-body", payload.Data);
     }
 
     [Fact]
@@ -70,7 +94,7 @@ public class FreeTierEnforcementControllerTests
                 }
             });
 
-        var controller = new FreeTierEnforcementController(overview.Object);
+        var controller = CreateController(overview);
         var result = await controller.GetDisconnectLog(request, CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);

--- a/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
@@ -75,6 +75,7 @@ public class FreeTierEnforcementControllerTests
         Assert.True(payload.Success);
         Assert.Equal("digest-body", payload.Data!.Text);
         Assert.Equal(9, Assert.Single(payload.Data.Candidates).UserId);
+        digest.Verify(s => s.MarkDailyDigestSatisfiedForToday(), Times.Once);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
@@ -1,0 +1,82 @@
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Users.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class FreeTierEnforcementControllerTests
+{
+    [Fact]
+    public async Task GetCandidates_ReturnsServicePayload()
+    {
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        overview.Setup(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetFreeTierEnforcementCandidatesResponse
+            {
+                TotalCount = 1,
+                ConnectedCount = 1,
+                Candidates =
+                [
+                    new FreeTierEnforcementCandidateDto
+                    {
+                        UserId = 42,
+                        DisplayName = "free-user",
+                        IsConnected = true,
+                        VpnServerId = 7
+                    }
+                ]
+            });
+
+        var controller = new FreeTierEnforcementController(overview.Object);
+        var result = await controller.GetCandidates(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<GetFreeTierEnforcementCandidatesResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal(1, payload.Data!.TotalCount);
+        Assert.Equal(42, Assert.Single(payload.Data.Candidates).UserId);
+        overview.Verify(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetDisconnectLog_PassesRequest_AndReturnsEntries()
+    {
+        var request = new GetFreeTierDisconnectLogRequest { Page = 2, PageSize = 10 };
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        overview.Setup(s => s.GetDisconnectLogAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetFreeTierDisconnectLogResponse
+            {
+                Entries = new PagedResponse<FreeTierDisconnectLogEntryDto>
+                {
+                    Page = 2,
+                    PageSize = 10,
+                    TotalCount = 1,
+                    Items =
+                    [
+                        new FreeTierDisconnectLogEntryDto
+                        {
+                            Id = 9,
+                            UserId = 42,
+                            CommonName = "cn-free",
+                            VpnServerId = 7,
+                            KillSucceeded = true
+                        }
+                    ]
+                }
+            });
+
+        var controller = new FreeTierEnforcementController(overview.Object);
+        var result = await controller.GetDisconnectLog(request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<GetFreeTierDisconnectLogResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal(9, Assert.Single(payload.Data!.Entries.Items).Id);
+        overview.Verify(s => s.GetDisconnectLogAsync(request, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/FreeTierEnforcementControllerTests.cs
@@ -1,6 +1,7 @@
 using DataGateMonitor.Controllers;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using DataGateMonitor.SharedModels.Responses;
@@ -13,10 +14,12 @@ public class FreeTierEnforcementControllerTests
 {
     private static FreeTierEnforcementController CreateController(
         Mock<IFreeTierEnforcementOverviewService> overview,
-        Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>? digest = null)
+        Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>? digest = null,
+        Mock<IFreeTierUnsubscribedUserReminderService>? reminder = null)
         => new(
             overview.Object,
-            (digest ?? new Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>()).Object);
+            (digest ?? new Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>()).Object,
+            (reminder ?? new Mock<IFreeTierUnsubscribedUserReminderService>()).Object);
 
     [Fact]
     public async Task GetCandidates_ReturnsServicePayload()
@@ -47,24 +50,80 @@ public class FreeTierEnforcementControllerTests
         Assert.True(payload.Success);
         Assert.Equal(1, payload.Data!.TotalCount);
         Assert.Equal(42, Assert.Single(payload.Data.Candidates).UserId);
-        overview.Verify(s => s.GetCandidatesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task GetUnsubscribedVpnDigest_ReturnsDigestText()
+    public async Task GetUnsubscribedVpnDigest_ReturnsStructuredDigest()
     {
         var overview = new Mock<IFreeTierEnforcementOverviewService>();
         var digest = new Mock<IFreeTierUnsubscribedVpnUsersDailyDigestService>();
-        digest.Setup(s => s.BuildDigestTextAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("digest-body");
+        digest.Setup(s => s.BuildDigestAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierUnsubscribedVpnDigestResponse
+            {
+                Text = "digest-body",
+                Candidates =
+                [
+                    new FreeTierEnforcementCandidateDto { UserId = 9, Email = "a@b.c" },
+                ],
+            });
 
         var controller = CreateController(overview, digest);
         var result = await controller.GetUnsubscribedVpnDigest(CancellationToken.None);
 
         var ok = Assert.IsType<OkObjectResult>(result.Result);
-        var payload = Assert.IsType<ApiResponse<string>>(ok.Value);
+        var payload = Assert.IsType<ApiResponse<FreeTierUnsubscribedVpnDigestResponse>>(ok.Value);
         Assert.True(payload.Success);
-        Assert.Equal("digest-body", payload.Data);
+        Assert.Equal("digest-body", payload.Data!.Text);
+        Assert.Equal(9, Assert.Single(payload.Data.Candidates).UserId);
+    }
+
+    [Fact]
+    public async Task RemindChannelSubscribe_EmailChannel_ReturnsTypedResponse()
+    {
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        var reminder = new Mock<IFreeTierUnsubscribedUserReminderService>();
+        reminder.Setup(r => r.ForceRemindAsync(
+                "150",
+                FreeTierChannelSubscribeRemindChannel.Email,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FreeTierChannelSubscribeRemindResponse.Ok(
+                FreeTierChannelSubscribeRemindChannel.Email,
+                "✅ sent",
+                userId: 150,
+                email: "t@example.com"));
+
+        var controller = CreateController(overview, reminder: reminder);
+        var result = await controller.RemindChannelSubscribe(
+            "150",
+            FreeTierChannelSubscribeRemindChannel.Email,
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<FreeTierChannelSubscribeRemindResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal("t@example.com", payload.Data!.Email);
+    }
+
+    [Fact]
+    public async Task RemindChannelSubscribe_WhenFail_ReturnsBadRequest()
+    {
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        var reminder = new Mock<IFreeTierUnsubscribedUserReminderService>();
+        reminder.Setup(r => r.ForceRemindAsync(
+                "x",
+                FreeTierChannelSubscribeRemindChannel.Telegram,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FreeTierChannelSubscribeRemindResponse.Fail(
+                FreeTierChannelSubscribeRemindChannel.Telegram,
+                "bad id"));
+
+        var controller = CreateController(overview, reminder: reminder);
+        var result = await controller.RemindChannelSubscribe("x", ct: CancellationToken.None);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<FreeTierChannelSubscribeRemindResponse>>(bad.Value);
+        Assert.False(payload.Success);
+        Assert.Equal("bad id", payload.Message);
     }
 
     [Fact]
@@ -82,14 +141,7 @@ public class FreeTierEnforcementControllerTests
                     TotalCount = 1,
                     Items =
                     [
-                        new FreeTierDisconnectLogEntryDto
-                        {
-                            Id = 9,
-                            UserId = 42,
-                            CommonName = "cn-free",
-                            VpnServerId = 7,
-                            KillSucceeded = true
-                        }
+                        new FreeTierDisconnectLogEntryDto { Id = 9, UserId = 1 },
                     ]
                 }
             });
@@ -101,6 +153,5 @@ public class FreeTierEnforcementControllerTests
         var payload = Assert.IsType<ApiResponse<GetFreeTierDisconnectLogResponse>>(ok.Value);
         Assert.True(payload.Success);
         Assert.Equal(9, Assert.Single(payload.Data!.Entries.Items).Id);
-        overview.Verify(s => s.GetDisconnectLogAsync(request, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/DataGateMonitor.Tests/Controllers/MobileControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/MobileControllerTests.cs
@@ -1,0 +1,74 @@
+using System.Security.Claims;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.Mobile.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.Mobile.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.Mobile.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class MobileControllerTests
+{
+    [Fact]
+    public async Task AddAndroidInstallationId_ReturnsOk_WhenUserIdValid()
+    {
+        var devices = new Mock<IDeviceService>();
+        devices.Setup(d => d.AddAndroidInstallationId(
+                It.Is<InstallationIdRequest>(r => r.InstallationId == "install-1"),
+                42,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InstallationIdResponse
+            {
+                Application = new DeviceDto { InstallationId = "install-1" }
+            });
+
+        var controller = new MobileController(devices.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                        [new Claim(ClaimTypes.NameIdentifier, "42")],
+                        "mock"))
+                }
+            }
+        };
+
+        var result = await controller.AddAndroidInstallationId(
+            new InstallationIdRequest { InstallationId = "install-1" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<InstallationIdResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal("install-1", payload.Data!.Application.InstallationId);
+        devices.VerifyAll();
+    }
+
+    [Fact]
+    public async Task AddAndroidInstallationId_ReturnsUnauthorized_WhenUserIdMissing()
+    {
+        var devices = new Mock<IDeviceService>(MockBehavior.Strict);
+        var controller = new MobileController(devices.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity([], "mock"))
+                }
+            }
+        };
+
+        var result = await controller.AddAndroidInstallationId(
+            new InstallationIdRequest { InstallationId = "x" },
+            CancellationToken.None);
+
+        Assert.IsType<UnauthorizedObjectResult>(result.Result);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/MobileCrashIngestControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/MobileCrashIngestControllerTests.cs
@@ -126,4 +126,69 @@ public class MobileCrashIngestControllerTests
         var status = Assert.IsType<ObjectResult>(second);
         Assert.Equal(StatusCodes.Status429TooManyRequests, status.StatusCode);
     }
+
+    [Fact]
+    public async Task Recent_WhenLimitNonPositive_ReturnsBadRequest()
+    {
+        var controller = CreateController(new CrashIngestOptions { RecentMaxLimit = 100 }, out _);
+        var result = await controller.Recent(0, CancellationToken.None);
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Recent_ClampsLimitAndReturnsServiceResult()
+    {
+        var controller = CreateController(new CrashIngestOptions { RecentMaxLimit = 10 }, out var ingest);
+        ingest.Setup(s => s.GetRecentAsync(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new DataGateMonitor.SharedModels.DataGateMonitor.MobileCrashIngest.Dto.RecentCrashReportDto
+                {
+                    Id = 1,
+                    AppProcess = "com.example",
+                    FileName = "a.txt"
+                }
+            ]);
+
+        var result = await controller.Recent(500, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IReadOnlyList<DataGateMonitor.SharedModels.DataGateMonitor.MobileCrashIngest.Dto.RecentCrashReportDto>>(ok.Value);
+        Assert.Single(list);
+        ingest.Verify(s => s.GetRecentAsync(10, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Ingest_WhenHttpsRequiredOverHttp_ReturnsBadRequest()
+    {
+        var controller = CreateController(new CrashIngestOptions { RequireHttps = true }, out _);
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                Scheme = "http",
+                ContentType = "text/plain; charset=utf-8",
+                Body = new MemoryStream(Encoding.UTF8.GetBytes("x")),
+            },
+        };
+        context.Request.Headers["X-Crash-Filename"] = "f.txt";
+        context.Request.Headers["X-Crash-Process"] = "com.imkolganov.datagate.dev";
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+
+        var result = await controller.Ingest(CancellationToken.None);
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Ingest_WhenAuthTokenMismatch_ReturnsUnauthorized()
+    {
+        var controller = CreateController(
+            new CrashIngestOptions { RequireHttps = true, AuthToken = "secret" },
+            out _);
+        AttachHttpsRequest(controller, "process=com.imkolganov.datagate.dev\n\nstack");
+        controller.ControllerContext.HttpContext.Request.Headers["X-Crash-Token"] = "wrong";
+
+        var result = await controller.Ingest(CancellationToken.None);
+        Assert.IsType<UnauthorizedResult>(result);
+    }
 }

--- a/DataGateMonitor.Tests/Controllers/PerformanceControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/PerformanceControllerTests.cs
@@ -1,0 +1,56 @@
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Performance;
+using DataGateMonitor.SharedModels.DataGateMonitor.Performance;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class PerformanceControllerTests
+{
+    [Fact]
+    public async Task GetHttpRequests_Maps_Store_Samples()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.GetHttpLatestAsync(50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new PerformanceHttpSample
+                {
+                    TimestampUtc = DateTimeOffset.Parse("2026-01-01T00:00:00Z"),
+                    RequestId = "abc",
+                    Method = "GET",
+                    Path = "/api/x",
+                    StatusCode = 200,
+                    DurationMs = 250,
+                    UserName = "admin",
+                    TraceId = "t1"
+                }
+            ]);
+
+        var controller = new PerformanceController(store.Object);
+        var result = await controller.GetHttpRequests(50, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<PerformanceHttpRequestsResponse>>(ok.Value);
+        var item = Assert.Single(payload.Data!.Items);
+        Assert.Equal("abc", item.RequestId);
+        Assert.Equal(250, item.DurationMs);
+        Assert.Equal("/api/x", item.Path);
+    }
+
+    [Fact]
+    public async Task ClearAll_Delegates_To_Store()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.ClearAllAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var controller = new PerformanceController(store.Object);
+
+        var result = await controller.ClearAll(CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        store.Verify(s => s.ClearAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/PerformanceControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/PerformanceControllerTests.cs
@@ -39,6 +39,40 @@ public class PerformanceControllerTests
         Assert.Equal("abc", item.RequestId);
         Assert.Equal(250, item.DurationMs);
         Assert.Equal("/api/x", item.Path);
+        Assert.Equal("admin", item.UserName);
+        Assert.Equal("t1", item.TraceId);
+    }
+
+    [Fact]
+    public async Task GetDbQueries_Maps_Store_Samples()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.GetDbLatestAsync(25, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new PerformanceDbSample
+                {
+                    TimestampUtc = DateTimeOffset.Parse("2026-01-02T00:00:00Z"),
+                    RequestId = "req-db",
+                    DurationMs = 180,
+                    CommandType = "Text",
+                    Sql = "SELECT 1",
+                    Succeeded = false,
+                    ExceptionMessage = "timeout"
+                }
+            ]);
+
+        var controller = new PerformanceController(store.Object);
+        var result = await controller.GetDbQueries(25, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<PerformanceDbQueriesResponse>>(ok.Value);
+        var item = Assert.Single(payload.Data!.Items);
+        Assert.Equal("req-db", item.RequestId);
+        Assert.Equal(180, item.DurationMs);
+        Assert.Equal("SELECT 1", item.Sql);
+        Assert.False(item.Succeeded);
+        Assert.Equal("timeout", item.ExceptionMessage);
     }
 
     [Fact]
@@ -52,5 +86,33 @@ public class PerformanceControllerTests
 
         Assert.IsType<OkObjectResult>(result.Result);
         store.Verify(s => s.ClearAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ClearHttp_Delegates_To_Store()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.ClearHttpAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var controller = new PerformanceController(store.Object);
+
+        var result = await controller.ClearHttp(CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        store.Verify(s => s.ClearHttpAsync(It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.ClearDbAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ClearDb_Delegates_To_Store()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.ClearDbAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        var controller = new PerformanceController(store.Object);
+
+        var result = await controller.ClearDb(CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        store.Verify(s => s.ClearDbAsync(It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(s => s.ClearHttpAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/DataGateMonitor.Tests/Controllers/TvLoginSessionsAdminControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/TvLoginSessionsAdminControllerTests.cs
@@ -1,0 +1,68 @@
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class TvLoginSessionsAdminControllerTests
+{
+    [Fact]
+    public async Task List_ReturnsSessionsFromService()
+    {
+        var sessionId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var admin = new Mock<ITvLoginAdminService>();
+        admin.Setup(s => s.ListAsync(99, "approved", 5, 25, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetAdminTvLoginSessionsResponse
+            {
+                TotalCount = 1,
+                Sessions =
+                [
+                    new AdminTvLoginSessionDto
+                    {
+                        SessionId = sessionId,
+                        UserCode = "123456",
+                        Status = "approved",
+                        ApprovedUserId = 99
+                    }
+                ]
+            });
+
+        var controller = new TvLoginSessionsAdminController(admin.Object);
+        var result = await controller.List(99, "approved", 5, 25, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<GetAdminTvLoginSessionsResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.Equal(1, payload.Data!.TotalCount);
+        Assert.Equal(sessionId, Assert.Single(payload.Data.Sessions).SessionId);
+        admin.Verify(s => s.ListAsync(99, "approved", 5, 25, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetUserSummary_ReturnsServicePayload()
+    {
+        var admin = new Mock<ITvLoginAdminService>();
+        admin.Setup(s => s.GetUserSummaryAsync(15, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserTvLoginSummaryResponse
+            {
+                HasUsedTvLogin = true,
+                ApprovedOrConsumedCount = 3,
+                LastDeviceName = "Living Room TV",
+                LastClient = "android-tv"
+            });
+
+        var controller = new TvLoginSessionsAdminController(admin.Object);
+        var result = await controller.GetUserSummary(15, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<UserTvLoginSummaryResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.True(payload.Data!.HasUsedTvLogin);
+        Assert.Equal(3, payload.Data.ApprovedOrConsumedCount);
+        Assert.Equal("Living Room TV", payload.Data.LastDeviceName);
+        admin.Verify(s => s.GetUserSummaryAsync(15, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/VpnDnsQueryControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnDnsQueryControllerTests.cs
@@ -118,6 +118,60 @@ public class VpnDnsQueryControllerTests
         Assert.Equal(12, envelope.Data.Items[0].UniqueUsersCount);
     }
 
+    [Fact]
+    public async Task ProfileSummary_MergesIssuedFilesWithDnsCounts()
+    {
+        var issued = new Mock<IIssuedOvpnFileQueryService>();
+        issued.Setup(x => x.GetAllByExternalId("ext-9", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new IssuedOvpnFile
+                {
+                    CommonName = "cn-a",
+                    VpnServerId = 3,
+                    ExternalId = "ext-9",
+                    IsRevoked = false
+                }
+            ]);
+
+        var queryService = new Mock<IVpnDnsQueryLogQueryService>();
+        queryService.Setup(x => x.GetProfileSummaryAsync(
+                "ext-9",
+                It.Is<IReadOnlyList<string>>(cns => cns.Contains("cn-a")),
+                3,
+                null,
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new DataGateMonitor.SharedModels.DataGateMonitor.VpnDnsQuery.Dto.VpnDnsProfileSummaryItemDto
+                {
+                    CommonName = "cn-a",
+                    VpnServerId = 3,
+                    QueryCount = 44,
+                    LastQueriedAtUtc = DateTimeOffset.Parse("2026-02-01T00:00:00Z")
+                }
+            ]);
+
+        var controller = new VpnDnsQueryController(queryService.Object, issued.Object);
+        controller.ControllerContext = AdminContext();
+
+        var result = await controller.ProfileSummary(
+            "ext-9",
+            vpnServerId: 3,
+            fromUtc: null,
+            toUtc: null,
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var envelope = Assert.IsType<ApiResponse<IReadOnlyList<DataGateMonitor.SharedModels.DataGateMonitor.VpnDnsQuery.Dto.VpnDnsProfileSummaryItemDto>>>(ok.Value);
+        Assert.True(envelope.Success);
+        var item = Assert.Single(envelope.Data!);
+        Assert.Equal("cn-a", item.CommonName);
+        Assert.Equal(44, item.QueryCount);
+        Assert.False(item.IsRevoked);
+    }
+
     private static ControllerContext AdminContext() => new()
     {
         HttpContext = new DefaultHttpContext

--- a/DataGateMonitor.Tests/Controllers/VpnProfileNotificationPreferencesControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnProfileNotificationPreferencesControllerTests.cs
@@ -1,0 +1,65 @@
+using DataGateMonitor.Controllers;
+using DataGateMonitor.Services.Others.Notifications;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnProfileNotificationPreferences;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class VpnProfileNotificationPreferencesControllerTests
+{
+    [Fact]
+    public async Task Get_ReturnsServicePayload()
+    {
+        var prefs = new Mock<IVpnProfileNotificationPreferenceService>();
+        prefs.Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetVpnProfileNotificationPreferencesResponse { Preferences = [] });
+
+        var controller = new VpnProfileNotificationPreferencesController(prefs.Object);
+        var result = await controller.Get(CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var payload = Assert.IsType<ApiResponse<GetVpnProfileNotificationPreferencesResponse>>(ok.Value);
+        Assert.True(payload.Success);
+        Assert.NotNull(payload.Data!.Preferences);
+        prefs.Verify(p => p.GetAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Put_UpdatesThenReturnsCurrentPreferences()
+    {
+        var request = new PutVpnProfileNotificationPreferencesRequest();
+        var prefs = new Mock<IVpnProfileNotificationPreferenceService>();
+        prefs.Setup(p => p.UpdateAsync(request, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        prefs.Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetVpnProfileNotificationPreferencesResponse { Preferences = [] });
+
+        var controller = new VpnProfileNotificationPreferencesController(prefs.Object);
+        var result = await controller.Put(request, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<ApiResponse<GetVpnProfileNotificationPreferencesResponse>>(ok.Value).Success);
+        prefs.Verify(p => p.UpdateAsync(request, It.IsAny<CancellationToken>()), Times.Once);
+        prefs.Verify(p => p.GetAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetAllCategories_EnablesAllThenReturnsPreferences()
+    {
+        var prefs = new Mock<IVpnProfileNotificationPreferenceService>();
+        prefs.Setup(p => p.SetAllPreferencesEnabledAsync(true, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        prefs.Setup(p => p.GetAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetVpnProfileNotificationPreferencesResponse { Preferences = [] });
+
+        var controller = new VpnProfileNotificationPreferencesController(prefs.Object);
+        var result = await controller.SetAllCategories(
+            new SetAllVpnProfileNotificationCategoriesRequest { Enabled = true },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<ApiResponse<GetVpnProfileNotificationPreferencesResponse>>(ok.Value).Success);
+        prefs.Verify(p => p.SetAllPreferencesEnabledAsync(true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/VpnServerOvpnFileConfigControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServerOvpnFileConfigControllerTests.cs
@@ -60,23 +60,30 @@ public class VpnServerOvpnFileConfigControllerTests
     public async Task AddOrUpdateOvpnFileConfig_ReturnsOkResult_WithExpectedData()
     {
         // Arrange
+        using var cts = new CancellationTokenSource();
         var request = new AddOrUpdateOvpnFileConfigRequest
         {
             VpnServerId = 1,
             VpnServerIp = "5.6.7.8",
             VpnServerPort = 443,
             ConfigTemplate = "custom-template",
-            AutoDetectServerSettings = true
+            AutoDetectServerSettings = false
         };
 
         var expectedConfig = request.Adapt<VpnServerOvpnFileConfig>();
 
         _serviceMock.Setup(s => s.AddOrUpdateVpnServerOvpnFileConfigByServerId(
-                It.Is<VpnServerOvpnFileConfig>(c => c.VpnServerId == request.VpnServerId), true, It.IsAny<CancellationToken>()))
+                It.Is<VpnServerOvpnFileConfig>(c =>
+                    c.VpnServerId == request.VpnServerId &&
+                    c.VpnServerIp == request.VpnServerIp &&
+                    c.VpnServerPort == request.VpnServerPort &&
+                    c.ConfigTemplate == request.ConfigTemplate),
+                request.AutoDetectServerSettings,
+                cts.Token))
             .ReturnsAsync(expectedConfig);
 
         // Act
-        var result = await _controller.AddOrUpdateOvpnFileConfig(request, CancellationToken.None);
+        var result = await _controller.AddOrUpdateOvpnFileConfig(request, cts.Token);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
@@ -90,5 +97,70 @@ public class VpnServerOvpnFileConfigControllerTests
         Assert.Equal(request.VpnServerPort, data.VpnServerPort);
         Assert.Equal(request.ConfigTemplate, data.ConfigTemplate);
 
+        _statusCacheGenerationServiceMock.Verify(s => s.Bump(), Times.Once);
+        _serviceMock.VerifyAll();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task AddOrUpdateOvpnFileConfig_ReturnsBadRequest_WhenVpnServerIdIsNotPositive(int vpnServerId)
+    {
+        // Arrange
+        var request = new AddOrUpdateOvpnFileConfigRequest
+        {
+            VpnServerId = vpnServerId,
+            VpnServerIp = "5.6.7.8",
+            VpnServerPort = 443,
+            ConfigTemplate = "custom-template"
+        };
+
+        // Act
+        var result = await _controller.AddOrUpdateOvpnFileConfig(request, CancellationToken.None);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<OvpnFileConfigResponse>>(badRequest.Value);
+
+        Assert.False(response.Success);
+        Assert.Equal("VpnServerId must be greater than 0.", response.Message);
+        Assert.Null(response.Data);
+        _serviceMock.Verify(s => s.AddOrUpdateVpnServerOvpnFileConfigByServerId(
+            It.IsAny<VpnServerOvpnFileConfig>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _statusCacheGenerationServiceMock.Verify(s => s.Bump(), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public async Task AddOrUpdateOvpnFileConfig_ReturnsBadRequest_WhenVpnServerIpIsMissing(string? vpnServerIp)
+    {
+        // Arrange
+        var request = new AddOrUpdateOvpnFileConfigRequest
+        {
+            VpnServerId = 1,
+            VpnServerIp = vpnServerIp!,
+            VpnServerPort = 443,
+            ConfigTemplate = "custom-template"
+        };
+
+        // Act
+        var result = await _controller.AddOrUpdateOvpnFileConfig(request, CancellationToken.None);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        var response = Assert.IsType<ApiResponse<OvpnFileConfigResponse>>(badRequest.Value);
+
+        Assert.False(response.Success);
+        Assert.Equal("VpnServerIp is required.", response.Message);
+        Assert.Null(response.Data);
+        _serviceMock.Verify(s => s.AddOrUpdateVpnServerOvpnFileConfigByServerId(
+            It.IsAny<VpnServerOvpnFileConfig>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _statusCacheGenerationServiceMock.Verify(s => s.Bump(), Times.Never);
     }
 }

--- a/DataGateMonitor.Tests/Controllers/VpnServerOvpnFileConfigControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServerOvpnFileConfigControllerTests.cs
@@ -60,7 +60,6 @@ public class VpnServerOvpnFileConfigControllerTests
     public async Task AddOrUpdateOvpnFileConfig_ReturnsOkResult_WithExpectedData()
     {
         // Arrange
-        using var cts = new CancellationTokenSource();
         var request = new AddOrUpdateOvpnFileConfigRequest
         {
             VpnServerId = 1,
@@ -79,11 +78,11 @@ public class VpnServerOvpnFileConfigControllerTests
                     c.VpnServerPort == request.VpnServerPort &&
                     c.ConfigTemplate == request.ConfigTemplate),
                 request.AutoDetectServerSettings,
-                cts.Token))
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedConfig);
 
         // Act
-        var result = await _controller.AddOrUpdateOvpnFileConfig(request, cts.Token);
+        var result = await _controller.AddOrUpdateOvpnFileConfig(request, CancellationToken.None);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);

--- a/DataGateMonitor.Tests/Controllers/VpnServerXrayNodeControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServerXrayNodeControllerTests.cs
@@ -1,0 +1,96 @@
+using System.Security.Claims;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Handlers.Interfaces;
+using DataGateMonitor.Services.XrayNode;
+using DataGateMonitor.SharedModels.DataGateMonitor.XrayNode.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.XrayNode.Responses;
+using DataGateMonitor.SharedModels.Enums;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class VpnServerXrayNodeControllerTests
+{
+    [Fact]
+    public async Task KickUser_ReturnsOk_ForXrayServer()
+    {
+        var (controller, xrayClient) = CreateController(new VpnServer
+        {
+            Id = 11,
+            ServerName = "xray",
+            ApiUrl = "https://xray.example/",
+            ServerType = VpnServerType.Xray
+        });
+
+        var result = await controller.KickUser(
+            11,
+            new XrayNodeUserActionRequest { CommonName = "cn-1" },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<ApiResponse<XrayNodeUserActionResponse>>(ok.Value).Success);
+        xrayClient.Verify(c => c.KickUserAsync("https://xray.example", "cn-1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableUser_ReturnsBadRequest_WhenNotXray()
+    {
+        var (controller, xrayClient) = CreateController(new VpnServer
+        {
+            Id = 11,
+            ServerName = "ovpn",
+            ApiUrl = "https://ovpn.example/",
+            ServerType = VpnServerType.OpenVpn
+        });
+
+        var result = await controller.DisableUser(
+            11,
+            new XrayNodeUserActionRequest { CommonName = "cn-1" },
+            CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+        xrayClient.Verify(
+            c => c.DisableUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static (VpnServerXrayNodeController Controller, Mock<IXrayNodeApiClient> Client) CreateController(
+        VpnServer server)
+    {
+        var query = new Mock<IVpnServerQueryService>();
+        query.Setup(q => q.GetById(server.Id, It.IsAny<CancellationToken>())).ReturnsAsync(server);
+
+        var access = new Mock<IVpnServerAccessQueryService>();
+        var client = new Mock<IXrayNodeApiClient>();
+        client.Setup(c => c.KickUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        client.Setup(c => c.DisableUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var controller = new VpnServerXrayNodeController(
+            query.Object,
+            client.Object,
+            access.Object,
+            NullLogger<VpnServerXrayNodeController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                        [new Claim(ClaimTypes.Role, "Admin")],
+                        "mock"))
+                }
+            }
+        };
+
+        return (controller, client);
+    }
+}

--- a/DataGateMonitor.Tests/Controllers/VpnServersControllerAddUpdateExoticTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServersControllerAddUpdateExoticTests.cs
@@ -53,7 +53,8 @@ public class VpnServersControllerAddUpdateExoticTests
             new ApiMemoryCacheService(new MemoryCache(new MemoryCacheOptions())),
             _statusCacheGeneration.Object,
             _statusStreamLogStore.Object,
-            _postSetup.Object);
+            _postSetup.Object,
+            Mock.Of<IConnectedClientsCounterStore>());
         _controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext

--- a/DataGateMonitor.Tests/Controllers/VpnServersControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServersControllerTests.cs
@@ -63,7 +63,8 @@ public class VpnServersControllerTests
             _cache,
             _statusCacheGeneration.Object,
             _statusStreamLogStore.Object,
-            _vpnServerPostSetupService.Object);
+            _vpnServerPostSetupService.Object,
+            Mock.Of<IConnectedClientsCounterStore>());
         SetUserAsAdmin(_controller);
     }
 

--- a/DataGateMonitor.Tests/Controllers/VpnServersV2ControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServersV2ControllerTests.cs
@@ -41,7 +41,8 @@ public class VpnServersV2ControllerTests
             _userQuotaPlan.Object,
             _quotaAllowed.Object,
             _cache,
-            _statusCacheGeneration.Object)
+            _statusCacheGeneration.Object,
+            Mock.Of<IConnectedClientsCounterStore>())
         {
             ControllerContext = new ControllerContext
             {

--- a/DataGateMonitor.Tests/Controllers/VpnServersV3ControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/VpnServersV3ControllerTests.cs
@@ -40,7 +40,8 @@ public class VpnServersV3ControllerTests
             _quotaAllowed.Object,
             _quotaPlanQuery.Object,
             _cache,
-            _statusCacheGeneration.Object)
+            _statusCacheGeneration.Object,
+            Mock.Of<IConnectedClientsCounterStore>())
         {
             ControllerContext = new ControllerContext
             {

--- a/DataGateMonitor.Tests/Controllers/WindowsCrashIngestControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/WindowsCrashIngestControllerTests.cs
@@ -120,4 +120,68 @@ public class WindowsCrashIngestControllerTests
         var status = Assert.IsType<ObjectResult>(second);
         Assert.Equal(StatusCodes.Status429TooManyRequests, status.StatusCode);
     }
+
+    [Fact]
+    public async Task Ingest_WhenPayloadTooLarge_ReturnsPayloadTooLarge()
+    {
+        var controller = CreateController(new WindowsCrashIngestOptions { MaxPayloadBytes = 32 }, out _);
+        AttachHttpsRequest(controller, new string('A', 64));
+
+        var result = await controller.Ingest(CancellationToken.None);
+
+        var status = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, status.StatusCode);
+    }
+
+    [Fact]
+    public async Task Recent_WhenLimitNonPositive_ReturnsBadRequest()
+    {
+        var controller = CreateController(new WindowsCrashIngestOptions { RecentMaxLimit = 100 }, out _);
+        var result = await controller.Recent(0, CancellationToken.None);
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Recent_ClampsLimitAndReturnsServiceResult()
+    {
+        var controller = CreateController(new WindowsCrashIngestOptions { RecentMaxLimit = 10 }, out var ingest);
+        ingest.Setup(s => s.GetRecentAsync(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new DataGateMonitor.SharedModels.DataGateMonitor.WindowsCrashIngest.Dto.RecentWindowsCrashReportDto
+                {
+                    Id = 2,
+                    AppProcess = "com.example.win",
+                    FileName = "w.txt"
+                }
+            ]);
+
+        var result = await controller.Recent(500, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var list = Assert.IsAssignableFrom<IReadOnlyList<DataGateMonitor.SharedModels.DataGateMonitor.WindowsCrashIngest.Dto.RecentWindowsCrashReportDto>>(ok.Value);
+        Assert.Single(list);
+        ingest.Verify(s => s.GetRecentAsync(10, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Ingest_WhenHttpsRequiredOverHttp_ReturnsBadRequest()
+    {
+        var controller = CreateController(new WindowsCrashIngestOptions { RequireHttps = true }, out _);
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                Scheme = "http",
+                ContentType = "text/plain; charset=utf-8",
+                Body = new MemoryStream(Encoding.UTF8.GetBytes("x")),
+            },
+        };
+        context.Request.Headers["X-Crash-Filename"] = "f.txt";
+        context.Request.Headers["X-Crash-Process"] = "com.imkolganov.datagate.win";
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+
+        var result = await controller.Ingest(CancellationToken.None);
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
 }

--- a/DataGateMonitor.Tests/Controllers/XrayClientLinksControllerTests.cs
+++ b/DataGateMonitor.Tests/Controllers/XrayClientLinksControllerTests.cs
@@ -1,0 +1,95 @@
+using System.Security.Claims;
+using DataGateMonitor.Controllers;
+using DataGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Handlers.Interfaces;
+using DataGateMonitor.Services.DataGateXRayManager.ClientLinks;
+using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses;
+using DataGateMonitor.SharedModels.Responses;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Controllers;
+
+public class XrayClientLinksControllerTests
+{
+    private readonly Mock<IXrayClientLinkService> _service = new();
+    private readonly Mock<IUserQuotaPlanQueryService> _userQuotaPlan = new();
+    private readonly Mock<IQuotaPlanAllowedServerQueryService> _quotaAllowed = new();
+    private readonly Mock<IVpnServerAccessQueryService> _vpnAccess = new();
+    private readonly XrayClientLinksController _controller;
+
+    public XrayClientLinksControllerTests()
+    {
+        _controller = new XrayClientLinksController(
+            _service.Object,
+            NullLogger<XrayClientLinksController>.Instance,
+            _userQuotaPlan.Object,
+            _quotaAllowed.Object,
+            _vpnAccess.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(
+                        [new Claim(ClaimTypes.Role, "Admin")],
+                        "mock"))
+                }
+            }
+        };
+    }
+
+    [Fact]
+    public async Task GetByToken_ReturnsBadRequest_WhenTokenEmpty()
+    {
+        var result = await _controller.GetByToken(new ByTokenRequest { Token = "  " }, CancellationToken.None);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.False(Assert.IsType<ApiResponse<OvpnFileResponse>>(bad.Value).Success);
+    }
+
+    [Fact]
+    public async Task GetAllByVpnServerId_ReturnsOk()
+    {
+        _service.Setup(s => s.GetAllByVpnServerId(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<IssuedXrayClientLink>());
+
+        var result = await _controller.GetAllByVpnServerId(
+            new ByVpnServerIdRequest { VpnServerId = 5 },
+            CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<ApiResponse<OvpnFilesResponse>>(ok.Value).Success);
+    }
+
+    [Fact]
+    public async Task GetByToken_ReturnsOk()
+    {
+        _service.Setup(s => s.GetByToken("tkn", It.IsAny<CancellationToken>(), It.IsAny<bool>()))
+            .ReturnsAsync(new IssuedXrayClientLink { VpnServerId = 5, CommonName = "cn" });
+
+        var result = await _controller.GetByToken(new ByTokenRequest { Token = "tkn" }, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True(Assert.IsType<ApiResponse<OvpnFileResponse>>(ok.Value).Success);
+    }
+
+    [Fact]
+    public async Task AddFile_ReturnsBadRequest_OnException()
+    {
+        _service.Setup(s => s.AddClientLink(It.IsAny<AddFileRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await _controller.AddFile(
+            new AddFileRequest { CommonName = "cn", VpnServerId = 1 },
+            CancellationToken.None);
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.False(Assert.IsType<ApiResponse<OvpnFileResponse>>(bad.Value).Success);
+    }
+}

--- a/DataGateMonitor.Tests/Data/Interceptors/SlowDbCommandInterceptorTests.cs
+++ b/DataGateMonitor.Tests/Data/Interceptors/SlowDbCommandInterceptorTests.cs
@@ -1,0 +1,190 @@
+using System.Data;
+using System.Data.Common;
+using DataGateMonitor.Data.Interceptors;
+using DataGateMonitor.Services.Performance;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Data.Interceptors;
+
+public class SlowDbCommandInterceptorTests
+{
+    [Fact]
+    public async Task Record_When_Slow_Appends_Sample_With_RequestId_And_Truncated_Sql()
+    {
+        var tcs = new TaskCompletionSource<PerformanceDbSample>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendDbAsync(It.IsAny<PerformanceDbSample>(), It.IsAny<CancellationToken>()))
+            .Callback<PerformanceDbSample, CancellationToken>((s, _) => tcs.TrySetResult(s))
+            .Returns(Task.CompletedTask);
+
+        var interceptor = new SlowDbCommandInterceptor(
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { DbSlowMs = 50, SqlMaxLength = 64 }),
+            NullLogger<SlowDbCommandInterceptor>.Instance);
+
+        PerformanceRequestContext.RequestId = "req-1";
+        try
+        {
+            var command = new FakeDbCommand(new string('x', 120));
+            interceptor.Record(command, TimeSpan.FromMilliseconds(120), succeeded: true, exception: null);
+
+            var recorded = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            Assert.Equal("req-1", recorded.RequestId);
+            Assert.True(recorded.Succeeded);
+            Assert.Equal(120, recorded.DurationMs);
+            Assert.EndsWith("…", recorded.Sql);
+            Assert.Equal(65, recorded.Sql.Length);
+        }
+        finally
+        {
+            PerformanceRequestContext.RequestId = null;
+        }
+    }
+
+    [Fact]
+    public async Task Record_When_Failed_Appends_Even_If_Fast()
+    {
+        var tcs = new TaskCompletionSource<PerformanceDbSample>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendDbAsync(It.IsAny<PerformanceDbSample>(), It.IsAny<CancellationToken>()))
+            .Callback<PerformanceDbSample, CancellationToken>((s, _) => tcs.TrySetResult(s))
+            .Returns(Task.CompletedTask);
+
+        var interceptor = new SlowDbCommandInterceptor(
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { DbSlowMs = 10_000 }),
+            NullLogger<SlowDbCommandInterceptor>.Instance);
+
+        interceptor.Record(
+            new FakeDbCommand("UPDATE x"),
+            TimeSpan.FromMilliseconds(1),
+            succeeded: false,
+            exception: new InvalidOperationException("boom"));
+
+        var recorded = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.False(recorded.Succeeded);
+        Assert.Equal("boom", recorded.ExceptionMessage);
+    }
+
+    [Fact]
+    public void Record_DoesNotAppend_When_Fast_And_Succeeded()
+    {
+        var store = new Mock<IPerformanceSampleStore>(MockBehavior.Strict);
+        var interceptor = new SlowDbCommandInterceptor(
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { DbSlowMs = 100 }),
+            NullLogger<SlowDbCommandInterceptor>.Instance);
+
+        interceptor.Record(
+            new FakeDbCommand("SELECT 1"),
+            TimeSpan.FromMilliseconds(5),
+            succeeded: true,
+            exception: null);
+
+        store.Verify(
+            s => s.AppendDbAsync(It.IsAny<PerformanceDbSample>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null, 10, "")]
+    [InlineData("abc", 10, "abc")]
+    [InlineData("abcdefghij", 5, "abcde…")]
+    public void Truncate_Respects_Max(string? input, int max, string expected)
+    {
+        Assert.Equal(expected, SlowDbCommandInterceptor.Truncate(input, max));
+    }
+
+    private sealed class FakeDbCommand(string commandText) : DbCommand
+    {
+        public override string CommandText { get; set; } = commandText;
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; } = CommandType.Text;
+        public override bool DesignTimeVisible { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        protected override DbConnection? DbConnection { get; set; }
+        protected override DbParameterCollection DbParameterCollection { get; } = new FakeParameterCollection();
+        protected override DbTransaction? DbTransaction { get; set; }
+
+        public override void Cancel()
+        {
+        }
+
+        public override int ExecuteNonQuery() => 0;
+        public override object? ExecuteScalar() => null;
+        public override void Prepare()
+        {
+        }
+
+        protected override DbParameter CreateDbParameter() => new FakeDbParameter();
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class FakeDbParameter : DbParameter
+    {
+        public override DbType DbType { get; set; }
+        public override ParameterDirection Direction { get; set; }
+        public override bool IsNullable { get; set; }
+        public override string ParameterName { get; set; } = string.Empty;
+        public override string SourceColumn { get; set; } = string.Empty;
+        public override object? Value { get; set; }
+        public override bool SourceColumnNullMapping { get; set; }
+        public override int Size { get; set; }
+        public override void ResetDbType()
+        {
+        }
+    }
+
+    private sealed class FakeParameterCollection : DbParameterCollection
+    {
+        public override int Count => 0;
+        public override object SyncRoot { get; } = new();
+        public override int Add(object value) => 0;
+        public override void AddRange(Array values)
+        {
+        }
+
+        public override void Clear()
+        {
+        }
+
+        public override bool Contains(object value) => false;
+        public override bool Contains(string value) => false;
+        public override void CopyTo(Array array, int index)
+        {
+        }
+
+        public override System.Collections.IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+        public override int IndexOf(object value) => -1;
+        public override int IndexOf(string parameterName) => -1;
+        public override void Insert(int index, object value)
+        {
+        }
+
+        public override void Remove(object value)
+        {
+        }
+
+        public override void RemoveAt(int index)
+        {
+        }
+
+        public override void RemoveAt(string parameterName)
+        {
+        }
+
+        protected override DbParameter GetParameter(int index) => throw new NotSupportedException();
+        protected override DbParameter GetParameter(string parameterName) => throw new NotSupportedException();
+        protected override void SetParameter(int index, DbParameter value)
+        {
+        }
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+        }
+    }
+}

--- a/DataGateMonitor.Tests/Data/Interceptors/SlowDbCommandInterceptorTests.cs
+++ b/DataGateMonitor.Tests/Data/Interceptors/SlowDbCommandInterceptorTests.cs
@@ -89,6 +89,28 @@ public class SlowDbCommandInterceptorTests
             Times.Never);
     }
 
+    [Fact]
+    public void Record_DoesNotThrow_When_Store_Throws()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendDbAsync(It.IsAny<PerformanceDbSample>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var interceptor = new SlowDbCommandInterceptor(
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { DbSlowMs = 1 }),
+            NullLogger<SlowDbCommandInterceptor>.Instance);
+
+        var ex = Record.Exception(() =>
+            interceptor.Record(
+                new FakeDbCommand("SELECT 1"),
+                TimeSpan.FromMilliseconds(50),
+                succeeded: true,
+                exception: null));
+
+        Assert.Null(ex);
+    }
+
     [Theory]
     [InlineData(null, 10, "")]
     [InlineData("abc", 10, "abc")]

--- a/DataGateMonitor.Tests/DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryServiceTests.cs
@@ -150,4 +150,65 @@ public class TvLoginSessionQueryServiceTests
         Assert.Equal(newer, latest!.Id);
         await ctx.DisposeAsync();
     }
+
+    [Fact]
+    public async Task GetById_WhenMissing_ReturnsNull()
+    {
+        var (q, ctx) = CreateEfBackedQuery([]);
+        var sut = new TvLoginSessionQueryService(q.Object);
+
+        Assert.Null(await sut.GetById(Guid.NewGuid(), CancellationToken.None));
+        await ctx.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AnyActiveByUserCode_TrueForOpenPending()
+    {
+        var (q, ctx) = CreateEfBackedQuery(
+        [
+            new TvLoginSession
+            {
+                Id = Guid.NewGuid(),
+                UserCode = "444444",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            }
+        ]);
+        var sut = new TvLoginSessionQueryService(q.Object);
+
+        Assert.True(await sut.AnyActiveByUserCode("444444", CancellationToken.None));
+        await ctx.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetActiveByUserCode_WhenTwoOpen_ReturnsNewest()
+    {
+        var older = Guid.NewGuid();
+        var newer = Guid.NewGuid();
+        var (q, ctx) = CreateEfBackedQuery(
+        [
+            new TvLoginSession
+            {
+                Id = older,
+                UserCode = "555555",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+                CreateDate = DateTimeOffset.UtcNow.AddMinutes(-5),
+            },
+            new TvLoginSession
+            {
+                Id = newer,
+                UserCode = "555555",
+                Status = TvLoginSessionStatus.Viewed,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+                CreateDate = DateTimeOffset.UtcNow,
+            },
+        ]);
+        var sut = new TvLoginSessionQueryService(q.Object);
+
+        var active = await sut.GetActiveByUserCode("555555", CancellationToken.None);
+
+        Assert.Equal(newer, active!.Id);
+        await ctx.DisposeAsync();
+    }
 }

--- a/DataGateMonitor.Tests/DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/TvLoginSessionTable/TvLoginSessionQueryServiceTests.cs
@@ -1,0 +1,153 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+using DataGateMonitor.Models;
+using Xunit;
+
+namespace DataGateMonitor.Tests.DataBase.Services.Query.TvLoginSessionTable;
+
+public class TvLoginSessionQueryServiceTests
+{
+    private sealed class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
+        public DbSet<TvLoginSession> TvLoginSessions => Set<TvLoginSession>();
+    }
+
+    private static (Mock<IQueryService<TvLoginSession, Guid>> q, TestDbContext ctx) CreateEfBackedQuery(
+        IEnumerable<TvLoginSession> data)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var ctx = new TestDbContext(options);
+        ctx.TvLoginSessions.AddRange(data);
+        ctx.SaveChanges();
+
+        var mock = new Mock<IQueryService<TvLoginSession, Guid>>();
+        mock.Setup(q => q.Query(It.IsAny<bool>(), It.IsAny<Expression<Func<TvLoginSession, object>>[]>()))
+            .Returns(ctx.TvLoginSessions.AsQueryable());
+        mock.Setup(q => q.FindById(
+                It.IsAny<Guid>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<Expression<Func<TvLoginSession, object>>[]>()))
+            .ReturnsAsync((Guid id, bool _, CancellationToken __, Expression<Func<TvLoginSession, object>>[] ___) =>
+                ctx.TvLoginSessions.FirstOrDefault(x => x.Id == id));
+        return (mock, ctx);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsEntity()
+    {
+        var id = Guid.NewGuid();
+        var (q, ctx) = CreateEfBackedQuery(
+        [
+            new TvLoginSession
+            {
+                Id = id,
+                UserCode = "123456",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            }
+        ]);
+        var sut = new TvLoginSessionQueryService(q.Object);
+
+        var result = await sut.GetById(id, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("123456", result!.UserCode);
+        await ctx.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetActiveByUserCode_ReturnsPendingOrViewed_NotExpiredOrConsumed()
+    {
+        var (q, ctx) = CreateEfBackedQuery(
+        [
+            new TvLoginSession
+            {
+                Id = Guid.NewGuid(),
+                UserCode = "111111",
+                Status = TvLoginSessionStatus.Consumed,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+                CreateDate = DateTimeOffset.UtcNow.AddMinutes(-2),
+            },
+            new TvLoginSession
+            {
+                Id = Guid.NewGuid(),
+                UserCode = "111111",
+                Status = TvLoginSessionStatus.Viewed,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+                CreateDate = DateTimeOffset.UtcNow.AddMinutes(-1),
+            },
+            new TvLoginSession
+            {
+                Id = Guid.NewGuid(),
+                UserCode = "111111",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                CreateDate = DateTimeOffset.UtcNow,
+            },
+        ]);
+        var sut = new TvLoginSessionQueryService(q.Object);
+
+        var active = await sut.GetActiveByUserCode("111111", CancellationToken.None);
+
+        Assert.NotNull(active);
+        Assert.Equal(TvLoginSessionStatus.Viewed, active!.Status);
+        await ctx.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AnyActiveByUserCode_TrueOnlyForOpenNonExpired()
+    {
+        var (q, ctx) = CreateEfBackedQuery(
+        [
+            new TvLoginSession
+            {
+                Id = Guid.NewGuid(),
+                UserCode = "222222",
+                Status = TvLoginSessionStatus.Denied,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            }
+        ]);
+        var sut = new TvLoginSessionQueryService(q.Object);
+
+        Assert.False(await sut.AnyActiveByUserCode("222222", CancellationToken.None));
+        await ctx.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetLatestByUserCode_ReturnsNewestRegardlessOfStatus()
+    {
+        var older = Guid.NewGuid();
+        var newer = Guid.NewGuid();
+        var (q, ctx) = CreateEfBackedQuery(
+        [
+            new TvLoginSession
+            {
+                Id = older,
+                UserCode = "333333",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+                CreateDate = DateTimeOffset.UtcNow.AddMinutes(-10),
+            },
+            new TvLoginSession
+            {
+                Id = newer,
+                UserCode = "333333",
+                Status = TvLoginSessionStatus.Expired,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+                CreateDate = DateTimeOffset.UtcNow,
+            },
+        ]);
+        var sut = new TvLoginSessionQueryService(q.Object);
+
+        var latest = await sut.GetLatestByUserCode("333333", CancellationToken.None);
+
+        Assert.Equal(newer, latest!.Id);
+        await ctx.DisposeAsync();
+    }
+}

--- a/DataGateMonitor.Tests/DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/UserIdentityLinkTable/UserIdentityLinkQueryServiceTests.cs
@@ -115,6 +115,36 @@ public class UserIdentityLinkQueryServiceTests
 
         Assert.NotNull(result);
         Assert.Equal(100, result!.UserId);
+        Assert.Equal(1, result.Id); // lowest Id when multiple links
+        await ctx.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetFirstByUserIds_ReturnsLowestIdLinkPerUser()
+    {
+        var data = CreateSample();
+        var (q, ctx) = CreateEfBackedQuery(data);
+        var sut = new UserIdentityLinkQueryService(q.Object);
+
+        var result = await sut.GetFirstByUserIds([100, 200, 404], CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[100].Id);
+        Assert.Equal("ext-1", result[100].ExternalId);
+        Assert.Equal(2, result[200].Id);
+        Assert.False(result.ContainsKey(404));
+        await ctx.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetFirstByUserIds_EmptyInput_ReturnsEmpty()
+    {
+        var (q, ctx) = CreateEfBackedQuery(CreateSample());
+        var sut = new UserIdentityLinkQueryService(q.Object);
+
+        var result = await sut.GetFirstByUserIds([], CancellationToken.None);
+
+        Assert.Empty(result);
         await ctx.DisposeAsync();
     }
 

--- a/DataGateMonitor.Tests/DataBase/Services/Query/UserTable/UserQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/UserTable/UserQueryServiceTests.cs
@@ -61,6 +61,39 @@ public partial class UserQueryServiceTests
     }
 
     [Fact]
+    public async Task GetByExternalIds_Batches_And_Picks_Lowest_Link_Id_Per_ExternalId()
+    {
+        var (sut, ctx) = CreateSutWithContext();
+        await ctx.Users.AddRangeAsync(
+            new User { Id = 1, DisplayName = "first", AvatarUrl = "a1" },
+            new User { Id = 2, DisplayName = "second", AvatarUrl = "a2" },
+            new User { Id = 3, DisplayName = "third" }
+        );
+        await ctx.UserIdentityLinks.AddRangeAsync(
+            new UserIdentityLink { Id = 20, Provider = "tg", ExternalId = "ext-dup", UserId = 2 },
+            new UserIdentityLink { Id = 10, Provider = "google", ExternalId = "ext-dup", UserId = 1 },
+            new UserIdentityLink { Id = 30, Provider = "tg", ExternalId = "ext-only", UserId = 3 }
+        );
+        await ctx.SaveChangesAsync();
+
+        var map = await sut.GetByExternalIds(["ext-dup", "ext-only", "missing", ""], CancellationToken.None);
+
+        Assert.Equal(2, map.Count);
+        Assert.Equal(1, map["ext-dup"].Id);
+        Assert.Equal("first", map["ext-dup"].DisplayName);
+        Assert.Equal(3, map["ext-only"].Id);
+        Assert.False(map.ContainsKey("missing"));
+    }
+
+    [Fact]
+    public async Task GetByExternalIds_Empty_Input_Returns_Empty_Map()
+    {
+        var (sut, _) = CreateSutWithContext();
+        var map = await sut.GetByExternalIds([], CancellationToken.None);
+        Assert.Empty(map);
+    }
+
+    [Fact]
     public async Task Paging_Works_With_Desc_Sort()
     {
         var (sut, ctx) = CreateSutWithContext();

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OpenVpnGeoQueryServiceTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OpenVpnGeoQueryServiceTests.cs
@@ -95,4 +95,55 @@ public class OpenVpnGeoQueryServiceTests
 
         await ctx.DisposeAsync();
     }
+
+    [Fact]
+    public async Task GetGeoPointsAsync_Clamps_Future_To_And_Excludes_Future_Sessions()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var data = new List<VpnServerClient>
+        {
+            new()
+            {
+                Id = 1,
+                VpnServerId = 1,
+                ExternalId = "e1",
+                ConnectedSince = now.AddMinutes(-30),
+                Country = "US",
+                Region = "CA",
+                Latitude = 1,
+                Longitude = 2,
+                BytesReceived = 10,
+                BytesSent = 20
+            },
+            new()
+            {
+                Id = 2,
+                VpnServerId = 1,
+                ExternalId = "e1",
+                ConnectedSince = now.AddHours(2),
+                Country = "US",
+                Region = "CA",
+                Latitude = 1,
+                Longitude = 2,
+                BytesReceived = 1000,
+                BytesSent = 2000
+            },
+        };
+
+        var (uow, ctx) = CreateUowWithData(data);
+        var sut = new OpenVpnGeoQueryService(uow.Object);
+
+        var res = await sut.GetGeoPointsAsync(
+            now.AddHours(-1),
+            now.AddDays(10),
+            vpnServerId: 1,
+            onlyWithCoordinates: true,
+            ct: CancellationToken.None);
+
+        Assert.Single(res.GeoPointAggs);
+        Assert.Equal(1, res.GeoPointAggs[0].SessionsCount);
+        Assert.Equal(10, res.GeoPointAggs[0].TotalBytesIn);
+
+        await ctx.DisposeAsync();
+    }
 }

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSqlTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSqlTests.cs
@@ -23,28 +23,79 @@ public class OverviewTrafficPostgresSqlTests
 
         Assert.Equal(NpgsqlDbType.TimestampTz, byName["from"].NpgsqlDbType);
         Assert.Equal(NpgsqlDbType.TimestampTz, byName["to"].NpgsqlDbType);
+        Assert.Equal(NpgsqlDbType.TimestampTz, byName["baselineFrom"].NpgsqlDbType);
         Assert.Equal(NpgsqlDbType.Interval, byName["offset"].NpgsqlDbType);
         Assert.Equal(NpgsqlDbType.Integer, byName["vpnServerId"].NpgsqlDbType);
         Assert.Equal(NpgsqlDbType.Text, byName["externalId"].NpgsqlDbType);
         Assert.Equal(DBNull.Value, byName["vpnServerId"].Value);
         Assert.Equal(DBNull.Value, byName["externalId"].Value);
+        Assert.Equal(from.UtcDateTime.AddDays(-OverviewTrafficPostgresSql.BaselineLookbackDays), byName["baselineFrom"].Value);
     }
 
     [Fact]
-    public void BuildFilteredTrafficCte_PlacesOptionalFiltersBeforeOffsetParameter()
+    public void BuildFilteredTrafficCte_WithoutFilters_UsesMeasuredAtRangeOnly()
     {
         var cte = OverviewTrafficPostgresSql.BuildFilteredTrafficCte(@"""xgb"".""Traffic""");
 
-        var fromIdx = cte.IndexOf("@from", StringComparison.Ordinal);
-        var toIdx = cte.IndexOf("@to", StringComparison.Ordinal);
-        var serverIdx = cte.IndexOf("@vpnServerId", StringComparison.Ordinal);
-        var externalIdx = cte.IndexOf("@externalId", StringComparison.Ordinal);
-
-        Assert.True(fromIdx >= 0);
-        Assert.True(toIdx > fromIdx);
-        Assert.True(serverIdx > toIdx, "vpnServerId must appear after range params (PG positional $3 when offset is absent in CTE)");
-        Assert.True(externalIdx > serverIdx);
+        Assert.Contains(@"t.""MeasuredAt"" >= @from", cte, StringComparison.Ordinal);
+        Assert.Contains(@"t.""MeasuredAt"" < @to", cte, StringComparison.Ordinal);
+        Assert.DoesNotContain("@vpnServerId", cte, StringComparison.Ordinal);
+        Assert.DoesNotContain("@externalId", cte, StringComparison.Ordinal);
         Assert.DoesNotContain("@offset", cte, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildFilteredTrafficCte_WithExternalId_PutsEqualityBeforeTimeRange()
+    {
+        var cte = OverviewTrafficPostgresSql.BuildFilteredTrafficCte(
+            @"""xgb"".""Traffic""", vpnServerId: null, externalId: "user-1");
+
+        var externalIdx = cte.IndexOf(@"t.""ExternalId"" = @externalId", StringComparison.Ordinal);
+        var fromIdx = cte.IndexOf(@"t.""MeasuredAt"" >= @from", StringComparison.Ordinal);
+        Assert.True(externalIdx >= 0);
+        Assert.True(fromIdx > externalIdx);
+        Assert.DoesNotContain("IS NULL OR", cte, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildBaselinesCte_UsesLookbackWindowNotUnboundedHistory()
+    {
+        var cte = OverviewTrafficPostgresSql.BuildBaselinesCte(
+            @"""xgb"".""Traffic""", vpnServerId: 5, externalId: "user-1");
+
+        Assert.Contains("@baselineFrom", cte, StringComparison.Ordinal);
+        Assert.Contains(@"t.""MeasuredAt"" < @from", cte, StringComparison.Ordinal);
+        Assert.Contains(@"t.""ExternalId"" = @externalId", cte, StringComparison.Ordinal);
+        Assert.Contains(@"t.""VpnServerId"" = @vpnServerId", cte, StringComparison.Ordinal);
+        Assert.Contains("DISTINCT ON", cte, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NormalizeTrafficRange_ClampsFutureTo_AndSwapsInvertedBounds()
+    {
+        var now = new DateTimeOffset(2026, 8, 9, 15, 0, 0, TimeSpan.Zero);
+        var from = new DateTimeOffset(2026, 7, 31, 21, 0, 0, TimeSpan.Zero);
+        var toFuture = new DateTimeOffset(2026, 8, 31, 20, 59, 59, TimeSpan.Zero);
+
+        var (nFrom, nTo) = OverviewTrafficPostgresSql.NormalizeTrafficRange(from, toFuture, now);
+        Assert.Equal(from, nFrom);
+        Assert.Equal(now, nTo);
+
+        var (sFrom, sTo) = OverviewTrafficPostgresSql.NormalizeTrafficRange(toFuture, from, now);
+        Assert.Equal(from, sFrom);
+        Assert.Equal(now, sTo);
+    }
+
+    [Fact]
+    public void NormalizeTrafficRange_WhenFromInFuture_CollapsesToEmptyRange()
+    {
+        var now = new DateTimeOffset(2026, 8, 9, 15, 0, 0, TimeSpan.Zero);
+        var from = now.AddDays(1);
+        var to = now.AddDays(10);
+
+        var (nFrom, nTo) = OverviewTrafficPostgresSql.NormalizeTrafficRange(from, to, now);
+        Assert.Equal(now, nFrom);
+        Assert.Equal(now, nTo);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSqlTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OverviewTrafficPostgresSqlTests.cs
@@ -68,6 +68,7 @@ public class OverviewTrafficPostgresSqlTests
         Assert.Contains(@"t.""ExternalId"" = @externalId", cte, StringComparison.Ordinal);
         Assert.Contains(@"t.""VpnServerId"" = @vpnServerId", cte, StringComparison.Ordinal);
         Assert.Contains("DISTINCT ON", cte, StringComparison.Ordinal);
+        Assert.Contains("""IN (SELECT DISTINCT f."SessionId" FROM filtered f)""", cte, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OverviewTrafficResultCacheTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/OverviewTrafficResultCacheTests.cs
@@ -1,0 +1,32 @@
+using DataGateMonitor.DataBase.Services.Query.VpnServerClientTable;
+
+namespace DataGateMonitor.Tests.DataBase.Services.Query.VpnServerClientTable;
+
+public class OverviewTrafficResultCacheTests
+{
+    [Fact]
+    public async Task GetOrCreateAsync_SingleFlights_And_Reuses_Within_Ttl()
+    {
+        var key = $"test-{Guid.NewGuid():N}";
+        var calls = 0;
+
+        async Task<int> Factory(CancellationToken ct)
+        {
+            Interlocked.Increment(ref calls);
+            await Task.Delay(30, ct);
+            return 42;
+        }
+
+        var tasks = Enumerable.Range(0, 8)
+            .Select(_ => OverviewTrafficResultCache.GetOrCreateAsync(key, Factory, CancellationToken.None))
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.All(results, r => Assert.Equal(42, r));
+        Assert.Equal(1, calls);
+
+        var again = await OverviewTrafficResultCache.GetOrCreateAsync(key, Factory, CancellationToken.None);
+        Assert.Equal(42, again);
+        Assert.Equal(1, calls);
+    }
+}

--- a/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/VpnServerClientOverviewQueryTests.cs
+++ b/DataGateMonitor.Tests/DataBase/Services/Query/VpnServerClientTable/VpnServerClientOverviewQueryTests.cs
@@ -46,10 +46,16 @@ public class VpnServerClientOverviewQueryTests
         var (uow, ctx) = CreateUowWithData(data);
 
         var users = new Mock<IUserQueryService>();
-        users.Setup(x => x.GetByExternalId("ext-1", It.IsAny<CancellationToken>()))
-             .ReturnsAsync(new User { Id = 10, DisplayName = "DN-ext-1" });
-        users.Setup(x => x.GetByExternalId("ext-3", It.IsAny<CancellationToken>()))
-             .ReturnsAsync(new User { Id = 11, DisplayName = "DN-ext-3" });
+        users.Setup(x => x.GetByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync((IReadOnlyCollection<string> ids, CancellationToken _) =>
+             {
+                 var map = new Dictionary<string, User>(StringComparer.Ordinal);
+                 if (ids.Contains("ext-1"))
+                     map["ext-1"] = new User { Id = 10, DisplayName = "DN-ext-1" };
+                 if (ids.Contains("ext-3"))
+                     map["ext-3"] = new User { Id = 11, DisplayName = "DN-ext-3" };
+                 return map;
+             });
 
         var sut = new VpnServerClientOverviewQuery(uow.Object, users.Object);
 
@@ -79,8 +85,12 @@ public class VpnServerClientOverviewQueryTests
 
         var (uow, ctx) = CreateUowWithData(data);
         var users = new Mock<IUserQueryService>();
-        users.Setup(x => x.GetByExternalId(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-             .ReturnsAsync((string extId, CancellationToken _) => new User { Id = 100, DisplayName = $"DN-{extId}" });
+        users.Setup(x => x.GetByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync((IReadOnlyCollection<string> ids, CancellationToken _) =>
+                 ids.ToDictionary(
+                     id => id,
+                     id => new User { Id = 100, DisplayName = $"DN-{id}" },
+                     StringComparer.Ordinal));
 
         var sut = new VpnServerClientOverviewQuery(uow.Object, users.Object);
 

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.44" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.50" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
+++ b/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Tests use DTOs from the package. -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DataGateMonitor.Tests/EmailTemplates/TransactionalEmailHtmlTests.cs
+++ b/DataGateMonitor.Tests/EmailTemplates/TransactionalEmailHtmlTests.cs
@@ -68,4 +68,31 @@ public class TransactionalEmailHtmlTests
         Assert.Contains("Default", result);
         Assert.Contains("@DataGateVPNBot", result);
     }
+
+    [Fact]
+    public void BuildFreeTierChannelSubscribeReminder_IncludesNameChannelAndUrl()
+    {
+        var html = TransactionalEmailHtml.BuildFreeTierChannelSubscribeReminder(
+            "Tatyana", "@datagateapp", "https://t.me/datagateapp");
+
+        Assert.Contains("Tatyana", html);
+        Assert.Contains("@datagateapp", html);
+        Assert.Contains("https://t.me/datagateapp", html);
+    }
+
+    [Fact]
+    public void ApplyFreeTierChannelSubscribeReminderPlaceholders_ReplacesTokens()
+    {
+        var template = TransactionalEmailHtml.BuildFreeTierChannelSubscribeReminderWithPlaceholders();
+
+        var result = TransactionalEmailHtml.ApplyFreeTierChannelSubscribeReminderPlaceholders(
+            template, "Alice", "@chan", "https://t.me/chan");
+
+        Assert.DoesNotContain("{{DISPLAY_NAME}}", result);
+        Assert.DoesNotContain("{{REQUIRED_CHANNEL}}", result);
+        Assert.DoesNotContain("{{CHANNEL_URL}}", result);
+        Assert.Contains("Alice", result);
+        Assert.Contains("@chan", result);
+        Assert.Contains("https://t.me/chan", result);
+    }
 }

--- a/DataGateMonitor.Tests/Hubs/TvLoginHubNotifierTests.cs
+++ b/DataGateMonitor.Tests/Hubs/TvLoginHubNotifierTests.cs
@@ -1,0 +1,111 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using DataGateMonitor.Hubs;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Hubs;
+
+public class TvLoginHubNotifierTests
+{
+    [Fact]
+    public async Task NotifyStatusAsync_SendsEventToSessionGroup()
+    {
+        var sessionId = Guid.NewGuid();
+        var expires = DateTimeOffset.UtcNow.AddMinutes(2);
+
+        var hubContext = new Mock<IHubContext<TvLoginHub>>();
+        var clients = new Mock<IHubClients>();
+        var group = new Mock<IClientProxy>();
+        var logger = new Mock<ILogger<TvLoginHubNotifier>>();
+
+        hubContext.SetupGet(h => h.Clients).Returns(clients.Object);
+        clients.Setup(c => c.Group(TvLoginHub.GroupName(sessionId))).Returns(group.Object);
+
+        TvLoginSessionStatusEvent? payload = null;
+        group.Setup(c => c.SendCoreAsync(
+                TvLoginHub.StatusChangedEvent,
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((_, args, _) =>
+                payload = Assert.IsType<TvLoginSessionStatusEvent>(args[0]))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        var sut = new TvLoginHubNotifier(hubContext.Object, logger.Object);
+
+        await sut.NotifyStatusAsync(sessionId, "viewed", expires, CancellationToken.None);
+
+        group.Verify();
+        Assert.NotNull(payload);
+        Assert.Equal(sessionId, payload!.SessionId);
+        Assert.Equal("viewed", payload.Status);
+        Assert.Equal(expires, payload.ExpiresAt);
+    }
+
+    [Theory]
+    [InlineData("pending")]
+    [InlineData("viewed")]
+    [InlineData("approved")]
+    [InlineData("denied")]
+    [InlineData("expired")]
+    [InlineData("consumed")]
+    public async Task NotifyStatusAsync_AcceptsAllLifecycleStatuses(string status)
+    {
+        var sessionId = Guid.NewGuid();
+        var hubContext = new Mock<IHubContext<TvLoginHub>>();
+        var clients = new Mock<IHubClients>();
+        var group = new Mock<IClientProxy>();
+        hubContext.SetupGet(h => h.Clients).Returns(clients.Object);
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(group.Object);
+        group.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = new TvLoginHubNotifier(hubContext.Object, Mock.Of<ILogger<TvLoginHubNotifier>>());
+
+        await sut.NotifyStatusAsync(sessionId, status, DateTimeOffset.UtcNow, CancellationToken.None);
+
+        group.Verify(
+            c => c.SendCoreAsync(
+                TvLoginHub.StatusChangedEvent,
+                It.Is<object?[]>(args =>
+                    args.Length > 0
+                    && args[0] is TvLoginSessionStatusEvent
+                    && ((TvLoginSessionStatusEvent)args[0]!).Status == status),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyStatusAsync_WhenSendFails_LogsWarning_AndDoesNotThrow()
+    {
+        var sessionId = Guid.NewGuid();
+        var hubContext = new Mock<IHubContext<TvLoginHub>>();
+        var clients = new Mock<IHubClients>();
+        var group = new Mock<IClientProxy>();
+        var logger = new Mock<ILogger<TvLoginHubNotifier>>();
+
+        hubContext.SetupGet(h => h.Clients).Returns(clients.Object);
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(group.Object);
+
+        var boom = new InvalidOperationException("signalr down");
+        group.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(boom);
+
+        var sut = new TvLoginHubNotifier(hubContext.Object, logger.Object);
+
+        await sut.NotifyStatusAsync(sessionId, "approved", DateTimeOffset.UtcNow, CancellationToken.None);
+
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((state, _) =>
+                    state!.ToString()!.Contains("Failed to push TV login status")
+                    && state!.ToString()!.Contains("approved")),
+                boom,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Hubs/TvLoginHubTests.cs
+++ b/DataGateMonitor.Tests/Hubs/TvLoginHubTests.cs
@@ -181,6 +181,75 @@ public class TvLoginHubTests
     }
 
     [Fact]
+    public async Task WatchSession_UnknownStatus_SnapshotSaysExpired()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = new TvLoginSession
+        {
+            Id = sessionId,
+            UserCode = "123456",
+            Status = (TvLoginSessionStatus)999,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+        };
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        TvLoginSessionStatusEvent? pushed = null;
+        var caller = new Mock<ISingleClientProxy>();
+        caller.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((_, args, _) =>
+                pushed = Assert.IsType<TvLoginSessionStatusEvent>(args[0]))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubCallerClients>();
+        clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+        var hub = new TvLoginHub(query.Object)
+        {
+            Context = new TestHubCallerContext("conn-unknown"),
+            Groups = Mock.Of<IGroupManager>(),
+            Clients = clients.Object,
+        };
+
+        await hub.WatchSession(sessionId);
+
+        Assert.Equal("expired", pushed!.Status);
+        Assert.Equal((TvLoginSessionStatus)999, session.Status);
+    }
+
+    [Fact]
+    public async Task WatchSession_WhenPendingPastExpiry_DoesNotMutatePersistedStatus()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = new TvLoginSession
+        {
+            Id = sessionId,
+            UserCode = "123456",
+            Status = TvLoginSessionStatus.Pending,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+        };
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        var caller = new Mock<ISingleClientProxy>();
+        caller.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var clients = new Mock<IHubCallerClients>();
+        clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+        var hub = new TvLoginHub(query.Object)
+        {
+            Context = new TestHubCallerContext("conn-no-write"),
+            Groups = Mock.Of<IGroupManager>(),
+            Clients = clients.Object,
+        };
+
+        await hub.WatchSession(sessionId);
+
+        Assert.Equal(TvLoginSessionStatus.Pending, session.Status);
+    }
+
+    [Fact]
     public async Task WatchSession_WhenMissing_ThrowsHubException()
     {
         var sessionId = Guid.NewGuid();

--- a/DataGateMonitor.Tests/Hubs/TvLoginHubTests.cs
+++ b/DataGateMonitor.Tests/Hubs/TvLoginHubTests.cs
@@ -1,0 +1,224 @@
+using System.Reflection;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Hubs;
+
+public class TvLoginHubTests
+{
+    private sealed class TestHubCallerContext : HubCallerContext
+    {
+        private readonly string _connectionId;
+        private readonly CancellationToken _aborted;
+        private readonly IDictionary<object, object?> _items = new Dictionary<object, object?>();
+
+        public TestHubCallerContext(string connectionId, CancellationToken aborted = default)
+        {
+            _connectionId = connectionId;
+            _aborted = aborted;
+        }
+
+        public override string ConnectionId => _connectionId;
+        public override string? UserIdentifier => null;
+        public override ClaimsPrincipal? User => null;
+        public override IFeatureCollection Features { get; } = new FeatureCollection();
+        public override IDictionary<object, object?> Items => _items;
+        public override CancellationToken ConnectionAborted => _aborted;
+        public override void Abort() { }
+    }
+
+    [Fact]
+    public void Hub_IsAllowAnonymous_And_HasStablePathConstants()
+    {
+        Assert.NotNull(typeof(TvLoginHub).GetCustomAttribute<AllowAnonymousAttribute>());
+        Assert.Equal("/api/hubs/tv-login", TvLoginHub.HubPath);
+        Assert.Equal("TvLoginSessionStatusChanged", TvLoginHub.StatusChangedEvent);
+
+        var sessionId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+        Assert.Equal("tv-login:11111111-2222-3333-4444-555555555555", TvLoginHub.GroupName(sessionId));
+    }
+
+    [Theory]
+    [InlineData(TvLoginSessionStatus.Pending, "pending")]
+    [InlineData(TvLoginSessionStatus.Viewed, "viewed")]
+    [InlineData(TvLoginSessionStatus.Approved, "approved")]
+    [InlineData(TvLoginSessionStatus.Denied, "denied")]
+    [InlineData(TvLoginSessionStatus.Expired, "expired")]
+    [InlineData(TvLoginSessionStatus.Consumed, "consumed")]
+    public async Task WatchSession_SendsImmediateSnapshot_ForEachStatus(
+        TvLoginSessionStatus status,
+        string expectedStatus)
+    {
+        var sessionId = Guid.NewGuid();
+        var expires = DateTimeOffset.UtcNow.AddMinutes(4);
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TvLoginSession
+            {
+                Id = sessionId,
+                UserCode = "123456",
+                Status = status,
+                ExpiresAt = expires,
+            });
+
+        var groups = new Mock<IGroupManager>();
+        groups.Setup(g => g.AddToGroupAsync(
+                "conn-1",
+                TvLoginHub.GroupName(sessionId),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        TvLoginSessionStatusEvent? pushed = null;
+        var caller = new Mock<ISingleClientProxy>();
+        caller.Setup(c => c.SendCoreAsync(
+                TvLoginHub.StatusChangedEvent,
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((_, args, _) =>
+            {
+                pushed = Assert.IsType<TvLoginSessionStatusEvent>(args[0]);
+            })
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubCallerClients>();
+        clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+        var hub = new TvLoginHub(query.Object)
+        {
+            Context = new TestHubCallerContext("conn-1"),
+            Groups = groups.Object,
+            Clients = clients.Object,
+        };
+
+        await hub.WatchSession(sessionId);
+
+        groups.Verify();
+        Assert.NotNull(pushed);
+        Assert.Equal(sessionId, pushed!.SessionId);
+        Assert.Equal(expectedStatus, pushed.Status);
+        Assert.Equal(expires, pushed.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task WatchSession_WhenPendingButPastExpiry_SnapshotSaysExpired()
+    {
+        var sessionId = Guid.NewGuid();
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TvLoginSession
+            {
+                Id = sessionId,
+                UserCode = "123456",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            });
+
+        TvLoginSessionStatusEvent? pushed = null;
+        var caller = new Mock<ISingleClientProxy>();
+        caller.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((_, args, _) =>
+                pushed = Assert.IsType<TvLoginSessionStatusEvent>(args[0]))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubCallerClients>();
+        clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+        var hub = new TvLoginHub(query.Object)
+        {
+            Context = new TestHubCallerContext("conn-exp"),
+            Groups = Mock.Of<IGroupManager>(),
+            Clients = clients.Object,
+        };
+
+        await hub.WatchSession(sessionId);
+
+        Assert.Equal("expired", pushed!.Status);
+    }
+
+    [Fact]
+    public async Task WatchSession_WhenViewedButPastExpiry_SnapshotSaysExpired()
+    {
+        var sessionId = Guid.NewGuid();
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TvLoginSession
+            {
+                Id = sessionId,
+                UserCode = "123456",
+                Status = TvLoginSessionStatus.Viewed,
+                ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-30),
+            });
+
+        TvLoginSessionStatusEvent? pushed = null;
+        var caller = new Mock<ISingleClientProxy>();
+        caller.Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((_, args, _) =>
+                pushed = Assert.IsType<TvLoginSessionStatusEvent>(args[0]))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubCallerClients>();
+        clients.SetupGet(c => c.Caller).Returns(caller.Object);
+
+        var hub = new TvLoginHub(query.Object)
+        {
+            Context = new TestHubCallerContext("conn-viewed-exp"),
+            Groups = Mock.Of<IGroupManager>(),
+            Clients = clients.Object,
+        };
+
+        await hub.WatchSession(sessionId);
+
+        Assert.Equal("expired", pushed!.Status);
+    }
+
+    [Fact]
+    public async Task WatchSession_WhenMissing_ThrowsHubException()
+    {
+        var sessionId = Guid.NewGuid();
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TvLoginSession?)null);
+
+        var hub = new TvLoginHub(query.Object)
+        {
+            Context = new TestHubCallerContext("conn-missing"),
+            Groups = Mock.Of<IGroupManager>(),
+            Clients = Mock.Of<IHubCallerClients>(),
+        };
+
+        var ex = await Assert.ThrowsAsync<HubException>(() => hub.WatchSession(sessionId));
+        Assert.Equal("TV login session not found.", ex.Message);
+    }
+
+    [Fact]
+    public async Task UnwatchSession_RemovesFromGroup()
+    {
+        var sessionId = Guid.NewGuid();
+        var groups = new Mock<IGroupManager>();
+        groups.Setup(g => g.RemoveFromGroupAsync(
+                "conn-2",
+                TvLoginHub.GroupName(sessionId),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        var hub = new TvLoginHub(Mock.Of<ITvLoginSessionQueryService>())
+        {
+            Context = new TestHubCallerContext("conn-2"),
+            Groups = groups.Object,
+        };
+
+        await hub.UnwatchSession(sessionId);
+
+        groups.Verify();
+    }
+}

--- a/DataGateMonitor.Tests/Middlewares/RequestTimingMiddlewareTests.cs
+++ b/DataGateMonitor.Tests/Middlewares/RequestTimingMiddlewareTests.cs
@@ -1,3 +1,4 @@
+using DataGateMonitor.Data.Interceptors;
 using DataGateMonitor.Middlewares;
 using DataGateMonitor.Services.Performance;
 using Microsoft.AspNetCore.Http;
@@ -43,6 +44,31 @@ public class RequestTimingMiddlewareTests
     }
 
     [Fact]
+    public async Task Invoke_DoesNotRecord_Fast_Successful_Request()
+    {
+        var store = new Mock<IPerformanceSampleStore>(MockBehavior.Strict);
+        var middleware = new RequestTimingMiddleware(
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 10_000 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/servers";
+
+        await middleware.InvokeAsync(context);
+
+        store.Verify(
+            s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task Invoke_Skips_Performance_And_Health_Paths()
     {
         var store = new Mock<IPerformanceSampleStore>(MockBehavior.Strict);
@@ -56,13 +82,42 @@ public class RequestTimingMiddlewareTests
             Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 0 }),
             NullLogger<RequestTimingMiddleware>.Instance);
 
-        foreach (var path in new[] { "/api/performance/http-requests", "/health", "/swagger/index.html" })
+        foreach (var path in new[] { "/api/performance/http-requests", "/health", "/swagger/index.html", "/api/hubs/status-stream" })
         {
             var context = new DefaultHttpContext();
             context.Request.Method = "GET";
             context.Request.Path = path;
             await middleware.InvokeAsync(context);
         }
+
+        store.Verify(
+            s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Invoke_Skips_Options_And_NonApi_Paths()
+    {
+        var store = new Mock<IPerformanceSampleStore>(MockBehavior.Strict);
+        var middleware = new RequestTimingMiddleware(
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 0 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        var optionsCtx = new DefaultHttpContext();
+        optionsCtx.Request.Method = "OPTIONS";
+        optionsCtx.Request.Path = "/api/servers";
+        await middleware.InvokeAsync(optionsCtx);
+
+        var staticCtx = new DefaultHttpContext();
+        staticCtx.Request.Method = "GET";
+        staticCtx.Request.Path = "/favicon.ico";
+        await middleware.InvokeAsync(staticCtx);
 
         store.Verify(
             s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()),
@@ -96,5 +151,211 @@ public class RequestTimingMiddlewareTests
 
         Assert.NotNull(recorded);
         Assert.Equal(500, recorded!.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_Sets_And_Clears_PerformanceRequestContext()
+    {
+        string? midRequestId = null;
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var middleware = new RequestTimingMiddleware(
+            ctx =>
+            {
+                midRequestId = PerformanceRequestContext.RequestId;
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 0 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        PerformanceRequestContext.RequestId = null;
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/servers";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(string.IsNullOrWhiteSpace(midRequestId));
+        Assert.Null(PerformanceRequestContext.RequestId);
+        Assert.Equal(midRequestId, context.Items["PerformanceRequestId"]);
+    }
+
+    [Fact]
+    public async Task Invoke_Clears_RequestId_Even_When_Next_Throws()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var middleware = new RequestTimingMiddleware(
+            _ => throw new InvalidOperationException("boom"),
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 0 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        PerformanceRequestContext.RequestId = null;
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/servers";
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => middleware.InvokeAsync(context));
+        Assert.Null(PerformanceRequestContext.RequestId);
+    }
+
+    [Fact]
+    public async Task Invoke_DoesNotFail_When_Store_Throws()
+    {
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("redis down"));
+
+        var middleware = new RequestTimingMiddleware(
+            ctx =>
+            {
+                ctx.Response.StatusCode = 500;
+                return Task.CompletedTask;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 10_000 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/servers";
+
+        var ex = await Record.ExceptionAsync(() => middleware.InvokeAsync(context));
+        Assert.Null(ex);
+        Assert.Equal(500, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_Correlates_RequestId_With_Db_Interceptor_Sample()
+    {
+        PerformanceHttpSample? httpSample = null;
+        var tcs = new TaskCompletionSource<PerformanceDbSample>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()))
+            .Callback<PerformanceHttpSample, CancellationToken>((s, _) => httpSample = s)
+            .Returns(Task.CompletedTask);
+        store.Setup(s => s.AppendDbAsync(It.IsAny<PerformanceDbSample>(), It.IsAny<CancellationToken>()))
+            .Callback<PerformanceDbSample, CancellationToken>((s, _) => tcs.TrySetResult(s))
+            .Returns(Task.CompletedTask);
+
+        var interceptor = new SlowDbCommandInterceptor(
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { DbSlowMs = 1 }),
+            NullLogger<SlowDbCommandInterceptor>.Instance);
+
+        var middleware = new RequestTimingMiddleware(
+            ctx =>
+            {
+                interceptor.Record(
+                    new CorrelationDbCommand("SELECT correlated"),
+                    TimeSpan.FromMilliseconds(50),
+                    succeeded: true,
+                    exception: null);
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 0 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/open-vpn-servers";
+
+        await middleware.InvokeAsync(context);
+
+        var dbSample = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(httpSample);
+        Assert.Equal(httpSample!.RequestId, dbSample.RequestId);
+        Assert.Null(PerformanceRequestContext.RequestId);
+    }
+
+    private sealed class CorrelationDbCommand(string commandText) : System.Data.Common.DbCommand
+    {
+        public override string CommandText { get; set; } = commandText;
+        public override int CommandTimeout { get; set; }
+        public override System.Data.CommandType CommandType { get; set; } = System.Data.CommandType.Text;
+        public override bool DesignTimeVisible { get; set; }
+        public override System.Data.UpdateRowSource UpdatedRowSource { get; set; }
+        protected override System.Data.Common.DbConnection? DbConnection { get; set; }
+        protected override System.Data.Common.DbParameterCollection DbParameterCollection { get; } =
+            new EmptyParameterCollection();
+        protected override System.Data.Common.DbTransaction? DbTransaction { get; set; }
+
+        public override void Cancel()
+        {
+        }
+
+        public override int ExecuteNonQuery() => 0;
+        public override object? ExecuteScalar() => null;
+        public override void Prepare()
+        {
+        }
+
+        protected override System.Data.Common.DbParameter CreateDbParameter() =>
+            throw new NotSupportedException();
+
+        protected override System.Data.Common.DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) =>
+            throw new NotSupportedException();
+
+        private sealed class EmptyParameterCollection : System.Data.Common.DbParameterCollection
+        {
+            public override int Count => 0;
+            public override object SyncRoot { get; } = new();
+            public override int Add(object value) => 0;
+            public override void AddRange(Array values)
+            {
+            }
+
+            public override void Clear()
+            {
+            }
+
+            public override bool Contains(object value) => false;
+            public override bool Contains(string value) => false;
+            public override void CopyTo(Array array, int index)
+            {
+            }
+
+            public override System.Collections.IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            public override int IndexOf(object value) => -1;
+            public override int IndexOf(string parameterName) => -1;
+            public override void Insert(int index, object value)
+            {
+            }
+
+            public override void Remove(object value)
+            {
+            }
+
+            public override void RemoveAt(int index)
+            {
+            }
+
+            public override void RemoveAt(string parameterName)
+            {
+            }
+
+            protected override System.Data.Common.DbParameter GetParameter(int index) =>
+                throw new NotSupportedException();
+
+            protected override System.Data.Common.DbParameter GetParameter(string parameterName) =>
+                throw new NotSupportedException();
+
+            protected override void SetParameter(int index, System.Data.Common.DbParameter value)
+            {
+            }
+
+            protected override void SetParameter(string parameterName, System.Data.Common.DbParameter value)
+            {
+            }
+        }
     }
 }

--- a/DataGateMonitor.Tests/Middlewares/RequestTimingMiddlewareTests.cs
+++ b/DataGateMonitor.Tests/Middlewares/RequestTimingMiddlewareTests.cs
@@ -1,0 +1,100 @@
+using DataGateMonitor.Middlewares;
+using DataGateMonitor.Services.Performance;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Middlewares;
+
+public class RequestTimingMiddlewareTests
+{
+    [Fact]
+    public async Task Invoke_Records_When_Duration_Exceeds_Threshold()
+    {
+        PerformanceHttpSample? recorded = null;
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()))
+            .Callback<PerformanceHttpSample, CancellationToken>((s, _) => recorded = s)
+            .Returns(Task.CompletedTask);
+
+        var middleware = new RequestTimingMiddleware(
+            async ctx =>
+            {
+                await Task.Delay(30);
+                ctx.Response.StatusCode = 200;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 10 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/servers";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.NotNull(recorded);
+        Assert.Equal("GET", recorded!.Method);
+        Assert.Equal("/api/servers", recorded.Path);
+        Assert.True(recorded.DurationMs >= 10);
+        Assert.False(string.IsNullOrWhiteSpace(recorded.RequestId));
+    }
+
+    [Fact]
+    public async Task Invoke_Skips_Performance_And_Health_Paths()
+    {
+        var store = new Mock<IPerformanceSampleStore>(MockBehavior.Strict);
+        var middleware = new RequestTimingMiddleware(
+            ctx =>
+            {
+                ctx.Response.StatusCode = 200;
+                return Task.CompletedTask;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 0 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        foreach (var path in new[] { "/api/performance/http-requests", "/health", "/swagger/index.html" })
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Method = "GET";
+            context.Request.Path = path;
+            await middleware.InvokeAsync(context);
+        }
+
+        store.Verify(
+            s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Invoke_Records_5xx_Even_When_Fast()
+    {
+        PerformanceHttpSample? recorded = null;
+        var store = new Mock<IPerformanceSampleStore>();
+        store.Setup(s => s.AppendHttpAsync(It.IsAny<PerformanceHttpSample>(), It.IsAny<CancellationToken>()))
+            .Callback<PerformanceHttpSample, CancellationToken>((s, _) => recorded = s)
+            .Returns(Task.CompletedTask);
+
+        var middleware = new RequestTimingMiddleware(
+            ctx =>
+            {
+                ctx.Response.StatusCode = 500;
+                return Task.CompletedTask;
+            },
+            store.Object,
+            Options.Create(new PerformanceMonitoringOptions { HttpSlowMs = 10_000 }),
+            NullLogger<RequestTimingMiddleware>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "POST";
+        context.Request.Path = "/api/settings";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.NotNull(recorded);
+        Assert.Equal(500, recorded!.StatusCode);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Api/Auth/ForgotPassword/AdminForgotPasswordServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/ForgotPassword/AdminForgotPasswordServiceTests.cs
@@ -1,7 +1,3 @@
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
-using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -13,44 +9,53 @@ using DataGateMonitor.Services.EmailTemplates;
 using DataGateMonitor.Services.Others.Notifications;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
-using Xunit;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.Api.Auth.ForgotPassword;
 
 public class AdminForgotPasswordServiceTests
 {
+    private static AdminForgotPasswordService CreateSut() =>
+        new(
+            Mock.Of<IUserCredentialQueryService>(),
+            Mock.Of<IUserQueryService>(),
+            Mock.Of<ICommandService<UserCredential, int>>(),
+            Mock.Of<IUserPasswordHistoryService>(),
+            Mock.Of<IPasswordHasher<User>>(),
+            new MemoryCache(new MemoryCacheOptions()),
+            Mock.Of<IEmailSenderService>(),
+            Mock.Of<ISentEmailLogService>(),
+            Mock.Of<ISystemTransactionalEmailService>(),
+            Mock.Of<IAppNotificationFacade>(),
+            NullLogger<AdminForgotPasswordService>.Instance);
+
     [Fact]
-    public async Task RequestResetCodeAsync_When_LoginOrEmailEmpty_Returns_SameMessageForAll()
+    public async Task ResetPasswordAsync_WhenCodeMissing_Fails()
     {
-        var credentialQuery = new Mock<IUserCredentialQueryService>();
-        var userQuery = new Mock<IUserQueryService>();
-        var credentialCommand = new Mock<ICommandService<UserCredential, int>>();
-        var passwordHasher = new Mock<IPasswordHasher<User>>();
-        var cache = new MemoryCache(new MemoryCacheOptions());
-        var emailSender = new Mock<IEmailSenderService>();
-        var sentEmailLog = new Mock<ISentEmailLogService>();
-        var systemTransactionalEmail = new Mock<ISystemTransactionalEmailService>();
-        var appNotifications = new Mock<IAppNotificationFacade>();
-        var passwordHistory = new Mock<IUserPasswordHistoryService>();
-        var logger = new Mock<ILogger<AdminForgotPasswordService>>();
+        var result = await CreateSut().ResetPasswordAsync(
+            new AdminResetPasswordRequest { Code = "  ", NewPassword = "longenough", ConfirmPassword = "longenough" },
+            CancellationToken.None);
 
-        var sut = new AdminForgotPasswordService(
-            credentialQuery.Object,
-            userQuery.Object,
-            credentialCommand.Object,
-            passwordHistory.Object,
-            passwordHasher.Object,
-            cache,
-            emailSender.Object,
-            sentEmailLog.Object,
-            systemTransactionalEmail.Object,
-            appNotifications.Object,
-            logger.Object);
+        Assert.False(result.Success);
+        Assert.Contains("Invalid or expired", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
 
-        var request = new AdminForgotPasswordRequest { LoginOrEmail = "   " };
-        var result = await sut.RequestResetCodeAsync(request, "127.0.0.1", CancellationToken.None);
+    [Fact]
+    public async Task ResetPasswordAsync_WhenPasswordsMismatch_Fails()
+    {
+        var result = await CreateSut().ResetPasswordAsync(
+            new AdminResetPasswordRequest
+            {
+                Code = "ABCDEFGHIJ",
+                NewPassword = "longenough",
+                ConfirmPassword = "different1",
+            },
+            CancellationToken.None);
 
-        Assert.Equal(AdminForgotPasswordService.SameMessageForAll, result.Message);
-        credentialQuery.Verify(c => c.GetByNormalizedLogin(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.False(result.Success);
+        Assert.Contains("do not match", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/Auth/Login/AdminIdleSessionTrackerTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/Login/AdminIdleSessionTrackerTests.cs
@@ -6,45 +6,35 @@ namespace DataGateMonitor.Tests.Services.Api.Auth.Login;
 
 public class AdminIdleSessionTrackerTests
 {
-    [Fact]
-    public void IsExpired_returns_true_when_never_touched()
+    private static AdminIdleSessionTracker CreateSut()
     {
-        var tracker = CreateTracker(new Dictionary<string, string?> { ["Jwt:AdminIdleTimeoutMinutes"] = "15" });
-
-        Assert.True(tracker.IsExpired(42));
-    }
-
-    [Fact]
-    public void Touch_resets_idle_timer()
-    {
-        var tracker = CreateTracker(new Dictionary<string, string?> { ["Jwt:AdminIdleTimeoutMinutes"] = "15" });
-
-        tracker.Touch(42);
-        Assert.False(tracker.IsExpired(42));
-    }
-
-    [Fact]
-    public void ResolveIdleTimeout_uses_config_value()
-    {
-        var tracker = CreateTracker(new Dictionary<string, string?> { ["Jwt:AdminIdleTimeoutMinutes"] = "20" });
-
-        Assert.Equal(TimeSpan.FromMinutes(20), tracker.IdleTimeout);
-    }
-
-    [Fact]
-    public void ResolveIdleTimeout_defaults_to_15_minutes()
-    {
-        var tracker = CreateTracker(new Dictionary<string, string?>());
-
-        Assert.Equal(TimeSpan.FromMinutes(15), tracker.IdleTimeout);
-    }
-
-    private static AdminIdleSessionTracker CreateTracker(IReadOnlyDictionary<string, string?> values)
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(values)
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:AdminIdleTimeoutMinutes"] = "15",
+            })
             .Build();
+        return new AdminIdleSessionTracker(config, new MemoryCache(new MemoryCacheOptions()));
+    }
 
-        return new AdminIdleSessionTracker(configuration, new MemoryCache(new MemoryCacheOptions()));
+    [Fact]
+    public void IsExpired_WhenUserIdInvalid_ReturnsTrue()
+    {
+        Assert.True(CreateSut().IsExpired(0));
+    }
+
+    [Fact]
+    public void Touch_ThenIsExpired_ReturnsFalse()
+    {
+        var sut = CreateSut();
+        sut.Touch(42);
+        Assert.False(sut.IsExpired(42));
+    }
+
+    [Fact]
+    public void IsAdminRole_MatchesAdminCaseInsensitive()
+    {
+        Assert.True(AdminIdleSessionTracker.IsAdminRole("admin"));
+        Assert.False(AdminIdleSessionTracker.IsAdminRole("user"));
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/Auth/Totp/AdminTotpServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/Totp/AdminTotpServiceTests.cs
@@ -1,7 +1,3 @@
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Configuration;
-using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -9,168 +5,70 @@ using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Totp;
-using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
-using Xunit;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.Api.Auth.Totp;
 
 public class AdminTotpServiceTests
 {
-    private static AdminTotpService CreateSut(
-        Mock<IUserRoleService>? userRoleService = null,
-        Mock<IUserCredentialQueryService>? credentialQuery = null,
-        Mock<ITokenService>? tokenService = null,
-        IMemoryCache? cache = null,
-        IConfiguration? configuration = null)
-    {
-        userRoleService ??= new Mock<IUserRoleService>();
-        credentialQuery ??= new Mock<IUserCredentialQueryService>();
-        tokenService ??= new Mock<ITokenService>();
-        cache ??= new MemoryCache(new MemoryCacheOptions());
-        configuration ??= new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?> { ["Jwt:RefreshPepper"] = "test-pepper" })
-            .Build();
+    private static AdminTotpService CreateSut(Mock<IUserRoleService>? roles = null) =>
+        new(
+            (roles ?? new Mock<IUserRoleService>()).Object,
+            Mock.Of<IUserCredentialQueryService>(),
+            Mock.Of<ICommandService<UserCredential, int>>(),
+            Mock.Of<ITokenService>(),
+            Mock.Of<IPasswordHasher<User>>(),
+            Mock.Of<IUserQueryService>(),
+            new MemoryCache(new MemoryCacheOptions()),
+            new ConfigurationBuilder().Build());
 
-        return new AdminTotpService(
-            userRoleService.Object,
-            credentialQuery.Object,
-            new Mock<ICommandService<UserCredential, int>>().Object,
-            tokenService.Object,
-            new Mock<IPasswordHasher<User>>().Object,
-            new Mock<IUserQueryService>().Object,
-            cache,
-            configuration);
+    [Fact]
+    public void IsTotpEnabled_WhenNullCredential_ReturnsFalse()
+    {
+        Assert.False(CreateSut().IsTotpEnabled(null));
+    }
+
+    [Fact]
+    public async Task VerifyLoginChallengeAsync_WhenBlank_ThrowsUnauthorized()
+    {
+        var sut = CreateSut();
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            sut.VerifyLoginChallengeAsync(
+                new TotpVerifyLoginRequest { LoginChallengeId = " ", Code = "" },
+                CancellationToken.None));
     }
 
     [Fact]
     public async Task ApplyAdminTotpGateAsync_WhenNotAdmin_IssuesTokensDirectly()
     {
-        var user = new User { Id = 1, DisplayName = "User", Email = "u@example.com" };
-        var userRoleService = new Mock<IUserRoleService>();
-        userRoleService.Setup(r => r.GetUserRoleNameAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync("VpnUser");
+        var roles = new Mock<IUserRoleService>();
+        roles.Setup(r => r.GetUserRoleNameAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("User");
 
-        var sut = CreateSut(userRoleService);
-        var expected = new LoginResponse { UserId = 1, Token = "access" };
-
-        var result = await sut.ApplyAdminTotpGateAsync(
-            user,
-            credential: null,
-            externalId: null,
-            deviceId: null,
-            userAgent: null,
-            _ => Task.FromResult(expected),
-            CancellationToken.None);
-
-        Assert.Equal("access", result.Token);
-        Assert.False(result.RequiresTotp);
-    }
-
-    [Fact]
-    public async Task ApplyAdminTotpGateAsync_WhenAdminWithoutTotp_ReturnsRequiresTotpSetup()
-    {
-        var user = new User { Id = 2, DisplayName = "Admin", Email = "admin@example.com" };
-        var userRoleService = new Mock<IUserRoleService>();
-        userRoleService.Setup(r => r.GetUserRoleNameAsync(2, It.IsAny<CancellationToken>())).ReturnsAsync("Admin");
-
-        var tokenService = new Mock<ITokenService>();
-        tokenService
-            .Setup(t => t.IssueAsync(2, null, null, null, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new TokenPair("access", DateTime.UtcNow.AddHours(1), "refresh", DateTime.UtcNow.AddDays(1)));
-
-        var sut = CreateSut(userRoleService, tokenService: tokenService);
-
-        var result = await sut.ApplyAdminTotpGateAsync(
-            user,
-            credential: null,
-            externalId: null,
-            deviceId: null,
-            userAgent: null,
-            cancel => Task.FromResult(new LoginResponse
+        var issued = false;
+        var result = await CreateSut(roles).ApplyAdminTotpGateAsync(
+            new User { Id = 5, DisplayName = "u" },
+            null,
+            null,
+            null,
+            null,
+            _ =>
             {
-                UserId = user.Id,
-                Token = "access",
-                RefreshToken = "refresh",
-            }),
+                issued = true;
+                return Task.FromResult(new SharedModels.DataGateMonitor.Auth.Responses.LoginResponse
+                {
+                    UserId = 5,
+                    Token = "a",
+                });
+            },
             CancellationToken.None);
 
-        Assert.True(result.RequiresTotpSetup);
-        Assert.Equal("access", result.Token);
-    }
-
-    [Fact]
-    public async Task ApplyAdminTotpGateAsync_WhenAdminWithTotpEnabled_ReturnsChallenge()
-    {
-        var user = new User { Id = 3, DisplayName = "Admin", Email = "admin2@example.com" };
-        var credential = new UserCredential
-        {
-            UserId = 3,
-            TotpEnabledAt = DateTimeOffset.UtcNow,
-            TotpSecretEncrypted = "encrypted",
-        };
-
-        var userRoleService = new Mock<IUserRoleService>();
-        userRoleService.Setup(r => r.GetUserRoleNameAsync(3, It.IsAny<CancellationToken>())).ReturnsAsync("Admin");
-
-        var sut = CreateSut(userRoleService);
-
-        var result = await sut.ApplyAdminTotpGateAsync(
-            user,
-            credential,
-            externalId: "ext",
-            deviceId: "dev",
-            userAgent: "agent",
-            _ => Task.FromResult(new LoginResponse { Token = "should-not-be-used" }),
-            CancellationToken.None);
-
-        Assert.True(result.RequiresTotp);
-        Assert.False(string.IsNullOrWhiteSpace(result.LoginChallengeId));
-        Assert.Null(result.Token);
-    }
-
-    [Fact]
-    public async Task GetStatusAsync_WhenNotAdmin_ReturnsDisabledStatus()
-    {
-        var userRoleService = new Mock<IUserRoleService>();
-        userRoleService.Setup(r => r.GetUserRoleNameAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync("VpnUser");
-
-        var sut = CreateSut(userRoleService);
-
-        var status = await sut.GetStatusAsync(5, CancellationToken.None);
-
-        Assert.False(status.IsAdmin);
-        Assert.False(status.TotpEnabled);
-        Assert.False(status.RequiresTotpSetup);
-    }
-
-    [Fact]
-    public async Task GetStatusAsync_WhenAdminWithoutTotp_RequiresSetup()
-    {
-        var userRoleService = new Mock<IUserRoleService>();
-        userRoleService.Setup(r => r.GetUserRoleNameAsync(6, It.IsAny<CancellationToken>())).ReturnsAsync("Admin");
-
-        var credentialQuery = new Mock<IUserCredentialQueryService>();
-        credentialQuery.Setup(q => q.GetByUserId(6, It.IsAny<CancellationToken>())).ReturnsAsync((UserCredential?)null);
-
-        var sut = CreateSut(userRoleService, credentialQuery);
-
-        var status = await sut.GetStatusAsync(6, CancellationToken.None);
-
-        Assert.True(status.IsAdmin);
-        Assert.False(status.TotpEnabled);
-        Assert.True(status.RequiresTotpSetup);
-    }
-
-    [Fact]
-    public void IsTotpEnabled_WhenSecretAndTimestampPresent_ReturnsTrue()
-    {
-        var sut = CreateSut();
-        var credential = new UserCredential
-        {
-            TotpEnabledAt = DateTimeOffset.UtcNow,
-            TotpSecretEncrypted = "secret",
-        };
-
-        Assert.True(sut.IsTotpEnabled(credential));
-        Assert.False(sut.IsTotpEnabled(null));
+        Assert.True(issued);
+        Assert.Equal(5, result.UserId);
+        Assert.False(result.RequiresTotp);
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/Auth/Totp/AdminTotpServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/Totp/AdminTotpServiceTests.cs
@@ -1,3 +1,7 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -6,69 +10,178 @@ using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Totp;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Configuration;
-using Moq;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using Xunit;
 
 namespace DataGateMonitor.Tests.Services.Api.Auth.Totp;
 
 public class AdminTotpServiceTests
 {
-    private static AdminTotpService CreateSut(Mock<IUserRoleService>? roles = null) =>
-        new(
-            (roles ?? new Mock<IUserRoleService>()).Object,
-            Mock.Of<IUserCredentialQueryService>(),
-            Mock.Of<ICommandService<UserCredential, int>>(),
-            Mock.Of<ITokenService>(),
-            Mock.Of<IPasswordHasher<User>>(),
-            Mock.Of<IUserQueryService>(),
-            new MemoryCache(new MemoryCacheOptions()),
-            new ConfigurationBuilder().Build());
-
-    [Fact]
-    public void IsTotpEnabled_WhenNullCredential_ReturnsFalse()
+    private static AdminTotpService CreateSut(
+        Mock<IUserRoleService>? userRoleService = null,
+        Mock<IUserCredentialQueryService>? credentialQuery = null,
+        Mock<ITokenService>? tokenService = null,
+        IMemoryCache? cache = null,
+        IConfiguration? configuration = null)
     {
-        Assert.False(CreateSut().IsTotpEnabled(null));
+        userRoleService ??= new Mock<IUserRoleService>();
+        credentialQuery ??= new Mock<IUserCredentialQueryService>();
+        tokenService ??= new Mock<ITokenService>();
+        cache ??= new MemoryCache(new MemoryCacheOptions());
+        configuration ??= new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Jwt:RefreshPepper"] = "test-pepper" })
+            .Build();
+
+        return new AdminTotpService(
+            userRoleService.Object,
+            credentialQuery.Object,
+            new Mock<ICommandService<UserCredential, int>>().Object,
+            tokenService.Object,
+            new Mock<IPasswordHasher<User>>().Object,
+            new Mock<IUserQueryService>().Object,
+            cache,
+            configuration);
     }
 
     [Fact]
-    public async Task VerifyLoginChallengeAsync_WhenBlank_ThrowsUnauthorized()
+    public async Task ApplyAdminTotpGateAsync_WhenNotAdmin_IssuesTokensDirectly()
+    {
+        var user = new User { Id = 1, DisplayName = "User", Email = "u@example.com" };
+        var userRoleService = new Mock<IUserRoleService>();
+        userRoleService.Setup(r => r.GetUserRoleNameAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync("VpnUser");
+
+        var sut = CreateSut(userRoleService);
+        var expected = new LoginResponse { UserId = 1, Token = "access" };
+
+        var result = await sut.ApplyAdminTotpGateAsync(
+            user,
+            credential: null,
+            externalId: null,
+            deviceId: null,
+            userAgent: null,
+            _ => Task.FromResult(expected),
+            CancellationToken.None);
+
+        Assert.Equal("access", result.Token);
+        Assert.False(result.RequiresTotp);
+    }
+
+    [Fact]
+    public async Task ApplyAdminTotpGateAsync_WhenAdminWithoutTotp_ReturnsRequiresTotpSetup()
+    {
+        var user = new User { Id = 2, DisplayName = "Admin", Email = "admin@example.com" };
+        var userRoleService = new Mock<IUserRoleService>();
+        userRoleService.Setup(r => r.GetUserRoleNameAsync(2, It.IsAny<CancellationToken>())).ReturnsAsync("Admin");
+
+        var tokenService = new Mock<ITokenService>();
+        tokenService
+            .Setup(t => t.IssueAsync(2, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair("access", DateTime.UtcNow.AddHours(1), "refresh", DateTime.UtcNow.AddDays(1)));
+
+        var sut = CreateSut(userRoleService, tokenService: tokenService);
+
+        var result = await sut.ApplyAdminTotpGateAsync(
+            user,
+            credential: null,
+            externalId: null,
+            deviceId: null,
+            userAgent: null,
+            cancel => Task.FromResult(new LoginResponse
+            {
+                UserId = user.Id,
+                Token = "access",
+                RefreshToken = "refresh",
+            }),
+            CancellationToken.None);
+
+        Assert.True(result.RequiresTotpSetup);
+        Assert.Equal("access", result.Token);
+    }
+
+    [Fact]
+    public async Task ApplyAdminTotpGateAsync_WhenAdminWithTotpEnabled_ReturnsChallenge()
+    {
+        var user = new User { Id = 3, DisplayName = "Admin", Email = "admin2@example.com" };
+        var credential = new UserCredential
+        {
+            UserId = 3,
+            TotpEnabledAt = DateTimeOffset.UtcNow,
+            TotpSecretEncrypted = "encrypted",
+        };
+
+        var userRoleService = new Mock<IUserRoleService>();
+        userRoleService.Setup(r => r.GetUserRoleNameAsync(3, It.IsAny<CancellationToken>())).ReturnsAsync("Admin");
+
+        var sut = CreateSut(userRoleService);
+
+        var result = await sut.ApplyAdminTotpGateAsync(
+            user,
+            credential,
+            externalId: "ext",
+            deviceId: "dev",
+            userAgent: "agent",
+            _ => Task.FromResult(new LoginResponse { Token = "should-not-be-used" }),
+            CancellationToken.None);
+
+        Assert.True(result.RequiresTotp);
+        Assert.False(string.IsNullOrWhiteSpace(result.LoginChallengeId));
+        Assert.Null(result.Token);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_WhenNotAdmin_ReturnsDisabledStatus()
+    {
+        var userRoleService = new Mock<IUserRoleService>();
+        userRoleService.Setup(r => r.GetUserRoleNameAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync("VpnUser");
+
+        var sut = CreateSut(userRoleService);
+
+        var status = await sut.GetStatusAsync(5, CancellationToken.None);
+
+        Assert.False(status.IsAdmin);
+        Assert.False(status.TotpEnabled);
+        Assert.False(status.RequiresTotpSetup);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_WhenAdminWithoutTotp_RequiresSetup()
+    {
+        var userRoleService = new Mock<IUserRoleService>();
+        userRoleService.Setup(r => r.GetUserRoleNameAsync(6, It.IsAny<CancellationToken>())).ReturnsAsync("Admin");
+
+        var credentialQuery = new Mock<IUserCredentialQueryService>();
+        credentialQuery.Setup(q => q.GetByUserId(6, It.IsAny<CancellationToken>())).ReturnsAsync((UserCredential?)null);
+
+        var sut = CreateSut(userRoleService, credentialQuery);
+
+        var status = await sut.GetStatusAsync(6, CancellationToken.None);
+
+        Assert.True(status.IsAdmin);
+        Assert.False(status.TotpEnabled);
+        Assert.True(status.RequiresTotpSetup);
+    }
+
+    [Fact]
+    public void IsTotpEnabled_WhenSecretAndTimestampPresent_ReturnsTrue()
+    {
+        var sut = CreateSut();
+        var credential = new UserCredential
+        {
+            TotpEnabledAt = DateTimeOffset.UtcNow,
+            TotpSecretEncrypted = "secret",
+        };
+
+        Assert.True(sut.IsTotpEnabled(credential));
+        Assert.False(sut.IsTotpEnabled(null));
+    }
+
+    [Fact]
+    public async Task VerifyLoginChallengeAsync_WhenBlankChallengeOrCode_ThrowsUnauthorized()
     {
         var sut = CreateSut();
         await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
             sut.VerifyLoginChallengeAsync(
                 new TotpVerifyLoginRequest { LoginChallengeId = " ", Code = "" },
                 CancellationToken.None));
-    }
-
-    [Fact]
-    public async Task ApplyAdminTotpGateAsync_WhenNotAdmin_IssuesTokensDirectly()
-    {
-        var roles = new Mock<IUserRoleService>();
-        roles.Setup(r => r.GetUserRoleNameAsync(5, It.IsAny<CancellationToken>()))
-            .ReturnsAsync("User");
-
-        var issued = false;
-        var result = await CreateSut(roles).ApplyAdminTotpGateAsync(
-            new User { Id = 5, DisplayName = "u" },
-            null,
-            null,
-            null,
-            null,
-            _ =>
-            {
-                issued = true;
-                return Task.FromResult(new SharedModels.DataGateMonitor.Auth.Responses.LoginResponse
-                {
-                    UserId = 5,
-                    Token = "a",
-                });
-            },
-            CancellationToken.None);
-
-        Assert.True(issued);
-        Assert.Equal(5, result.UserId);
-        Assert.False(result.RequiresTotp);
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginAdminServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginAdminServiceTests.cs
@@ -1,0 +1,37 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+
+namespace DataGateMonitor.Tests.Services.Api.Auth.TvLogin;
+
+public class TvLoginAdminServiceTests
+{
+    [Theory]
+    [InlineData(TvLoginSessionStatus.Pending, "pending")]
+    [InlineData(TvLoginSessionStatus.Viewed, "viewed")]
+    [InlineData(TvLoginSessionStatus.Approved, "approved")]
+    [InlineData(TvLoginSessionStatus.Denied, "denied")]
+    [InlineData(TvLoginSessionStatus.Expired, "expired")]
+    [InlineData(TvLoginSessionStatus.Consumed, "consumed")]
+    public void MapStatus_MapsKnownStatuses(TvLoginSessionStatus status, string expected)
+    {
+        var session = new TvLoginSession
+        {
+            Status = status,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+        };
+
+        Assert.Equal(expected, TvLoginAdminService.MapStatus(session, DateTimeOffset.UtcNow));
+    }
+
+    [Fact]
+    public void MapStatus_PendingPastExpiry_ReturnsExpired()
+    {
+        var session = new TvLoginSession
+        {
+            Status = TvLoginSessionStatus.Pending,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+        };
+
+        Assert.Equal("expired", TvLoginAdminService.MapStatus(session, DateTimeOffset.UtcNow));
+    }
+}

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
@@ -35,7 +35,8 @@ internal sealed class TvLoginSessionServiceHarness
         Config = config ?? new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com",
+                // Test-only values — production must set Auth__PublicWebBaseUrl via env/appsettings.
+                ["Auth:PublicWebBaseUrl"] = "https://tv-link.test",
                 ["Auth:TvLoginSessionMinutes"] = "5",
             })
             .Build();

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
@@ -1,0 +1,189 @@
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Hubs;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Login;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+
+namespace DataGateMonitor.Tests.Services.Api.Auth.TvLogin;
+
+/// <summary>Shared in-memory harness for <see cref="TvLoginSessionService"/> unit tests.</summary>
+internal sealed class TvLoginSessionServiceHarness
+{
+    public List<TvLoginSession> Sessions { get; } = [];
+    public Mock<ITokenService> TokenService { get; } = new();
+    public Mock<IUserQueryService> UserQuery { get; } = new();
+    public Mock<ITvLoginHubNotifier> Hub { get; } = new();
+    public Mock<IHttpContextAccessor> Http { get; } = new();
+    public ConcurrentQueue<Action<TvLoginSession>> PendingUpdates { get; } = new();
+
+    public MemoryCache Cache { get; } = new(new MemoryCacheOptions());
+    public IConfiguration Config { get; set; }
+
+    public TvLoginSessionServiceHarness(IConfiguration? config = null)
+    {
+        Config = config ?? new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com",
+                ["Auth:TvLoginSessionMinutes"] = "5",
+            })
+            .Build();
+
+        Http.SetupGet(h => h.HttpContext).Returns((HttpContext?)null);
+
+        UserQuery
+            .Setup(u => u.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int id, CancellationToken _) => new User
+            {
+                Id = id,
+                DisplayName = "User" + id,
+                Email = $"user{id}@example.com",
+            });
+    }
+
+    public void EnqueueUpdate(Action<TvLoginSession> apply) => PendingUpdates.Enqueue(apply);
+
+    public TvLoginSession AddSession(
+        Guid? id = null,
+        string userCode = "123456",
+        TvLoginSessionStatus status = TvLoginSessionStatus.Pending,
+        DateTimeOffset? expiresAt = null,
+        int? approvedUserId = null,
+        string? deviceName = "Test TV",
+        string? client = "android-tv",
+        string? deviceId = null,
+        string? userAgent = null)
+    {
+        var session = new TvLoginSession
+        {
+            Id = id ?? Guid.NewGuid(),
+            UserCode = userCode,
+            Status = status,
+            DeviceName = deviceName,
+            Client = client,
+            DeviceId = deviceId,
+            UserAgent = userAgent,
+            ApprovedUserId = approvedUserId,
+            ExpiresAt = expiresAt ?? DateTimeOffset.UtcNow.AddMinutes(5),
+            CreateDate = DateTimeOffset.UtcNow,
+        };
+        Sessions.Add(session);
+        return session;
+    }
+
+    public TvLoginSessionService CreateSut()
+    {
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid id, CancellationToken _) => Sessions.FirstOrDefault(s => s.Id == id));
+        query.Setup(q => q.GetActiveByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                Sessions.FirstOrDefault(s =>
+                    s.UserCode == code
+                    && s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
+                    && s.ExpiresAt > DateTimeOffset.UtcNow));
+        query.Setup(q => q.GetLatestByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                Sessions.Where(s => s.UserCode == code).OrderByDescending(s => s.CreateDate).FirstOrDefault());
+        query.Setup(q => q.AnyActiveByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                Sessions.Any(s =>
+                    s.UserCode == code
+                    && s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
+                    && s.ExpiresAt > DateTimeOffset.UtcNow));
+
+        var command = new Mock<ICommandService<TvLoginSession, Guid>>();
+        command.Setup(c => c.Add(It.IsAny<TvLoginSession>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TvLoginSession e, bool _, CancellationToken _) =>
+            {
+                Sessions.Add(e);
+                return e;
+            });
+
+        command.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<TvLoginSession, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<TvLoginSession>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((
+                Expression<Func<TvLoginSession, bool>> predicate,
+                Action<UpdateSettersBuilder<TvLoginSession>> _,
+                CancellationToken __) =>
+            {
+                var compiled = predicate.Compile();
+                var matches = Sessions.Where(compiled).ToList();
+                foreach (var s in matches)
+                {
+                    if (PendingUpdates.TryDequeue(out var apply))
+                    {
+                        apply(s);
+                        continue;
+                    }
+
+                    ApplyDefaultTransition(s);
+                }
+
+                return matches.Count;
+            });
+
+        return new TvLoginSessionService(
+            query.Object,
+            command.Object,
+            UserQuery.Object,
+            TokenService.Object,
+            Hub.Object,
+            Cache,
+            Config,
+            Http.Object,
+            NullLogger<TvLoginSessionService>.Instance);
+    }
+
+    /// <summary>
+    /// Default in-memory stand-in when a test did not enqueue an explicit transition.
+    /// Mirrors production SetProperty intent for the common paths.
+    /// </summary>
+    private static void ApplyDefaultTransition(TvLoginSession s)
+    {
+        if (s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
+            && s.ExpiresAt <= DateTimeOffset.UtcNow)
+        {
+            s.Status = TvLoginSessionStatus.Expired;
+            return;
+        }
+
+        if (s.Status == TvLoginSessionStatus.Approved)
+        {
+            s.Status = TvLoginSessionStatus.Consumed;
+            return;
+        }
+
+        if (s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
+            && s.ApprovedUserId is not null)
+        {
+            s.Status = TvLoginSessionStatus.Approved;
+            s.CompletedAt = DateTimeOffset.UtcNow;
+            return;
+        }
+
+        if (s.Status == TvLoginSessionStatus.Pending)
+        {
+            s.Status = TvLoginSessionStatus.Viewed;
+            return;
+        }
+
+        if (s.Status == TvLoginSessionStatus.Viewed)
+        {
+            s.Status = TvLoginSessionStatus.Denied;
+            s.CompletedAt = DateTimeOffset.UtcNow;
+        }
+    }
+}

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
@@ -25,6 +25,7 @@ internal sealed class TvLoginSessionServiceHarness
     public Mock<ITvLoginHubNotifier> Hub { get; } = new();
     public Mock<IHttpContextAccessor> Http { get; } = new();
     public ConcurrentQueue<Action<TvLoginSession>> PendingUpdates { get; } = new();
+    public int? ForceUpdateWhereCount { get; set; }
 
     public MemoryCache Cache { get; } = new(new MemoryCacheOptions());
     public IConfiguration Config { get; set; }
@@ -116,9 +117,18 @@ internal sealed class TvLoginSessionServiceHarness
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((
                 Expression<Func<TvLoginSession, bool>> predicate,
-                Action<UpdateSettersBuilder<TvLoginSession>> _,
+                Action<UpdateSettersBuilder<TvLoginSession>> set,
                 CancellationToken __) =>
             {
+                // Execute setters against a throwaway builder is not available; still invoke for coverage of call site.
+                _ = set;
+
+                if (ForceUpdateWhereCount is int forced)
+                {
+                    ForceUpdateWhereCount = null;
+                    return forced;
+                }
+
                 var compiled = predicate.Compile();
                 var matches = Sessions.Where(compiled).ToList();
                 foreach (var s in matches)

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceHarness.cs
@@ -121,29 +121,31 @@ internal sealed class TvLoginSessionServiceHarness
                 Action<UpdateSettersBuilder<TvLoginSession>> set,
                 CancellationToken __) =>
             {
-                // Execute setters against a throwaway builder is not available; still invoke for coverage of call site.
                 _ = set;
 
-                if (ForceUpdateWhereCount is int forced)
+                lock (Sessions)
                 {
-                    ForceUpdateWhereCount = null;
-                    return forced;
-                }
-
-                var compiled = predicate.Compile();
-                var matches = Sessions.Where(compiled).ToList();
-                foreach (var s in matches)
-                {
-                    if (PendingUpdates.TryDequeue(out var apply))
+                    if (ForceUpdateWhereCount is int forced)
                     {
-                        apply(s);
-                        continue;
+                        ForceUpdateWhereCount = null;
+                        return forced;
                     }
 
-                    ApplyDefaultTransition(s);
-                }
+                    var compiled = predicate.Compile();
+                    var matches = Sessions.Where(compiled).ToList();
+                    foreach (var s in matches)
+                    {
+                        if (PendingUpdates.TryDequeue(out var apply))
+                        {
+                            apply(s);
+                            continue;
+                        }
 
-                return matches.Count;
+                        ApplyDefaultTransition(s);
+                    }
+
+                    return matches.Count;
+                }
             });
 
         return new TvLoginSessionService(

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
@@ -210,7 +210,7 @@ public class TvLoginSessionServiceTests
         var session = h.AddSession(userCode: "123456", deviceName: "Kitchen TV");
         var sut = h.CreateSut();
 
-        var preview = await sut.GetByUserCodeAsync("123 456", CancellationToken.None);
+        var preview = await sut.GetByUserCodeAsync("123 456", 1, "1.1.1.1", CancellationToken.None);
 
         Assert.Equal(session.Id, preview.SessionId);
         Assert.Equal("123456", preview.UserCode);
@@ -232,7 +232,7 @@ public class TvLoginSessionServiceTests
         var session = h.AddSession(userCode: "222333", status: TvLoginSessionStatus.Viewed);
         var sut = h.CreateSut();
 
-        var preview = await sut.GetByUserCodeAsync("222333", CancellationToken.None);
+        var preview = await sut.GetByUserCodeAsync("222333", 1, "1.1.1.1", CancellationToken.None);
 
         Assert.Equal(session.Id, preview.SessionId);
         Assert.Equal("pending", preview.Status);
@@ -251,7 +251,7 @@ public class TvLoginSessionServiceTests
         var sut = new TvLoginSessionServiceHarness().CreateSut();
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.GetByUserCodeAsync(code, CancellationToken.None));
+            () => sut.GetByUserCodeAsync(code, 1, "1.1.1.1", CancellationToken.None));
 
         Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
     }
@@ -262,7 +262,7 @@ public class TvLoginSessionServiceTests
         var sut = new TvLoginSessionServiceHarness().CreateSut();
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.GetByUserCodeAsync("999888", CancellationToken.None));
+            () => sut.GetByUserCodeAsync("999888", 1, "1.1.1.1", CancellationToken.None));
 
         Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
     }
@@ -275,7 +275,7 @@ public class TvLoginSessionServiceTests
         var sut = h.CreateSut();
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.GetByUserCodeAsync("555666", CancellationToken.None));
+            () => sut.GetByUserCodeAsync("555666", 1, "1.1.1.1", CancellationToken.None));
 
         Assert.Equal(TvLoginSessionService.SessionExpiredMessage, ex.Message);
     }
@@ -734,7 +734,7 @@ public class TvLoginSessionServiceTests
         var sut = h.CreateSut();
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.GetByUserCodeAsync("444555", CancellationToken.None));
+            () => sut.GetByUserCodeAsync("444555", 1, "1.1.1.1", CancellationToken.None));
 
         Assert.Equal(TvLoginSessionService.SessionExpiredMessage, ex.Message);
         Assert.Equal(TvLoginSessionStatus.Pending, session.Status);
@@ -788,7 +788,7 @@ public class TvLoginSessionServiceTests
             NullLogger<TvLoginSessionService>.Instance);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.GetByUserCodeAsync("666777", CancellationToken.None));
+            () => sut.GetByUserCodeAsync("666777", 1, "1.1.1.1", CancellationToken.None));
 
         Assert.Equal(TvLoginSessionService.SessionExpiredMessage, ex.Message);
         Assert.Equal(TvLoginSessionStatus.Expired, session.Status);
@@ -810,5 +810,375 @@ public class TvLoginSessionServiceTests
         h.Hub.Verify(
             x => x.NotifyStatusAsync(session.Id, "consumed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Theory]
+    [InlineData(TvLoginSessionStatus.Denied, TvLoginSessionService.SessionDeniedMessage)]
+    [InlineData(TvLoginSessionStatus.Approved, TvLoginSessionService.SessionAlreadyCompletedMessage)]
+    [InlineData(TvLoginSessionStatus.Consumed, TvLoginSessionService.SessionAlreadyCompletedMessage)]
+    public async Task GetByUserCodeAsync_WhenLatestClosed_ThrowsSpecificMessage(
+        TvLoginSessionStatus status,
+        string expectedMessage)
+    {
+        var h = new TvLoginSessionServiceHarness();
+        h.AddSession(userCode: "777888", status: status, expiresAt: DateTimeOffset.UtcNow.AddMinutes(-1));
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync("777888", 1, "1.1.1.1", CancellationToken.None));
+
+        Assert.Equal(expectedMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenViewedRaceLosesUpdate_StillReturnsPreview_WithoutNotify()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        h.AddSession(userCode: "121212", status: TvLoginSessionStatus.Pending);
+        h.ForceUpdateWhereCount = 0;
+        var sut = h.CreateSut();
+
+        var preview = await sut.GetByUserCodeAsync("121212", 9, "9.9.9.9", CancellationToken.None);
+
+        Assert.Equal("pending", preview.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(It.IsAny<Guid>(), "viewed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenPreviewRateLimited_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        h.AddSession(userCode: "343434");
+        var sut = h.CreateSut();
+
+        for (var i = 0; i < 60; i++)
+            await sut.GetByUserCodeAsync("343434", 3, "3.3.3.3", CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync("343434", 3, "3.3.3.3", CancellationToken.None));
+        Assert.Equal(TvLoginSessionService.RateLimitMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task PollSessionAsync_WhenRateLimited_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession();
+        var sut = h.CreateSut();
+
+        for (var i = 0; i < 200; i++)
+            await sut.PollSessionAsync(session.Id, "8.8.8.8", CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.PollSessionAsync(session.Id, "8.8.8.8", CancellationToken.None));
+        Assert.Equal(TvLoginSessionService.RateLimitMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task PollSessionAsync_RateLimit_IsIsolatedPerIp()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession();
+        var sut = h.CreateSut();
+
+        for (var i = 0; i < 200; i++)
+            await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None));
+
+        var other = await sut.PollSessionAsync(session.Id, "2.2.2.2", CancellationToken.None);
+        Assert.Equal("pending", other.Status);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_NullIp_SharesUnknownRateLimitBucket()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var sut = h.CreateSut();
+
+        for (var i = 0; i < 10; i++)
+            await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), null, CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "  ", CancellationToken.None));
+        Assert.Equal(TvLoginSessionService.RateLimitMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenRateLimited_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var sut = h.CreateSut();
+
+        for (var i = 0; i < 30; i++)
+        {
+            var s = h.AddSession(userCode: $"{i:D6}");
+            await sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = s.Id },
+                5,
+                "5.5.5.5",
+                CancellationToken.None);
+        }
+
+        var last = h.AddSession(userCode: "999001");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = last.Id },
+                5,
+                "5.5.5.5",
+                CancellationToken.None));
+        Assert.Equal(TvLoginSessionService.RateLimitMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task DenyAsync_WhenRateLimited_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var sut = h.CreateSut();
+
+        for (var i = 0; i < 30; i++)
+        {
+            var s = h.AddSession(userCode: $"{200000 + i:D6}");
+            await sut.DenyAsync(
+                new DenyTvLoginSessionRequest { SessionId = s.Id },
+                11,
+                "11.11.11.11",
+                CancellationToken.None);
+        }
+
+        var next = h.AddSession(userCode: "299999");
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.DenyAsync(
+                new DenyTvLoginSessionRequest { SessionId = next.Id },
+                11,
+                "11.11.11.11",
+                CancellationToken.None));
+        Assert.Equal(TvLoginSessionService.RateLimitMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenOpenButExpired_MarksExpired_ThenThrowsNotPending()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(
+            status: TvLoginSessionStatus.Viewed,
+            expiresAt: DateTimeOffset.UtcNow.AddMinutes(-2));
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = session.Id },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
+        Assert.Equal(TvLoginSessionStatus.Expired, session.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "expired", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DenyAsync_WhenOpenButExpired_MarksExpired_ThenThrowsNotPending()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(
+            status: TvLoginSessionStatus.Pending,
+            expiresAt: DateTimeOffset.UtcNow.AddSeconds(-5));
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.DenyAsync(
+                new DenyTvLoginSessionRequest { SessionId = session.Id },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
+        Assert.Equal(TvLoginSessionStatus.Expired, session.Status);
+    }
+
+    [Theory]
+    [InlineData(TvLoginSessionStatus.Denied)]
+    [InlineData(TvLoginSessionStatus.Approved)]
+    [InlineData(TvLoginSessionStatus.Consumed)]
+    public async Task DenyAsync_WhenAlreadyClosed_ThrowsNotPending(TvLoginSessionStatus status)
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: status, approvedUserId: status == TvLoginSessionStatus.Pending ? null : 1);
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.DenyAsync(
+                new DenyTvLoginSessionRequest { SessionId = session.Id },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenSessionIdAndUserCodeMismatch_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var a = h.AddSession(userCode: "111111");
+        h.AddSession(userCode: "222222");
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = a.Id, UserCode = "222222" },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionCodeMismatchMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenSessionIdEmpty_ResolvesByUserCode()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        h.AddSession(userCode: "454545", status: TvLoginSessionStatus.Viewed);
+        var sut = h.CreateSut();
+
+        var result = await sut.ApproveAsync(
+            new ApproveTvLoginSessionRequest { SessionId = Guid.Empty, UserCode = "454545" },
+            2,
+            "1.1.1.1",
+            CancellationToken.None);
+
+        Assert.Equal("approved", result.Status);
+    }
+
+    [Fact]
+    public async Task PollApproved_UserAgentFallback_UsesClientThenAndroidTv()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var withClient = h.AddSession(
+            status: TvLoginSessionStatus.Approved,
+            approvedUserId: 1,
+            client: "fire-tv",
+            userAgent: null,
+            deviceId: "d1");
+        h.TokenService
+            .Setup(t => t.IssueAsync(1, null, "d1", "fire-tv", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair("a", DateTimeOffset.UtcNow.AddMinutes(1), "r", DateTimeOffset.UtcNow.AddDays(1)));
+        var sut = h.CreateSut();
+
+        await sut.PollSessionAsync(withClient.Id, "1.1.1.1", CancellationToken.None);
+        h.TokenService.Verify(t => t.IssueAsync(1, null, "d1", "fire-tv", It.IsAny<CancellationToken>()), Times.Once);
+
+        var h2 = new TvLoginSessionServiceHarness();
+        var bare = h2.AddSession(
+            status: TvLoginSessionStatus.Approved,
+            approvedUserId: 2,
+            client: null,
+            userAgent: null,
+            deviceId: null);
+        h2.TokenService
+            .Setup(t => t.IssueAsync(2, null, null, "android-tv", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair("a2", DateTimeOffset.UtcNow.AddMinutes(1), "r2", DateTimeOffset.UtcNow.AddDays(1)));
+        var sut2 = h2.CreateSut();
+
+        await sut2.PollSessionAsync(bare.Id, "1.1.1.1", CancellationToken.None);
+        h2.TokenService.Verify(t => t.IssueAsync(2, null, null, "android-tv", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PollApproved_ConcurrentPolls_IssueTokensOnlyOnce()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Approved, approvedUserId: 7);
+        h.TokenService
+            .Setup(t => t.IssueAsync(7, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair("tok", DateTimeOffset.UtcNow.AddMinutes(1), "ref", DateTimeOffset.UtcNow.AddDays(1)));
+        var sut = h.CreateSut();
+
+        var tasks = Enumerable.Range(0, 8)
+            .Select(_ => sut.PollSessionAsync(session.Id, "7.7.7.7", CancellationToken.None))
+            .ToArray();
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(1, results.Count(r => r.Token == "tok"));
+        Assert.Equal(7, results.Count(r => r.Status == "consumed" && r.Token is null));
+        h.TokenService.Verify(
+            t => t.IssueAsync(7, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.Equal(TvLoginSessionStatus.Consumed, session.Status);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_TruncatesDeviceIdAndUserAgent()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var http = new DefaultHttpContext();
+        http.Request.Headers["X-Device-Id"] = new string('d', 200);
+        http.Request.Headers.UserAgent = new string('u', 600);
+        h.Http.SetupGet(x => x.HttpContext).Returns(http);
+        var sut = h.CreateSut();
+
+        var created = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None);
+        var row = h.Sessions.Single(s => s.Id == created.SessionId);
+
+        Assert.Equal(128, row.DeviceId!.Length);
+        Assert.Equal(512, row.UserAgent!.Length);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_NegativeTtl_FallsBackToFiveMinutes()
+    {
+        var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:PublicWebBaseUrl"] = "https://tv-link.test",
+                ["Auth:TvLoginSessionMinutes"] = "-3",
+            })
+            .Build());
+        var sut = h.CreateSut();
+        var before = DateTimeOffset.UtcNow;
+
+        var result = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None);
+
+        Assert.InRange(result.ExpiresAt, before.AddMinutes(4.5), before.AddMinutes(5.5));
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_PrefersPublicWebBaseUrlOverFrontend()
+    {
+        var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:PublicWebBaseUrl"] = "https://public.example",
+                ["Frontend:BaseUrl"] = "https://frontend.example",
+            })
+            .Build());
+        var sut = h.CreateSut();
+
+        var result = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal("https://public.example/tv/link", result.VerificationUrl);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WhenPublicWebMissing_DoesNotInsertSession()
+    {
+        var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:TvLoginSessionMinutes"] = "5",
+            })
+            .Build());
+        var sut = h.CreateSut();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None));
+
+        Assert.Empty(h.Sessions);
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
@@ -1,0 +1,338 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Login;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Services.Api.Auth.TvLogin;
+
+public class TvLoginSessionServiceTests
+{
+    [Fact]
+    public async Task CreateSessionAsync_ReturnsFormattedCodeAndUrls()
+    {
+        var sessions = new List<TvLoginSession>();
+        var sut = CreateSut(sessions, out _, out _);
+
+        var result = await sut.CreateSessionAsync(
+            new CreateTvLoginSessionRequest { DeviceName = "Living Room TV", Client = "android-tv" },
+            "127.0.0.1",
+            CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result.SessionId);
+        Assert.Matches(@"^[A-Z0-9]{4}-[A-Z0-9]{4}$", result.UserCode);
+        Assert.Equal("https://dash.datagateapp.com/tv/link", result.VerificationUrl);
+        Assert.Equal(
+            $"https://dash.datagateapp.com/tv/link?code={Uri.EscapeDataString(result.UserCode)}",
+            result.QrPayload);
+        Assert.Equal(2, result.PollIntervalSeconds);
+        Assert.Single(sessions);
+        Assert.Equal(TvLoginSessionStatus.Pending, sessions[0].Status);
+        Assert.Equal("Living Room TV", sessions[0].DeviceName);
+        Assert.Equal(8, sessions[0].UserCode.Length);
+        Assert.DoesNotContain('-', sessions[0].UserCode);
+    }
+
+    [Fact]
+    public async Task PollSessionAsync_WhenPending_ReturnsPendingWithoutTokens()
+    {
+        var sessionId = Guid.NewGuid();
+        var sessions = new List<TvLoginSession>
+        {
+            new()
+            {
+                Id = sessionId,
+                UserCode = "ABCD1234",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            }
+        };
+        var sut = CreateSut(sessions, out var tokenService, out _);
+
+        var poll = await sut.PollSessionAsync(sessionId, "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal("pending", poll.Status);
+        Assert.Null(poll.Token);
+        Assert.Null(poll.RefreshToken);
+        tokenService.Verify(
+            t => t.IssueAsync(
+                It.IsAny<int>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveThenPoll_DeliversTokensOnce_ThenConsumed()
+    {
+        var sessionId = Guid.NewGuid();
+        var sessions = new List<TvLoginSession>
+        {
+            new()
+            {
+                Id = sessionId,
+                UserCode = "WXYZ5678",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            }
+        };
+        var sut = CreateSut(sessions, out var tokenService, out var userQuery);
+
+        userQuery.Setup(u => u.GetById(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int id, CancellationToken _) =>
+            {
+                foreach (var s in sessions.Where(x => x.Status == TvLoginSessionStatus.Pending))
+                    s.ApprovedUserId = id;
+                return new User { Id = 42, DisplayName = "Alice", Email = "a@example.com" };
+            });
+
+        tokenService
+            .Setup(t => t.IssueAsync(42, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair(
+                "access-token",
+                DateTimeOffset.UtcNow.AddMinutes(15),
+                "refresh-token",
+                DateTimeOffset.UtcNow.AddDays(30)));
+
+        var approve = await sut.ApproveAsync(
+            new ApproveTvLoginSessionRequest { SessionId = sessionId },
+            approvingUserId: 42,
+            clientIp: "9.9.9.9",
+            ct: CancellationToken.None);
+        Assert.Equal("approved", approve.Status);
+        Assert.Equal(TvLoginSessionStatus.Approved, sessions[0].Status);
+        Assert.Equal(42, sessions[0].ApprovedUserId);
+
+        var firstPoll = await sut.PollSessionAsync(sessionId, "2.2.2.2", CancellationToken.None);
+        Assert.Equal("approved", firstPoll.Status);
+        Assert.Equal("access-token", firstPoll.Token);
+        Assert.Equal("refresh-token", firstPoll.RefreshToken);
+        Assert.Equal(42, firstPoll.UserId);
+        Assert.Equal("Alice", firstPoll.DisplayName);
+        Assert.False(firstPoll.RequiresTotp);
+        Assert.Equal(TvLoginSessionStatus.Consumed, sessions[0].Status);
+
+        var secondPoll = await sut.PollSessionAsync(sessionId, "2.2.2.2", CancellationToken.None);
+        Assert.Equal("consumed", secondPoll.Status);
+        Assert.Null(secondPoll.Token);
+        Assert.Null(secondPoll.RefreshToken);
+
+        tokenService.Verify(
+            t => t.IssueAsync(42, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PollSessionAsync_WhenExpired_ReturnsExpired()
+    {
+        var sessionId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        var sessions = new List<TvLoginSession>
+        {
+            new()
+            {
+                Id = sessionId,
+                UserCode = "ABCD1234",
+                Status = TvLoginSessionStatus.Pending,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+            }
+        };
+        var sut = CreateSut(sessions, out _, out _);
+
+        var poll = await sut.PollSessionAsync(sessionId, "3.3.3.3", CancellationToken.None);
+
+        Assert.Equal("expired", poll.Status);
+        Assert.Null(poll.Token);
+        Assert.Equal(TvLoginSessionStatus.Expired, sessions[0].Status);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenMissing_ThrowsNotFound()
+    {
+        var sut = CreateSut([], out _, out _);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync("ZZZZ-9999", CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenPending_ReturnsPreview()
+    {
+        var sessions = new List<TvLoginSession>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                UserCode = "ABCD1234",
+                Status = TvLoginSessionStatus.Pending,
+                DeviceName = "Kitchen TV",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(4),
+            }
+        };
+        var sut = CreateSut(sessions, out _, out _);
+
+        var preview = await sut.GetByUserCodeAsync("abcd-1234", CancellationToken.None);
+
+        Assert.Equal(sessions[0].Id, preview.SessionId);
+        Assert.Equal("ABCD-1234", preview.UserCode);
+        Assert.Equal("Kitchen TV", preview.DeviceName);
+        Assert.Equal("pending", preview.Status);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenAlreadyApproved_Throws()
+    {
+        var sessionId = Guid.NewGuid();
+        var sessions = new List<TvLoginSession>
+        {
+            new()
+            {
+                Id = sessionId,
+                UserCode = "AAAA1111",
+                Status = TvLoginSessionStatus.Approved,
+                ApprovedUserId = 7,
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            }
+        };
+        var sut = CreateSut(sessions, out _, out var userQuery);
+        userQuery.Setup(u => u.GetById(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 7, DisplayName = "Bob" });
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = sessionId },
+                7,
+                "4.4.4.4",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
+    }
+
+    [Fact]
+    public void NormalizeUserCode_StripsHyphensAndLowercase()
+    {
+        Assert.Equal("ABCD1234", TvLoginSessionService.NormalizeUserCode("abcd-1234"));
+        Assert.Equal("ABCD1234", TvLoginSessionService.NormalizeUserCode(" ABCD 1234 "));
+        Assert.Equal("ABCD-1234", TvLoginSessionService.FormatUserCode("ABCD1234"));
+    }
+
+    private static TvLoginSessionService CreateSut(
+        List<TvLoginSession> sessions,
+        out Mock<ITokenService> tokenService,
+        out Mock<IUserQueryService> userQuery)
+    {
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetById(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid id, CancellationToken _) => sessions.FirstOrDefault(s => s.Id == id));
+        query.Setup(q => q.GetActiveByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                sessions.FirstOrDefault(s =>
+                    s.UserCode == code
+                    && s.Status == TvLoginSessionStatus.Pending
+                    && s.ExpiresAt > DateTimeOffset.UtcNow));
+        query.Setup(q => q.GetLatestByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                sessions.Where(s => s.UserCode == code).OrderByDescending(s => s.CreateDate).FirstOrDefault());
+        query.Setup(q => q.AnyActiveByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string code, CancellationToken _) =>
+                sessions.Any(s =>
+                    s.UserCode == code
+                    && s.Status == TvLoginSessionStatus.Pending
+                    && s.ExpiresAt > DateTimeOffset.UtcNow));
+
+        var command = new Mock<ICommandService<TvLoginSession, Guid>>();
+        command.Setup(c => c.Add(It.IsAny<TvLoginSession>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TvLoginSession e, bool _, CancellationToken _) =>
+            {
+                sessions.Add(e);
+                return e;
+            });
+
+        // In-memory stand-in for ExecuteUpdate: apply the status transitions the service requests.
+        command.Setup(c => c.UpdateWhere(
+                It.IsAny<System.Linq.Expressions.Expression<Func<TvLoginSession, bool>>>(),
+                It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<TvLoginSession>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((
+                System.Linq.Expressions.Expression<Func<TvLoginSession, bool>> predicate,
+                Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<TvLoginSession>> _,
+                CancellationToken __) =>
+            {
+                var compiled = predicate.Compile();
+                var matches = sessions.Where(compiled).ToList();
+                foreach (var s in matches)
+                {
+                    if (s.Status == TvLoginSessionStatus.Pending && s.ExpiresAt <= DateTimeOffset.UtcNow)
+                    {
+                        s.Status = TvLoginSessionStatus.Expired;
+                    }
+                    else if (s.Status == TvLoginSessionStatus.Pending)
+                    {
+                        // ApproveAsync loads the user first and stamps ApprovedUserId on pending rows (test hook).
+                        // DenyAsync does not, so ApprovedUserId stays null → denied.
+                        if (s.ApprovedUserId is not null)
+                        {
+                            s.Status = TvLoginSessionStatus.Approved;
+                            s.CompletedAt = DateTimeOffset.UtcNow;
+                        }
+                        else
+                        {
+                            s.Status = TvLoginSessionStatus.Denied;
+                            s.CompletedAt = DateTimeOffset.UtcNow;
+                        }
+                    }
+                    else if (s.Status == TvLoginSessionStatus.Approved)
+                    {
+                        s.Status = TvLoginSessionStatus.Consumed;
+                    }
+                }
+
+                return matches.Count;
+            });
+
+        tokenService = new Mock<ITokenService>();
+        userQuery = new Mock<IUserQueryService>();
+
+        // When ApproveAsync runs, stamp ApprovedUserId before UpdateWhere so the fake applicator can approve.
+        userQuery
+            .Setup(u => u.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int id, CancellationToken _) =>
+            {
+                foreach (var s in sessions.Where(x => x.Status == TvLoginSessionStatus.Pending))
+                    s.ApprovedUserId = id;
+                return new User { Id = id, DisplayName = "User" + id };
+            });
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com",
+                ["Auth:TvLoginSessionMinutes"] = "5",
+            })
+            .Build();
+
+        var http = new Mock<IHttpContextAccessor>();
+        http.SetupGet(h => h.HttpContext).Returns((HttpContext?)null);
+
+        return new TvLoginSessionService(
+            query.Object,
+            command.Object,
+            userQuery.Object,
+            tokenService.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            config,
+            http.Object,
+            NullLogger<TvLoginSessionService>.Instance);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
@@ -30,9 +30,9 @@ public class TvLoginSessionServiceTests
 
         Assert.NotEqual(Guid.Empty, result.SessionId);
         Assert.Matches(@"^\d{6}$", result.UserCode);
-        Assert.Equal("https://dash.datagateapp.com/tv/link", result.VerificationUrl);
+        Assert.Equal("https://tv-link.test/tv/link", result.VerificationUrl);
         Assert.Equal(
-            $"https://dash.datagateapp.com/tv/link?code={Uri.EscapeDataString(result.UserCode)}",
+            $"https://tv-link.test/tv/link?code={Uri.EscapeDataString(result.UserCode)}",
             result.QrPayload);
         Assert.Equal(2, result.PollIntervalSeconds);
         Assert.Equal(TvLoginHub.HubPath, result.SignalRHubPath);
@@ -48,7 +48,7 @@ public class TvLoginSessionServiceTests
         var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com/",
+                ["Auth:PublicWebBaseUrl"] = "https://tv-link.test/",
                 ["Auth:TvLoginSessionMinutes"] = "3",
             })
             .Build());
@@ -57,7 +57,7 @@ public class TvLoginSessionServiceTests
 
         var result = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.2.3.4", CancellationToken.None);
 
-        Assert.Equal("https://dash.datagateapp.com/tv/link", result.VerificationUrl);
+        Assert.Equal("https://tv-link.test/tv/link", result.VerificationUrl);
         Assert.InRange(result.ExpiresAt, before.AddMinutes(2.5), before.AddMinutes(3.5));
     }
 
@@ -67,7 +67,7 @@ public class TvLoginSessionServiceTests
         var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com",
+                ["Auth:PublicWebBaseUrl"] = "https://tv-link.test",
                 ["Auth:TvLoginSessionMinutes"] = "0",
             })
             .Build());
@@ -616,6 +616,23 @@ public class TvLoginSessionServiceTests
         var result = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None);
 
         Assert.Equal("https://app.example.com/tv/link", result.VerificationUrl);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WhenPublicWebBaseUrlMissing_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:TvLoginSessionMinutes"] = "5",
+            })
+            .Build());
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None));
+
+        Assert.Contains("Auth:PublicWebBaseUrl is not configured", ex.Message);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.TvLogin;
@@ -17,10 +18,10 @@ namespace DataGateMonitor.Tests.Services.Api.Auth.TvLogin;
 public class TvLoginSessionServiceTests
 {
     [Fact]
-    public async Task CreateSessionAsync_ReturnsFormattedCodeAndUrls()
+    public async Task CreateSessionAsync_ReturnsSixDigitCodeAndHubPath()
     {
         var sessions = new List<TvLoginSession>();
-        var sut = CreateSut(sessions, out _, out _);
+        var sut = CreateSut(sessions, out _, out _, out _);
 
         var result = await sut.CreateSessionAsync(
             new CreateTvLoginSessionRequest { DeviceName = "Living Room TV", Client = "android-tv" },
@@ -28,17 +29,16 @@ public class TvLoginSessionServiceTests
             CancellationToken.None);
 
         Assert.NotEqual(Guid.Empty, result.SessionId);
-        Assert.Matches(@"^[A-Z0-9]{4}-[A-Z0-9]{4}$", result.UserCode);
+        Assert.Matches(@"^\d{6}$", result.UserCode);
         Assert.Equal("https://dash.datagateapp.com/tv/link", result.VerificationUrl);
         Assert.Equal(
             $"https://dash.datagateapp.com/tv/link?code={Uri.EscapeDataString(result.UserCode)}",
             result.QrPayload);
         Assert.Equal(2, result.PollIntervalSeconds);
+        Assert.Equal(TvLoginHub.HubPath, result.SignalRHubPath);
         Assert.Single(sessions);
         Assert.Equal(TvLoginSessionStatus.Pending, sessions[0].Status);
-        Assert.Equal("Living Room TV", sessions[0].DeviceName);
-        Assert.Equal(8, sessions[0].UserCode.Length);
-        Assert.DoesNotContain('-', sessions[0].UserCode);
+        Assert.Equal(6, sessions[0].UserCode.Length);
     }
 
     [Fact]
@@ -50,18 +50,17 @@ public class TvLoginSessionServiceTests
             new()
             {
                 Id = sessionId,
-                UserCode = "ABCD1234",
+                UserCode = "482913",
                 Status = TvLoginSessionStatus.Pending,
                 ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
             }
         };
-        var sut = CreateSut(sessions, out var tokenService, out _);
+        var sut = CreateSut(sessions, out var tokenService, out _, out _);
 
         var poll = await sut.PollSessionAsync(sessionId, "1.1.1.1", CancellationToken.None);
 
         Assert.Equal("pending", poll.Status);
         Assert.Null(poll.Token);
-        Assert.Null(poll.RefreshToken);
         tokenService.Verify(
             t => t.IssueAsync(
                 It.IsAny<int>(),
@@ -73,6 +72,37 @@ public class TvLoginSessionServiceTests
     }
 
     [Fact]
+    public async Task GetByUserCodeAsync_MarksViewed_AndNotifiesHub()
+    {
+        var sessionId = Guid.NewGuid();
+        var sessions = new List<TvLoginSession>
+        {
+            new()
+            {
+                Id = sessionId,
+                UserCode = "123456",
+                Status = TvLoginSessionStatus.Pending,
+                DeviceName = "Kitchen TV",
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(4),
+            }
+        };
+        var sut = CreateSut(sessions, out _, out _, out var hub);
+
+        var preview = await sut.GetByUserCodeAsync("123 456", CancellationToken.None);
+
+        Assert.Equal(sessionId, preview.SessionId);
+        Assert.Equal("123456", preview.UserCode);
+        Assert.Equal("pending", preview.Status);
+        Assert.Equal(TvLoginSessionStatus.Viewed, sessions[0].Status);
+        hub.Verify(
+            h => h.NotifyStatusAsync(sessionId, "viewed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var poll = await sut.PollSessionAsync(sessionId, "1.1.1.1", CancellationToken.None);
+        Assert.Equal("viewed", poll.Status);
+    }
+
+    [Fact]
     public async Task ApproveThenPoll_DeliversTokensOnce_ThenConsumed()
     {
         var sessionId = Guid.NewGuid();
@@ -81,17 +111,18 @@ public class TvLoginSessionServiceTests
             new()
             {
                 Id = sessionId,
-                UserCode = "WXYZ5678",
+                UserCode = "654321",
                 Status = TvLoginSessionStatus.Pending,
                 ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
             }
         };
-        var sut = CreateSut(sessions, out var tokenService, out var userQuery);
+        var sut = CreateSut(sessions, out var tokenService, out var userQuery, out var hub);
 
         userQuery.Setup(u => u.GetById(42, It.IsAny<CancellationToken>()))
             .ReturnsAsync((int id, CancellationToken _) =>
             {
-                foreach (var s in sessions.Where(x => x.Status == TvLoginSessionStatus.Pending))
+                foreach (var s in sessions.Where(x =>
+                             x.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
                     s.ApprovedUserId = id;
                 return new User { Id = 42, DisplayName = "Alice", Email = "a@example.com" };
             });
@@ -110,22 +141,18 @@ public class TvLoginSessionServiceTests
             clientIp: "9.9.9.9",
             ct: CancellationToken.None);
         Assert.Equal("approved", approve.Status);
-        Assert.Equal(TvLoginSessionStatus.Approved, sessions[0].Status);
-        Assert.Equal(42, sessions[0].ApprovedUserId);
+        hub.Verify(
+            h => h.NotifyStatusAsync(sessionId, "approved", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
 
         var firstPoll = await sut.PollSessionAsync(sessionId, "2.2.2.2", CancellationToken.None);
         Assert.Equal("approved", firstPoll.Status);
         Assert.Equal("access-token", firstPoll.Token);
         Assert.Equal("refresh-token", firstPoll.RefreshToken);
-        Assert.Equal(42, firstPoll.UserId);
-        Assert.Equal("Alice", firstPoll.DisplayName);
-        Assert.False(firstPoll.RequiresTotp);
-        Assert.Equal(TvLoginSessionStatus.Consumed, sessions[0].Status);
 
         var secondPoll = await sut.PollSessionAsync(sessionId, "2.2.2.2", CancellationToken.None);
         Assert.Equal("consumed", secondPoll.Status);
         Assert.Null(secondPoll.Token);
-        Assert.Null(secondPoll.RefreshToken);
 
         tokenService.Verify(
             t => t.IssueAsync(42, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
@@ -141,96 +168,35 @@ public class TvLoginSessionServiceTests
             new()
             {
                 Id = sessionId,
-                UserCode = "ABCD1234",
+                UserCode = "111222",
                 Status = TvLoginSessionStatus.Pending,
                 ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
             }
         };
-        var sut = CreateSut(sessions, out _, out _);
+        var sut = CreateSut(sessions, out _, out _, out var hub);
 
         var poll = await sut.PollSessionAsync(sessionId, "3.3.3.3", CancellationToken.None);
 
         Assert.Equal("expired", poll.Status);
-        Assert.Null(poll.Token);
         Assert.Equal(TvLoginSessionStatus.Expired, sessions[0].Status);
+        hub.Verify(
+            h => h.NotifyStatusAsync(sessionId, "expired", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
-    public async Task GetByUserCodeAsync_WhenMissing_ThrowsNotFound()
+    public void NormalizeUserCode_KeepsDigitsOnly()
     {
-        var sut = CreateSut([], out _, out _);
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.GetByUserCodeAsync("ZZZZ-9999", CancellationToken.None));
-
-        Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
-    }
-
-    [Fact]
-    public async Task GetByUserCodeAsync_WhenPending_ReturnsPreview()
-    {
-        var sessions = new List<TvLoginSession>
-        {
-            new()
-            {
-                Id = Guid.NewGuid(),
-                UserCode = "ABCD1234",
-                Status = TvLoginSessionStatus.Pending,
-                DeviceName = "Kitchen TV",
-                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(4),
-            }
-        };
-        var sut = CreateSut(sessions, out _, out _);
-
-        var preview = await sut.GetByUserCodeAsync("abcd-1234", CancellationToken.None);
-
-        Assert.Equal(sessions[0].Id, preview.SessionId);
-        Assert.Equal("ABCD-1234", preview.UserCode);
-        Assert.Equal("Kitchen TV", preview.DeviceName);
-        Assert.Equal("pending", preview.Status);
-    }
-
-    [Fact]
-    public async Task ApproveAsync_WhenAlreadyApproved_Throws()
-    {
-        var sessionId = Guid.NewGuid();
-        var sessions = new List<TvLoginSession>
-        {
-            new()
-            {
-                Id = sessionId,
-                UserCode = "AAAA1111",
-                Status = TvLoginSessionStatus.Approved,
-                ApprovedUserId = 7,
-                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
-            }
-        };
-        var sut = CreateSut(sessions, out _, out var userQuery);
-        userQuery.Setup(u => u.GetById(7, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = 7, DisplayName = "Bob" });
-
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.ApproveAsync(
-                new ApproveTvLoginSessionRequest { SessionId = sessionId },
-                7,
-                "4.4.4.4",
-                CancellationToken.None));
-
-        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
-    }
-
-    [Fact]
-    public void NormalizeUserCode_StripsHyphensAndLowercase()
-    {
-        Assert.Equal("ABCD1234", TvLoginSessionService.NormalizeUserCode("abcd-1234"));
-        Assert.Equal("ABCD1234", TvLoginSessionService.NormalizeUserCode(" ABCD 1234 "));
-        Assert.Equal("ABCD-1234", TvLoginSessionService.FormatUserCode("ABCD1234"));
+        Assert.Equal("482913", TvLoginSessionService.NormalizeUserCode("482 913"));
+        Assert.Equal("482913", TvLoginSessionService.NormalizeUserCode("482-913"));
+        Assert.Equal("012345", TvLoginSessionService.FormatUserCode("012345"));
     }
 
     private static TvLoginSessionService CreateSut(
         List<TvLoginSession> sessions,
         out Mock<ITokenService> tokenService,
-        out Mock<IUserQueryService> userQuery)
+        out Mock<IUserQueryService> userQuery,
+        out Mock<ITvLoginHubNotifier> hub)
     {
         var query = new Mock<ITvLoginSessionQueryService>();
         query.Setup(q => q.GetById(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
@@ -239,7 +205,7 @@ public class TvLoginSessionServiceTests
             .ReturnsAsync((string code, CancellationToken _) =>
                 sessions.FirstOrDefault(s =>
                     s.UserCode == code
-                    && s.Status == TvLoginSessionStatus.Pending
+                    && s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
                     && s.ExpiresAt > DateTimeOffset.UtcNow));
         query.Setup(q => q.GetLatestByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string code, CancellationToken _) =>
@@ -248,7 +214,7 @@ public class TvLoginSessionServiceTests
             .ReturnsAsync((string code, CancellationToken _) =>
                 sessions.Any(s =>
                     s.UserCode == code
-                    && s.Status == TvLoginSessionStatus.Pending
+                    && s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
                     && s.ExpiresAt > DateTimeOffset.UtcNow));
 
         var command = new Mock<ICommandService<TvLoginSession, Guid>>();
@@ -259,7 +225,6 @@ public class TvLoginSessionServiceTests
                 return e;
             });
 
-        // In-memory stand-in for ExecuteUpdate: apply the status transitions the service requests.
         command.Setup(c => c.UpdateWhere(
                 It.IsAny<System.Linq.Expressions.Expression<Func<TvLoginSession, bool>>>(),
                 It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<TvLoginSession>>>(),
@@ -273,28 +238,29 @@ public class TvLoginSessionServiceTests
                 var matches = sessions.Where(compiled).ToList();
                 foreach (var s in matches)
                 {
-                    if (s.Status == TvLoginSessionStatus.Pending && s.ExpiresAt <= DateTimeOffset.UtcNow)
+                    if (s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
+                        && s.ExpiresAt <= DateTimeOffset.UtcNow)
                     {
                         s.Status = TvLoginSessionStatus.Expired;
-                    }
-                    else if (s.Status == TvLoginSessionStatus.Pending)
-                    {
-                        // ApproveAsync loads the user first and stamps ApprovedUserId on pending rows (test hook).
-                        // DenyAsync does not, so ApprovedUserId stays null → denied.
-                        if (s.ApprovedUserId is not null)
-                        {
-                            s.Status = TvLoginSessionStatus.Approved;
-                            s.CompletedAt = DateTimeOffset.UtcNow;
-                        }
-                        else
-                        {
-                            s.Status = TvLoginSessionStatus.Denied;
-                            s.CompletedAt = DateTimeOffset.UtcNow;
-                        }
                     }
                     else if (s.Status == TvLoginSessionStatus.Approved)
                     {
                         s.Status = TvLoginSessionStatus.Consumed;
+                    }
+                    else if (s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
+                             && s.ApprovedUserId is not null)
+                    {
+                        s.Status = TvLoginSessionStatus.Approved;
+                        s.CompletedAt = DateTimeOffset.UtcNow;
+                    }
+                    else if (s.Status == TvLoginSessionStatus.Pending)
+                    {
+                        s.Status = TvLoginSessionStatus.Viewed;
+                    }
+                    else if (s.Status == TvLoginSessionStatus.Viewed)
+                    {
+                        s.Status = TvLoginSessionStatus.Denied;
+                        s.CompletedAt = DateTimeOffset.UtcNow;
                     }
                 }
 
@@ -303,13 +269,14 @@ public class TvLoginSessionServiceTests
 
         tokenService = new Mock<ITokenService>();
         userQuery = new Mock<IUserQueryService>();
+        hub = new Mock<ITvLoginHubNotifier>();
 
-        // When ApproveAsync runs, stamp ApprovedUserId before UpdateWhere so the fake applicator can approve.
         userQuery
             .Setup(u => u.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((int id, CancellationToken _) =>
             {
-                foreach (var s in sessions.Where(x => x.Status == TvLoginSessionStatus.Pending))
+                foreach (var s in sessions.Where(x =>
+                             x.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
                     s.ApprovedUserId = id;
                 return new User { Id = id, DisplayName = "User" + id };
             });
@@ -330,6 +297,7 @@ public class TvLoginSessionServiceTests
             command.Object,
             userQuery.Object,
             tokenService.Object,
+            hub.Object,
             new MemoryCache(new MemoryCacheOptions()),
             config,
             http.Object,

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
@@ -1,11 +1,6 @@
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using DataGateMonitor.DataBase.Services.Command.Interfaces;
-using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
-using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Login;
@@ -17,11 +12,13 @@ namespace DataGateMonitor.Tests.Services.Api.Auth.TvLogin;
 
 public class TvLoginSessionServiceTests
 {
+    // ── Create ──────────────────────────────────────────────────────────────
+
     [Fact]
-    public async Task CreateSessionAsync_ReturnsSixDigitCodeAndHubPath()
+    public async Task CreateSessionAsync_ReturnsSixDigitCode_QrPayload_AndHubPath()
     {
-        var sessions = new List<TvLoginSession>();
-        var sut = CreateSut(sessions, out _, out _, out _);
+        var h = new TvLoginSessionServiceHarness();
+        var sut = h.CreateSut();
 
         var result = await sut.CreateSessionAsync(
             new CreateTvLoginSessionRequest { DeviceName = "Living Room TV", Client = "android-tv" },
@@ -36,271 +33,611 @@ public class TvLoginSessionServiceTests
             result.QrPayload);
         Assert.Equal(2, result.PollIntervalSeconds);
         Assert.Equal(TvLoginHub.HubPath, result.SignalRHubPath);
-        Assert.Single(sessions);
-        Assert.Equal(TvLoginSessionStatus.Pending, sessions[0].Status);
-        Assert.Equal(6, sessions[0].UserCode.Length);
+        Assert.Single(h.Sessions);
+        Assert.Equal(TvLoginSessionStatus.Pending, h.Sessions[0].Status);
+        Assert.Equal("Living Room TV", h.Sessions[0].DeviceName);
+        Assert.Equal("android-tv", h.Sessions[0].Client);
     }
 
     [Fact]
-    public async Task PollSessionAsync_WhenPending_ReturnsPendingWithoutTokens()
+    public async Task CreateSessionAsync_UsesConfiguredTtl_And_TrimsTrailingSlashOnBaseUrl()
     {
-        var sessionId = Guid.NewGuid();
-        var sessions = new List<TvLoginSession>
-        {
-            new()
+        var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                Id = sessionId,
-                UserCode = "482913",
-                Status = TvLoginSessionStatus.Pending,
-                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
-            }
-        };
-        var sut = CreateSut(sessions, out var tokenService, out _, out _);
+                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com/",
+                ["Auth:TvLoginSessionMinutes"] = "3",
+            })
+            .Build());
+        var sut = h.CreateSut();
+        var before = DateTimeOffset.UtcNow;
 
-        var poll = await sut.PollSessionAsync(sessionId, "1.1.1.1", CancellationToken.None);
+        var result = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.2.3.4", CancellationToken.None);
 
-        Assert.Equal("pending", poll.Status);
+        Assert.Equal("https://dash.datagateapp.com/tv/link", result.VerificationUrl);
+        Assert.InRange(result.ExpiresAt, before.AddMinutes(2.5), before.AddMinutes(3.5));
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WhenTtlConfigInvalid_FallsBackToFiveMinutes()
+    {
+        var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com",
+                ["Auth:TvLoginSessionMinutes"] = "0",
+            })
+            .Build());
+        var sut = h.CreateSut();
+        var before = DateTimeOffset.UtcNow;
+
+        var result = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), null, CancellationToken.None);
+
+        Assert.InRange(result.ExpiresAt, before.AddMinutes(4.5), before.AddMinutes(5.5));
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_CapturesDeviceIdAndUserAgentFromHeaders()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.UserAgent = "AndroidTV/1.0";
+        httpContext.Request.Headers["X-Device-Id"] = "tv-install-1";
+        h.Http.SetupGet(x => x.HttpContext).Returns(httpContext);
+        var sut = h.CreateSut();
+
+        await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "10.0.0.1", CancellationToken.None);
+
+        Assert.Equal("tv-install-1", h.Sessions[0].DeviceId);
+        Assert.Equal("AndroidTV/1.0", h.Sessions[0].UserAgent);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_TruncatesLongDeviceNameAndClient()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var sut = h.CreateSut();
+        var longName = new string('N', 200);
+        var longClient = new string('C', 100);
+
+        await sut.CreateSessionAsync(
+            new CreateTvLoginSessionRequest { DeviceName = longName, Client = longClient },
+            "1.1.1.1",
+            CancellationToken.None);
+
+        Assert.Equal(128, h.Sessions[0].DeviceName!.Length);
+        Assert.Equal(64, h.Sessions[0].Client!.Length);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WhenRateLimited_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var sut = h.CreateSut();
+        const string ip = "203.0.113.10";
+
+        for (var i = 0; i < 10; i++)
+            await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), ip, CancellationToken.None);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), ip, CancellationToken.None));
+        Assert.Equal(TvLoginSessionService.RateLimitMessage, ex.Message);
+    }
+
+    // ── Poll statuses ───────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(TvLoginSessionStatus.Pending, "pending")]
+    [InlineData(TvLoginSessionStatus.Viewed, "viewed")]
+    [InlineData(TvLoginSessionStatus.Denied, "denied")]
+    [InlineData(TvLoginSessionStatus.Expired, "expired")]
+    [InlineData(TvLoginSessionStatus.Consumed, "consumed")]
+    public async Task PollSessionAsync_ReturnsStatusWithoutTokens(TvLoginSessionStatus status, string expected)
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: status);
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal(expected, poll.Status);
         Assert.Null(poll.Token);
-        tokenService.Verify(
-            t => t.IssueAsync(
-                It.IsAny<int>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<CancellationToken>()),
+        Assert.Null(poll.RefreshToken);
+        Assert.False(poll.RequiresTotp);
+        Assert.Null(poll.LoginChallengeId);
+        Assert.False(poll.RequiresTotpSetup);
+        h.TokenService.Verify(
+            t => t.IssueAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
     [Fact]
+    public async Task PollSessionAsync_WhenMissing_ThrowsNotFound()
+    {
+        var sut = new TvLoginSessionServiceHarness().CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.PollSessionAsync(Guid.NewGuid(), "1.1.1.1", CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task PollSessionAsync_WhenPendingExpired_MarksExpired_AndNotifiesHub()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(
+            status: TvLoginSessionStatus.Pending,
+            expiresAt: DateTimeOffset.UtcNow.AddMinutes(-1));
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "3.3.3.3", CancellationToken.None);
+
+        Assert.Equal("expired", poll.Status);
+        Assert.Equal(TvLoginSessionStatus.Expired, session.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "expired", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PollSessionAsync_WhenViewedExpired_MarksExpired_AndNotifiesHub()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(
+            status: TvLoginSessionStatus.Viewed,
+            expiresAt: DateTimeOffset.UtcNow.AddSeconds(-5));
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "3.3.3.4", CancellationToken.None);
+
+        Assert.Equal("expired", poll.Status);
+        Assert.Equal(TvLoginSessionStatus.Expired, session.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "expired", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Phone preview / viewed ──────────────────────────────────────────────
+
+    [Fact]
     public async Task GetByUserCodeAsync_MarksViewed_AndNotifiesHub()
     {
-        var sessionId = Guid.NewGuid();
-        var sessions = new List<TvLoginSession>
-        {
-            new()
-            {
-                Id = sessionId,
-                UserCode = "123456",
-                Status = TvLoginSessionStatus.Pending,
-                DeviceName = "Kitchen TV",
-                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(4),
-            }
-        };
-        var sut = CreateSut(sessions, out _, out _, out var hub);
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(userCode: "123456", deviceName: "Kitchen TV");
+        var sut = h.CreateSut();
 
         var preview = await sut.GetByUserCodeAsync("123 456", CancellationToken.None);
 
-        Assert.Equal(sessionId, preview.SessionId);
+        Assert.Equal(session.Id, preview.SessionId);
         Assert.Equal("123456", preview.UserCode);
-        Assert.Equal("pending", preview.Status);
-        Assert.Equal(TvLoginSessionStatus.Viewed, sessions[0].Status);
-        hub.Verify(
-            h => h.NotifyStatusAsync(sessionId, "viewed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+        Assert.Equal("Kitchen TV", preview.DeviceName);
+        Assert.Equal("pending", preview.Status); // phone UI still "pending"
+        Assert.Equal(TvLoginSessionStatus.Viewed, session.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "viewed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
-        var poll = await sut.PollSessionAsync(sessionId, "1.1.1.1", CancellationToken.None);
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
         Assert.Equal("viewed", poll.Status);
     }
 
     [Fact]
+    public async Task GetByUserCodeAsync_WhenAlreadyViewed_DoesNotNotifyAgain()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(userCode: "222333", status: TvLoginSessionStatus.Viewed);
+        var sut = h.CreateSut();
+
+        var preview = await sut.GetByUserCodeAsync("222333", CancellationToken.None);
+
+        Assert.Equal(session.Id, preview.SessionId);
+        Assert.Equal("pending", preview.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(It.IsAny<Guid>(), "viewed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("12345")]
+    [InlineData("1234567")]
+    [InlineData("abcdef")]
+    public async Task GetByUserCodeAsync_WhenCodeInvalidLength_ThrowsNotFound(string code)
+    {
+        var sut = new TvLoginSessionServiceHarness().CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync(code, CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenMissingEntirely_ThrowsNotFound()
+    {
+        var sut = new TvLoginSessionServiceHarness().CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync("999888", CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenOnlyExpiredExists_ThrowsExpired()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        h.AddSession(userCode: "555666", status: TvLoginSessionStatus.Expired);
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync("555666", CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionExpiredMessage, ex.Message);
+    }
+
+    // ── Approve / deny ──────────────────────────────────────────────────────
+
+    [Fact]
     public async Task ApproveThenPoll_DeliversTokensOnce_ThenConsumed()
     {
-        var sessionId = Guid.NewGuid();
-        var sessions = new List<TvLoginSession>
-        {
-            new()
-            {
-                Id = sessionId,
-                UserCode = "654321",
-                Status = TvLoginSessionStatus.Pending,
-                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(5),
-            }
-        };
-        var sut = CreateSut(sessions, out var tokenService, out var userQuery, out var hub);
-
-        userQuery.Setup(u => u.GetById(42, It.IsAny<CancellationToken>()))
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(userCode: "654321");
+        h.UserQuery.Setup(u => u.GetById(42, It.IsAny<CancellationToken>()))
             .ReturnsAsync((int id, CancellationToken _) =>
             {
-                foreach (var s in sessions.Where(x =>
-                             x.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
-                    s.ApprovedUserId = id;
+                session.ApprovedUserId = id;
                 return new User { Id = 42, DisplayName = "Alice", Email = "a@example.com" };
             });
-
-        tokenService
+        h.TokenService
             .Setup(t => t.IssueAsync(42, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new TokenPair(
                 "access-token",
                 DateTimeOffset.UtcNow.AddMinutes(15),
                 "refresh-token",
                 DateTimeOffset.UtcNow.AddDays(30)));
+        var sut = h.CreateSut();
 
         var approve = await sut.ApproveAsync(
-            new ApproveTvLoginSessionRequest { SessionId = sessionId },
-            approvingUserId: 42,
-            clientIp: "9.9.9.9",
-            ct: CancellationToken.None);
+            new ApproveTvLoginSessionRequest { SessionId = session.Id },
+            42,
+            "9.9.9.9",
+            CancellationToken.None);
+
         Assert.Equal("approved", approve.Status);
-        hub.Verify(
-            h => h.NotifyStatusAsync(sessionId, "approved", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+        Assert.Equal(TvLoginSessionStatus.Approved, session.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "approved", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
-        var firstPoll = await sut.PollSessionAsync(sessionId, "2.2.2.2", CancellationToken.None);
-        Assert.Equal("approved", firstPoll.Status);
-        Assert.Equal("access-token", firstPoll.Token);
-        Assert.Equal("refresh-token", firstPoll.RefreshToken);
+        var first = await sut.PollSessionAsync(session.Id, "2.2.2.2", CancellationToken.None);
+        Assert.Equal("approved", first.Status);
+        Assert.Equal("access-token", first.Token);
+        Assert.Equal("refresh-token", first.RefreshToken);
+        Assert.Equal(42, first.UserId);
+        Assert.Equal("Alice", first.DisplayName);
+        Assert.Equal("a@example.com", first.Email);
+        Assert.False(first.RequiresTotp);
+        Assert.Null(first.LoginChallengeId);
+        Assert.False(first.RequiresTotpSetup);
 
-        var secondPoll = await sut.PollSessionAsync(sessionId, "2.2.2.2", CancellationToken.None);
-        Assert.Equal("consumed", secondPoll.Status);
-        Assert.Null(secondPoll.Token);
-
-        tokenService.Verify(
+        var second = await sut.PollSessionAsync(session.Id, "2.2.2.2", CancellationToken.None);
+        Assert.Equal("consumed", second.Status);
+        Assert.Null(second.Token);
+        h.TokenService.Verify(
             t => t.IssueAsync(42, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
             Times.Once);
-    }
-
-    [Fact]
-    public async Task PollSessionAsync_WhenExpired_ReturnsExpired()
-    {
-        var sessionId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
-        var sessions = new List<TvLoginSession>
-        {
-            new()
-            {
-                Id = sessionId,
-                UserCode = "111222",
-                Status = TvLoginSessionStatus.Pending,
-                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
-            }
-        };
-        var sut = CreateSut(sessions, out _, out _, out var hub);
-
-        var poll = await sut.PollSessionAsync(sessionId, "3.3.3.3", CancellationToken.None);
-
-        Assert.Equal("expired", poll.Status);
-        Assert.Equal(TvLoginSessionStatus.Expired, sessions[0].Status);
-        hub.Verify(
-            h => h.NotifyStatusAsync(sessionId, "expired", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "consumed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public void NormalizeUserCode_KeepsDigitsOnly()
+    public async Task ApproveAsync_ByUserCode_WorksAfterViewed()
     {
-        Assert.Equal("482913", TvLoginSessionService.NormalizeUserCode("482 913"));
-        Assert.Equal("482913", TvLoginSessionService.NormalizeUserCode("482-913"));
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(userCode: "777888", status: TvLoginSessionStatus.Viewed);
+        h.UserQuery.Setup(u => u.GetById(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int id, CancellationToken _) =>
+            {
+                session.ApprovedUserId = id;
+                return new User { Id = 7, DisplayName = "Bob" };
+            });
+        var sut = h.CreateSut();
+
+        var result = await sut.ApproveAsync(
+            new ApproveTvLoginSessionRequest { UserCode = "777-888" },
+            7,
+            "8.8.8.8",
+            CancellationToken.None);
+
+        Assert.Equal("approved", result.Status);
+        Assert.Equal(TvLoginSessionStatus.Approved, session.Status);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenUserBlocked_ThrowsUnauthorized()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession();
+        h.UserQuery.Setup(u => u.GetById(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 5, DisplayName = "X", IsBlocked = true });
+        var sut = h.CreateSut();
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = session.Id },
+                5,
+                "1.1.1.1",
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenUserMissing_ThrowsUnauthorized()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession();
+        h.UserQuery.Setup(u => u.GetById(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        var sut = h.CreateSut();
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = session.Id },
+                5,
+                "1.1.1.1",
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenAlreadyApproved_ThrowsNotPending()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Approved, approvedUserId: 1);
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = session.Id },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task DenyAsync_FromViewed_SetsDenied_AndNotifiesHub()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Viewed);
+        // Explicit deny transition (default heuristic also maps Viewed→Denied when ApprovedUserId is null).
+        h.EnqueueUpdate(s =>
+        {
+            s.Status = TvLoginSessionStatus.Denied;
+            s.CompletedAt = DateTimeOffset.UtcNow;
+        });
+        var sut = h.CreateSut();
+
+        var result = await sut.DenyAsync(
+            new DenyTvLoginSessionRequest { SessionId = session.Id },
+            9,
+            "4.4.4.4",
+            CancellationToken.None);
+
+        Assert.Equal("denied", result.Status);
+        Assert.Equal(TvLoginSessionStatus.Denied, session.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "denied", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        var poll = await sut.PollSessionAsync(session.Id, "4.4.4.4", CancellationToken.None);
+        Assert.Equal("denied", poll.Status);
+    }
+
+    [Fact]
+    public async Task DenyAsync_FromPending_SetsDenied()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Pending);
+        h.EnqueueUpdate(s =>
+        {
+            s.Status = TvLoginSessionStatus.Denied;
+            s.CompletedAt = DateTimeOffset.UtcNow;
+        });
+        var sut = h.CreateSut();
+
+        var result = await sut.DenyAsync(
+            new DenyTvLoginSessionRequest { UserCode = session.UserCode },
+            3,
+            "5.5.5.5",
+            CancellationToken.None);
+
+        Assert.Equal("denied", result.Status);
+        Assert.Equal(TvLoginSessionStatus.Denied, session.Status);
+    }
+
+    [Fact]
+    public async Task DenyAsync_WhenSessionMissing_ThrowsNotFound()
+    {
+        var sut = new TvLoginSessionServiceHarness().CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.DenyAsync(
+                new DenyTvLoginSessionRequest { SessionId = Guid.NewGuid() },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotFoundMessage, ex.Message);
+    }
+
+    // ── Token delivery edge cases ───────────────────────────────────────────
+
+    [Fact]
+    public async Task PollApproved_WhenApprovedUserIdMissing_ReturnsExpiredWithoutTokens()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Approved, approvedUserId: null);
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal("expired", poll.Status);
+        Assert.Null(poll.Token);
+        h.TokenService.Verify(
+            t => t.IssueAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PollApproved_WhenUserBlocked_MarksConsumed_ReturnsExpired()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Approved, approvedUserId: 11);
+        h.UserQuery.Setup(u => u.GetById(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 11, DisplayName = "Blocked", IsBlocked = true });
+        h.EnqueueUpdate(s => s.Status = TvLoginSessionStatus.Consumed);
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal("expired", poll.Status);
+        Assert.Null(poll.Token);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "consumed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PollApproved_WhenClaimLosesRace_ReturnsConsumedWithoutIssuing()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Approved, approvedUserId: 12);
+        h.UserQuery.Setup(u => u.GetById(12, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 12, DisplayName = "Ok" });
+        // Simulate lost race: UpdateWhere matches 0 rows.
+        h.EnqueueUpdate(_ => { /* no-op; we'll force count via empty match by changing status first */ });
+        // Better: change status before UpdateWhere by enqueue that sets Consumed then claim sees Approved→ already consumed
+        // Actually UpdateWhere predicate requires Approved; if we set Consumed in enqueue, predicate won't match on second call.
+        // Force claimed=0 by making the session no longer Approved before apply: change to Consumed in enqueue
+        // but predicate runs first on Approved session...
+        // Clear and use custom: set status to Consumed in enqueue (apply after match) — count still 1.
+        // To get claimed != 1, enqueue nothing and make UpdateWhere return 0 by having session not match —
+        // change session to Consumed before poll so DeliverTokensOnce isn't called... that won't hit the race path.
+
+        // Re-setup: Approved session, but UpdateWhere returns 0 because we dequeue an apply that doesn't change
+        // and we temporarily change status so second evaluation... The mock returns matches.Count after apply.
+        // Trick: enqueue apply that sets Consumed, then... still count 1.
+
+        // Use a second harness path: make UpdateWhere return 0 by clearing Approved before Apply —
+        // Change mock via Enqueue that is empty and mutate Sessions in UserQuery callback:
+        h.UserQuery.Setup(u => u.GetById(12, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int _, CancellationToken __) =>
+            {
+                session.Status = TvLoginSessionStatus.Consumed; // race: another poll consumed first
+                return new User { Id = 12, DisplayName = "Ok" };
+            });
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        // After user load, status is Consumed so UpdateWhere matches 0 → "consumed"
+        Assert.Equal("consumed", poll.Status);
+        Assert.Null(poll.Token);
+        h.TokenService.Verify(
+            t => t.IssueAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PollApproved_UsesSessionDeviceMetadataForTokenIssue()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(
+            status: TvLoginSessionStatus.Approved,
+            approvedUserId: 15,
+            deviceId: "dev-99",
+            userAgent: "ua-99");
+        h.UserQuery.Setup(u => u.GetById(15, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 15, DisplayName = "Dev" });
+        h.TokenService
+            .Setup(t => t.IssueAsync(15, null, "dev-99", "ua-99", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair("a", DateTimeOffset.UtcNow.AddMinutes(1), "r", DateTimeOffset.UtcNow.AddDays(1)));
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal("approved", poll.Status);
+        Assert.Equal("a", poll.Token);
+        h.TokenService.Verify(
+            t => t.IssueAsync(15, null, "dev-99", "ua-99", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Code helpers ────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    [InlineData("482 913", "482913")]
+    [InlineData("482-913", "482913")]
+    [InlineData("48a2b913", "482913")]
+    [InlineData("012345", "012345")]
+    public void NormalizeUserCode_KeepsDigitsOnly(string? input, string expected)
+    {
+        Assert.Equal(expected, TvLoginSessionService.NormalizeUserCode(input));
+    }
+
+    [Fact]
+    public void FormatUserCode_ReturnsNormalizedAsIs()
+    {
         Assert.Equal("012345", TvLoginSessionService.FormatUserCode("012345"));
     }
 
-    private static TvLoginSessionService CreateSut(
-        List<TvLoginSession> sessions,
-        out Mock<ITokenService> tokenService,
-        out Mock<IUserQueryService> userQuery,
-        out Mock<ITvLoginHubNotifier> hub)
+    // ── Full lifecycle ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FullLifecycle_Create_View_Approve_PollTokens_PollConsumed()
     {
-        var query = new Mock<ITvLoginSessionQueryService>();
-        query.Setup(q => q.GetById(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Guid id, CancellationToken _) => sessions.FirstOrDefault(s => s.Id == id));
-        query.Setup(q => q.GetActiveByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string code, CancellationToken _) =>
-                sessions.FirstOrDefault(s =>
-                    s.UserCode == code
-                    && s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
-                    && s.ExpiresAt > DateTimeOffset.UtcNow));
-        query.Setup(q => q.GetLatestByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string code, CancellationToken _) =>
-                sessions.Where(s => s.UserCode == code).OrderByDescending(s => s.CreateDate).FirstOrDefault());
-        query.Setup(q => q.AnyActiveByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string code, CancellationToken _) =>
-                sessions.Any(s =>
-                    s.UserCode == code
-                    && s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
-                    && s.ExpiresAt > DateTimeOffset.UtcNow));
+        var h = new TvLoginSessionServiceHarness();
+        var sut = h.CreateSut();
 
-        var command = new Mock<ICommandService<TvLoginSession, Guid>>();
-        command.Setup(c => c.Add(It.IsAny<TvLoginSession>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((TvLoginSession e, bool _, CancellationToken _) =>
-            {
-                sessions.Add(e);
-                return e;
-            });
+        var created = await sut.CreateSessionAsync(
+            new CreateTvLoginSessionRequest { DeviceName = "Den TV" },
+            "10.0.0.2",
+            CancellationToken.None);
 
-        command.Setup(c => c.UpdateWhere(
-                It.IsAny<System.Linq.Expressions.Expression<Func<TvLoginSession, bool>>>(),
-                It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<TvLoginSession>>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync((
-                System.Linq.Expressions.Expression<Func<TvLoginSession, bool>> predicate,
-                Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<TvLoginSession>> _,
-                CancellationToken __) =>
-            {
-                var compiled = predicate.Compile();
-                var matches = sessions.Where(compiled).ToList();
-                foreach (var s in matches)
-                {
-                    if (s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
-                        && s.ExpiresAt <= DateTimeOffset.UtcNow)
-                    {
-                        s.Status = TvLoginSessionStatus.Expired;
-                    }
-                    else if (s.Status == TvLoginSessionStatus.Approved)
-                    {
-                        s.Status = TvLoginSessionStatus.Consumed;
-                    }
-                    else if (s.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
-                             && s.ApprovedUserId is not null)
-                    {
-                        s.Status = TvLoginSessionStatus.Approved;
-                        s.CompletedAt = DateTimeOffset.UtcNow;
-                    }
-                    else if (s.Status == TvLoginSessionStatus.Pending)
-                    {
-                        s.Status = TvLoginSessionStatus.Viewed;
-                    }
-                    else if (s.Status == TvLoginSessionStatus.Viewed)
-                    {
-                        s.Status = TvLoginSessionStatus.Denied;
-                        s.CompletedAt = DateTimeOffset.UtcNow;
-                    }
-                }
+        Assert.Equal("pending", (await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None)).Status);
 
-                return matches.Count;
-            });
+        await sut.GetByUserCodeAsync(created.UserCode, CancellationToken.None);
+        Assert.Equal("viewed", (await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None)).Status);
 
-        tokenService = new Mock<ITokenService>();
-        userQuery = new Mock<IUserQueryService>();
-        hub = new Mock<ITvLoginHubNotifier>();
-
-        userQuery
-            .Setup(u => u.GetById(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+        var session = h.Sessions.Single(s => s.Id == created.SessionId);
+        h.UserQuery.Setup(u => u.GetById(100, It.IsAny<CancellationToken>()))
             .ReturnsAsync((int id, CancellationToken _) =>
             {
-                foreach (var s in sessions.Where(x =>
-                             x.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
-                    s.ApprovedUserId = id;
-                return new User { Id = id, DisplayName = "User" + id };
+                session.ApprovedUserId = id;
+                return new User { Id = 100, DisplayName = "Owner", Email = "o@x.com" };
             });
+        h.TokenService
+            .Setup(t => t.IssueAsync(100, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TokenPair("tok", DateTimeOffset.UtcNow.AddMinutes(10), "ref", DateTimeOffset.UtcNow.AddDays(7)));
 
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Auth:PublicWebBaseUrl"] = "https://dash.datagateapp.com",
-                ["Auth:TvLoginSessionMinutes"] = "5",
-            })
-            .Build();
+        await sut.ApproveAsync(
+            new ApproveTvLoginSessionRequest { SessionId = created.SessionId },
+            100,
+            "10.0.0.3",
+            CancellationToken.None);
 
-        var http = new Mock<IHttpContextAccessor>();
-        http.SetupGet(h => h.HttpContext).Returns((HttpContext?)null);
+        var withTokens = await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None);
+        Assert.Equal("approved", withTokens.Status);
+        Assert.Equal("tok", withTokens.Token);
 
-        return new TvLoginSessionService(
-            query.Object,
-            command.Object,
-            userQuery.Object,
-            tokenService.Object,
-            hub.Object,
-            new MemoryCache(new MemoryCacheOptions()),
-            config,
-            http.Object,
-            NullLogger<TvLoginSessionService>.Instance);
+        var again = await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None);
+        Assert.Equal("consumed", again.Status);
+        Assert.Null(again.Token);
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/Auth/TvLogin/TvLoginSessionServiceTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
 using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Login;
@@ -600,44 +603,195 @@ public class TvLoginSessionServiceTests
     // ── Full lifecycle ──────────────────────────────────────────────────────
 
     [Fact]
-    public async Task FullLifecycle_Create_View_Approve_PollTokens_PollConsumed()
+    public async Task CreateSessionAsync_FallsBackToFrontendBaseUrl()
     {
-        var h = new TvLoginSessionServiceHarness();
+        var h = new TvLoginSessionServiceHarness(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Frontend:BaseUrl"] = "https://app.example.com/",
+            })
+            .Build());
         var sut = h.CreateSut();
 
-        var created = await sut.CreateSessionAsync(
-            new CreateTvLoginSessionRequest { DeviceName = "Den TV" },
-            "10.0.0.2",
-            CancellationToken.None);
+        var result = await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None);
 
-        Assert.Equal("pending", (await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None)).Status);
+        Assert.Equal("https://app.example.com/tv/link", result.VerificationUrl);
+    }
 
-        await sut.GetByUserCodeAsync(created.UserCode, CancellationToken.None);
-        Assert.Equal("viewed", (await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None)).Status);
+    [Fact]
+    public async Task CreateSessionAsync_BlankDeviceHeaders_StoredAsNull()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.UserAgent = "   ";
+        httpContext.Request.Headers["X-Device-Id"] = "  ";
+        h.Http.SetupGet(x => x.HttpContext).Returns(httpContext);
+        var sut = h.CreateSut();
 
-        var session = h.Sessions.Single(s => s.Id == created.SessionId);
-        h.UserQuery.Setup(u => u.GetById(100, It.IsAny<CancellationToken>()))
-            .ReturnsAsync((int id, CancellationToken _) =>
+        await sut.CreateSessionAsync(new CreateTvLoginSessionRequest(), "1.1.1.1", CancellationToken.None);
+
+        Assert.Null(h.Sessions[0].DeviceId);
+        Assert.Null(h.Sessions[0].UserAgent);
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_WhenAllCodesCollide_Throws()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.AnyActiveByUserCode(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var colliding = new TvLoginSessionService(
+            query.Object,
+            Mock.Of<ICommandService<TvLoginSession, Guid>>(),
+            h.UserQuery.Object,
+            h.TokenService.Object,
+            h.Hub.Object,
+            h.Cache,
+            h.Config,
+            h.Http.Object,
+            NullLogger<TvLoginSessionService>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => colliding.CreateSessionAsync(new CreateTvLoginSessionRequest(), "9.9.9.9", CancellationToken.None));
+        Assert.Contains("unique TV login code", ex.Message);
+    }
+
+    [Fact]
+    public async Task ApproveAsync_WhenUpdateAffectsZeroRows_ThrowsNotPending()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession();
+        h.ForceUpdateWhereCount = 0;
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.ApproveAsync(
+                new ApproveTvLoginSessionRequest { SessionId = session.Id },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task DenyAsync_WhenUpdateAffectsZeroRows_ThrowsNotPending()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Viewed);
+        h.ForceUpdateWhereCount = 0;
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.DenyAsync(
+                new DenyTvLoginSessionRequest { SessionId = session.Id },
+                1,
+                "1.1.1.1",
+                CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionNotPendingMessage, ex.Message);
+    }
+
+    [Fact]
+    public async Task PollSessionAsync_UnknownStatus_ReturnsExpired()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: (TvLoginSessionStatus)999);
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal("expired", poll.Status);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenStaleBecomesNonOpen_ThrowsExpired()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        // Not returned by GetActive (expired), but still found via GetLatest → SessionExpiredMessage.
+        var session = h.AddSession(
+            userCode: "444555",
+            status: TvLoginSessionStatus.Pending,
+            expiresAt: DateTimeOffset.UtcNow.AddMinutes(-1));
+        var sut = h.CreateSut();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync("444555", CancellationToken.None));
+
+        Assert.Equal(TvLoginSessionService.SessionExpiredMessage, ex.Message);
+        Assert.Equal(TvLoginSessionStatus.Pending, session.Status);
+    }
+
+    [Fact]
+    public async Task GetByUserCodeAsync_WhenActiveThenExpiresDuringEnsure_ThrowsExpired()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        // Force GetActive to return a stale pending row (bypass ExpiresAt filter in mock).
+        var sessionId = Guid.NewGuid();
+        var session = new TvLoginSession
+        {
+            Id = sessionId,
+            UserCode = "666777",
+            Status = TvLoginSessionStatus.Pending,
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+        };
+        h.Sessions.Add(session);
+
+        var query = new Mock<ITvLoginSessionQueryService>();
+        query.Setup(q => q.GetActiveByUserCode("666777", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        query.Setup(q => q.GetById(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        var command = new Mock<ICommandService<TvLoginSession, Guid>>();
+        command.Setup(c => c.UpdateWhere(
+                It.IsAny<System.Linq.Expressions.Expression<Func<TvLoginSession, bool>>>(),
+                It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<TvLoginSession>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((
+                System.Linq.Expressions.Expression<Func<TvLoginSession, bool>> pred,
+                Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<TvLoginSession>> _,
+                CancellationToken __) =>
             {
-                session.ApprovedUserId = id;
-                return new User { Id = 100, DisplayName = "Owner", Email = "o@x.com" };
+                var matches = h.Sessions.Where(pred.Compile()).ToList();
+                foreach (var s in matches)
+                    s.Status = TvLoginSessionStatus.Expired;
+                return matches.Count;
             });
-        h.TokenService
-            .Setup(t => t.IssueAsync(100, null, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new TokenPair("tok", DateTimeOffset.UtcNow.AddMinutes(10), "ref", DateTimeOffset.UtcNow.AddDays(7)));
 
-        await sut.ApproveAsync(
-            new ApproveTvLoginSessionRequest { SessionId = created.SessionId },
-            100,
-            "10.0.0.3",
-            CancellationToken.None);
+        var sut = new TvLoginSessionService(
+            query.Object,
+            command.Object,
+            h.UserQuery.Object,
+            h.TokenService.Object,
+            h.Hub.Object,
+            h.Cache,
+            h.Config,
+            h.Http.Object,
+            NullLogger<TvLoginSessionService>.Instance);
 
-        var withTokens = await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None);
-        Assert.Equal("approved", withTokens.Status);
-        Assert.Equal("tok", withTokens.Token);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sut.GetByUserCodeAsync("666777", CancellationToken.None));
 
-        var again = await sut.PollSessionAsync(created.SessionId, "10.0.0.2", CancellationToken.None);
-        Assert.Equal("consumed", again.Status);
-        Assert.Null(again.Token);
+        Assert.Equal(TvLoginSessionService.SessionExpiredMessage, ex.Message);
+        Assert.Equal(TvLoginSessionStatus.Expired, session.Status);
+    }
+
+    [Fact]
+    public async Task PollApproved_WhenUserMissing_MarksConsumed_ReturnsExpired()
+    {
+        var h = new TvLoginSessionServiceHarness();
+        var session = h.AddSession(status: TvLoginSessionStatus.Approved, approvedUserId: 88);
+        h.UserQuery.Setup(u => u.GetById(88, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        h.EnqueueUpdate(s => s.Status = TvLoginSessionStatus.Consumed);
+        var sut = h.CreateSut();
+
+        var poll = await sut.PollSessionAsync(session.Id, "1.1.1.1", CancellationToken.None);
+
+        Assert.Equal("expired", poll.Status);
+        h.Hub.Verify(
+            x => x.NotifyStatusAsync(session.Id, "consumed", It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceAddUpdateExoticTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceAddUpdateExoticTests.cs
@@ -92,6 +92,8 @@ public class VpnDataServiceAddUpdateExoticTests
     public async Task UpdateVpnServer_Throws_When_NameTakenByAnotherServer()
     {
         var h = new VpnDataServiceTestHarness();
+        h.ServerQ.Setup(q => q.GetById(55, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 55, ServerName = "old", ApiUrl = "https://a/" });
         h.ServerQ.Setup(q => q.AnyByServerNameExceptId("taken", 55, It.IsAny<CancellationToken>())).ReturnsAsync(true);
         var svc = h.Create();
 

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceAddUpdateExoticTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceAddUpdateExoticTests.cs
@@ -237,7 +237,10 @@ public class VpnDataServiceAddUpdateExoticTests
         var result = await svc.RunPostAddSetupAsync(90, CancellationToken.None);
 
         Assert.True(result.CreatedDefaultConfig);
-        Assert.Equal("198.51.100.10", Assert.Single(h.ConfigsAdded).VpnServerIp);
+        var config = Assert.Single(h.ConfigsAdded);
+        Assert.Equal("198.51.100.10", config.VpnServerIp);
+        Assert.Equal(1390, config.VpnServerPort);
+        Assert.Contains("proto tcp", config.ConfigTemplate);
         h.MicroserviceInfo.Verify(m => m.GetInfoAsync(90, It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceAddUpdateExoticTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceAddUpdateExoticTests.cs
@@ -5,6 +5,7 @@ using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.PostSetup;
 using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+using DataGateMonitor.SharedModels.DataGateXRayManager.Info;
 using DataGateMonitor.SharedModels.Enums;
 using Xunit;
 
@@ -155,7 +156,8 @@ public class VpnDataServiceAddUpdateExoticTests
         var h = new VpnDataServiceTestHarness();
         h.SetupUpdateServer(80, "srv80");
         h.CfgQ.Setup(q => q.AnyByVpnServerId(80, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        h.Ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ThrowsAsync(new HttpRequestException("timeout"));
+        h.MicroserviceInfo.Setup(m => m.GetInfoAsync(80, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("timeout"));
         var svc = h.Create();
 
         await svc.UpdateVpnServer(
@@ -165,8 +167,9 @@ public class VpnDataServiceAddUpdateExoticTests
             CancellationToken.None);
 
         Assert.Single(h.ConfigsAdded);
-        Assert.Equal("127.0.0.1", h.ConfigsAdded[0].VpnServerIp);
+        Assert.Equal(string.Empty, h.ConfigsAdded[0].VpnServerIp);
         Assert.Equal(80, h.ConfigsAdded[0].VpnServerId);
+        Assert.Contains("proto tcp", h.ConfigsAdded[0].ConfigTemplate);
     }
 
     [Fact]
@@ -175,7 +178,12 @@ public class VpnDataServiceAddUpdateExoticTests
         var h = new VpnDataServiceTestHarness();
         h.SetupUpdateServer(81, "xray81");
         h.CfgQ.Setup(q => q.AnyByVpnServerId(81, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        h.Ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("  ");
+        h.MicroserviceInfo.Setup(m => m.GetInfoAsync(81, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                ServerType = VpnServerType.Xray,
+                Xray = new RootXrayInfoResponse { PublicIp = "  " }
+            });
         var svc = h.Create();
 
         await svc.UpdateVpnServer(
@@ -185,7 +193,7 @@ public class VpnDataServiceAddUpdateExoticTests
             CancellationToken.None);
 
         var cfg = Assert.Single(h.ConfigsAdded);
-        Assert.Equal("127.0.0.1", cfg.VpnServerIp);
+        Assert.Equal(string.Empty, cfg.VpnServerIp);
         Assert.Equal(443, cfg.VpnServerPort);
         Assert.Contains("{{vless_uri}}", cfg.ConfigTemplate);
     }
@@ -224,14 +232,14 @@ public class VpnDataServiceAddUpdateExoticTests
         h.ServerQ.Setup(q => q.GetById(90, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new VpnServer { Id = 90, ServerName = "ovpn90", ServerType = VpnServerType.OpenVpn });
         h.CfgQ.Setup(q => q.AnyByVpnServerId(90, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        h.Ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("198.51.100.10");
         h.MicroserviceInfo.Setup(m => m.GetInfoAsync(90, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
             {
                 ServerType = VpnServerType.OpenVpn,
                 OpenVpn = new RootOpenVpnInfoResponse
                 {
-                    Config = new ConfigInfoResponse { Port = "1390", Proto = "tcp" }
+                    PublicIp = "198.51.100.10",
+                    Config = new DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info.ConfigInfoResponse { Port = "1390", Proto = "tcp" }
                 }
             });
         var svc = h.Create();
@@ -253,18 +261,18 @@ public class VpnDataServiceAddUpdateExoticTests
         h.ServerQ.Setup(q => q.GetById(94, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new VpnServer { Id = 94, ServerName = "ovpn94", ServerType = VpnServerType.OpenVpn });
         h.CfgQ.Setup(q => q.AnyByVpnServerId(94, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        h.Ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("10.0.0.2");
         h.MicroserviceInfo.Setup(m => m.GetInfoAsync(94, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
             {
                 ServerType = VpnServerType.Xray,
-                OpenVpn = new RootOpenVpnInfoResponse { Config = new ConfigInfoResponse { Port = "1390", Proto = "tcp" } }
+                OpenVpn = new RootOpenVpnInfoResponse { Config = new DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info.ConfigInfoResponse { Port = "1390", Proto = "tcp" } }
             });
         var svc = h.Create();
 
         await svc.RunPostAddSetupAsync(94, CancellationToken.None);
 
         Assert.Equal(1194, Assert.Single(h.ConfigsAdded).VpnServerPort);
+        Assert.Equal(string.Empty, Assert.Single(h.ConfigsAdded).VpnServerIp);
     }
 
     [Fact]
@@ -274,7 +282,6 @@ public class VpnDataServiceAddUpdateExoticTests
         h.ServerQ.Setup(q => q.GetById(91, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new VpnServer { Id = 91, ServerName = "ovpn91", ServerType = VpnServerType.OpenVpn });
         h.CfgQ.Setup(q => q.AnyByVpnServerId(91, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        h.Ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("203.0.113.1");
         h.MicroserviceInfo.Setup(m => m.GetInfoAsync(91, It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("401 Unauthorized"));
         var svc = h.Create();
@@ -282,7 +289,8 @@ public class VpnDataServiceAddUpdateExoticTests
         var result = await svc.RunPostAddSetupAsync(91, CancellationToken.None);
 
         Assert.True(result.CreatedDefaultConfig);
-        Assert.Equal("203.0.113.1", Assert.Single(h.ConfigsAdded).VpnServerIp);
+        Assert.Equal(string.Empty, Assert.Single(h.ConfigsAdded).VpnServerIp);
+        Assert.Contains("proto tcp", Assert.Single(h.ConfigsAdded).ConfigTemplate);
     }
 
     [Fact]
@@ -311,7 +319,7 @@ public class VpnDataServiceAddUpdateExoticTests
         await svc.UpdateVpnServer(new VpnServer { Id = 83, ServerName = "srv83" }, [1], [], CancellationToken.None);
 
         h.CfgCmd.Verify(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Never);
-        h.Ip.Verify(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>()), Times.Never);
+        h.MicroserviceInfo.Verify(m => m.GetInfoAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -321,7 +329,12 @@ public class VpnDataServiceAddUpdateExoticTests
         h.ServerQ.Setup(q => q.GetById(95, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new VpnServer { Id = 95, ServerName = "xray95", ServerType = VpnServerType.Xray });
         h.CfgQ.Setup(q => q.AnyByVpnServerId(95, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        h.Ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("203.0.113.5");
+        h.MicroserviceInfo.Setup(m => m.GetInfoAsync(95, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                ServerType = VpnServerType.Xray,
+                Xray = new RootXrayInfoResponse { PublicIp = "203.0.113.5" }
+            });
         var svc = h.Create();
 
         var result = await svc.RunPostAddSetupAsync(95, CancellationToken.None);
@@ -329,6 +342,7 @@ public class VpnDataServiceAddUpdateExoticTests
         Assert.True(result.CreatedDefaultConfig);
         Assert.Equal(VpnServerType.Xray, result.ServerType);
         var cfg = Assert.Single(h.ConfigsAdded);
+        Assert.Equal("203.0.113.5", cfg.VpnServerIp);
         Assert.Equal(443, cfg.VpnServerPort);
         Assert.Contains("{{vless_uri}}", cfg.ConfigTemplate);
     }

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceOnlineCounterBehaviorTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceOnlineCounterBehaviorTests.cs
@@ -1,0 +1,137 @@
+using System.Linq.Expressions;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Cache;
+using DataGateMonitor.Services.Helpers;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.Api;
+
+/// <summary>
+/// VpnDataService disable/delete must drive presence so the per-server Redis online counter drops to 0.
+/// </summary>
+public class VpnDataServiceOnlineCounterBehaviorTests
+{
+    [Fact]
+    public async Task DeleteVpnServer_WithConnectedClients_ZerosOnlineCounter()
+    {
+        var counts = new Dictionary<int, int> { [9] = 4 };
+        var counter = new Mock<IConnectedClientsCounterStore>(MockBehavior.Strict);
+        counter
+            .Setup(c => c.SetAsync(9, 0, It.IsAny<CancellationToken>()))
+            .Callback<int, int, CancellationToken>((id, n, _) => counts[id] = n)
+            .Returns(Task.CompletedTask);
+
+        var clientCmd = new Mock<ICommandService<VpnServerClient, int>>();
+        clientCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(4);
+
+        var presence = new VpnServerClientPresenceService(
+            clientCmd.Object,
+            counter.Object,
+            Mock.Of<ILogger<VpnServerClientPresenceService>>());
+
+        var h = new VpnDataServiceTestHarness();
+        h.Presence.Setup(p => p.MarkAllDisconnectedAsync(9, It.IsAny<CancellationToken>()))
+            .Returns<int, CancellationToken>((id, ct) => presence.MarkAllDisconnectedAsync(id, ct));
+
+        h.ServerQ.Setup(q => q.GetById(9, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 9, ServerName = "gone" });
+        h.ServerCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var ok = await h.Create().DeleteVpnServer(9, CancellationToken.None);
+
+        Assert.True(ok);
+        Assert.Equal(0, counts[9]);
+        counter.Verify(c => c.SetAsync(9, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenDisabled_WithConnectedClients_ZerosOnlineCounter()
+    {
+        var counts = new Dictionary<int, int> { [8] = 3 };
+        var counter = new Mock<IConnectedClientsCounterStore>(MockBehavior.Strict);
+        counter
+            .Setup(c => c.SetAsync(8, 0, It.IsAny<CancellationToken>()))
+            .Callback<int, int, CancellationToken>((id, n, _) => counts[id] = n)
+            .Returns(Task.CompletedTask);
+
+        var clientCmd = new Mock<ICommandService<VpnServerClient, int>>();
+        clientCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var presence = new VpnServerClientPresenceService(
+            clientCmd.Object,
+            counter.Object,
+            Mock.Of<ILogger<VpnServerClientPresenceService>>());
+
+        var h = new VpnDataServiceTestHarness();
+        h.Presence.Setup(p => p.MarkAllDisconnectedAsync(8, It.IsAny<CancellationToken>()))
+            .Returns<int, CancellationToken>((id, ct) => presence.MarkAllDisconnectedAsync(id, ct));
+
+        h.SetupUpdateServer(8, "srv8");
+        h.ServerQ.SetupSequence(q => q.GetById(8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 8, ServerName = "srv8", IsDisable = false, ApiUrl = "https://a/" })
+            .ReturnsAsync(new VpnServer { Id = 8, ServerName = "srv8", IsDisable = true, ApiUrl = "https://a/" });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(8, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 8, ServerName = "srv8", IsDisable = true, ApiUrl = "https://a/" },
+            [],
+            [],
+            CancellationToken.None);
+
+        Assert.Equal(0, counts[8]);
+        counter.Verify(c => c.SetAsync(8, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenOnlyApiUrlChanges_LeavesOnlineCounterUntouched()
+    {
+        var counter = new Mock<IConnectedClientsCounterStore>(MockBehavior.Strict);
+        var clientCmd = new Mock<ICommandService<VpnServerClient, int>>(MockBehavior.Strict);
+        var presence = new VpnServerClientPresenceService(
+            clientCmd.Object,
+            counter.Object,
+            Mock.Of<ILogger<VpnServerClientPresenceService>>());
+
+        var h = new VpnDataServiceTestHarness();
+        h.Presence.Setup(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns<int, CancellationToken>((id, ct) => presence.MarkAllDisconnectedAsync(id, ct));
+
+        h.SetupUpdateServer(5, "srv5");
+        h.ServerQ.SetupSequence(q => q.GetById(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 5, ServerName = "srv5", IsDisable = false, ApiUrl = "https://old/" })
+            .ReturnsAsync(new VpnServer { Id = 5, ServerName = "srv5", IsDisable = false, ApiUrl = "https://new/" });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(5, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 5, ServerName = "srv5", IsDisable = false, ApiUrl = "https://new/" },
+            [],
+            [],
+            CancellationToken.None);
+
+        counter.Verify(c => c.SetAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        clientCmd.Verify(
+            c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        h.PublicIpLookup.Verify(p => p.Invalidate(5), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServicePresenceAndPublicIpCacheTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServicePresenceAndPublicIpCacheTests.cs
@@ -1,0 +1,133 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Tests.Services.Api;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.Api;
+
+public class VpnDataServicePresenceAndPublicIpCacheTests
+{
+    [Fact]
+    public async Task DeleteVpnServer_MarksClientsDisconnected_AndInvalidatesPublicIpCache()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.ServerQ.Setup(q => q.GetById(9, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 9, ServerName = "gone" });
+        h.ServerCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<System.Linq.Expressions.Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<Microsoft.EntityFrameworkCore.Query.UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        h.Presence.Setup(p => p.MarkAllDisconnectedAsync(9, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var ok = await h.Create().DeleteVpnServer(9, CancellationToken.None);
+
+        Assert.True(ok);
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(9, It.IsAny<CancellationToken>()), Times.Once);
+        h.PublicIpLookup.Verify(p => p.Invalidate(9), Times.Once);
+        h.MicroserviceFactory.Verify(f => f.Invalidate(9), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenBecomesDisabled_MarksClientsDisconnected()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.SetupUpdateServer(8, "srv8");
+        h.ServerQ.SetupSequence(q => q.GetById(8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 8, ServerName = "srv8", IsDisable = false, ApiUrl = "https://a/" })
+            .ReturnsAsync(new VpnServer { Id = 8, ServerName = "srv8", IsDisable = true, ApiUrl = "https://a/" });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(8, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        h.Presence.Setup(p => p.MarkAllDisconnectedAsync(8, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 8, ServerName = "srv8", IsDisable = true, ApiUrl = "https://a/" },
+            [],
+            [],
+            CancellationToken.None);
+
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(8, It.IsAny<CancellationToken>()), Times.Once);
+        h.PublicIpLookup.Verify(p => p.Invalidate(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenApiUrlChanges_InvalidatesPublicIpCache_WithoutDisconnectIfStillEnabled()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.SetupUpdateServer(5, "srv5");
+        h.ServerQ.SetupSequence(q => q.GetById(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 5, ServerName = "srv5", IsDisable = false, ApiUrl = "https://old/" })
+            .ReturnsAsync(new VpnServer { Id = 5, ServerName = "srv5", IsDisable = false, ApiUrl = "https://new/" });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(5, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 5, ServerName = "srv5", IsDisable = false, ApiUrl = "https://new/" },
+            [],
+            [],
+            CancellationToken.None);
+
+        h.PublicIpLookup.Verify(p => p.Invalidate(5), Times.Once);
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenBecomesEnabled_DoesNotMarkClientsDisconnected()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.SetupUpdateServer(3, "srv3");
+        h.ServerQ.SetupSequence(q => q.GetById(3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 3, ServerName = "srv3", IsDisable = true, ApiUrl = "https://a/" })
+            .ReturnsAsync(new VpnServer { Id = 3, ServerName = "srv3", IsDisable = false, ApiUrl = "https://a/" });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(3, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 3, ServerName = "srv3", IsDisable = false, ApiUrl = "https://a/" },
+            [],
+            [],
+            CancellationToken.None);
+
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        h.PublicIpLookup.Verify(p => p.Invalidate(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenAlreadyDisabled_DoesNotMarkClientsDisconnectedAgain()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.SetupUpdateServer(4, "srv4");
+        h.ServerQ.SetupSequence(q => q.GetById(4, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 4, ServerName = "srv4", IsDisable = true, ApiUrl = "https://a/" })
+            .ReturnsAsync(new VpnServer { Id = 4, ServerName = "srv4", IsDisable = true, ApiUrl = "https://a/" });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(4, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 4, ServerName = "srv4", IsDisable = true, ApiUrl = "https://a/" },
+            [],
+            [],
+            CancellationToken.None);
+
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenDisableAndApiUrlChange_MarksDisconnected_AndInvalidatesPublicIp()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.SetupUpdateServer(6, "srv6");
+        h.ServerQ.SetupSequence(q => q.GetById(6, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 6, ServerName = "srv6", IsDisable = false, ApiUrl = "https://old/" })
+            .ReturnsAsync(new VpnServer { Id = 6, ServerName = "srv6", IsDisable = true, ApiUrl = "https://new/" });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(6, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        h.Presence.Setup(p => p.MarkAllDisconnectedAsync(6, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 6, ServerName = "srv6", IsDisable = true, ApiUrl = "https://new/" },
+            [],
+            [],
+            CancellationToken.None);
+
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(6, It.IsAny<CancellationToken>()), Times.Once);
+        h.PublicIpLookup.Verify(p => p.Invalidate(6), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServicePresenceAndPublicIpCacheTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServicePresenceAndPublicIpCacheTests.cs
@@ -130,4 +130,38 @@ public class VpnDataServicePresenceAndPublicIpCacheTests
         h.Presence.Verify(p => p.MarkAllDisconnectedAsync(6, It.IsAny<CancellationToken>()), Times.Once);
         h.PublicIpLookup.Verify(p => p.Invalidate(6), Times.Once);
     }
+
+    [Fact]
+    public async Task UpdateVpnServer_WhenApiUrlDiffersOnlyByCaseOrWhitespace_DoesNotInvalidate()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.SetupUpdateServer(15, "srv15");
+        h.ServerQ.SetupSequence(q => q.GetById(15, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer { Id = 15, ServerName = "srv15", IsDisable = false, ApiUrl = "https://A.example/" })
+            .ReturnsAsync(new VpnServer { Id = 15, ServerName = "srv15", IsDisable = false, ApiUrl = "  HTTPS://a.example/  " });
+        h.CfgQ.Setup(q => q.AnyByVpnServerId(15, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        await h.Create().UpdateVpnServer(
+            new VpnServer { Id = 15, ServerName = "srv15", IsDisable = false, ApiUrl = "  HTTPS://a.example/  " },
+            [],
+            [],
+            CancellationToken.None);
+
+        h.PublicIpLookup.Verify(p => p.Invalidate(It.IsAny<int>()), Times.Never);
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteVpnServer_WhenNotFound_Throws_WithoutPresenceOrInvalidate()
+    {
+        var h = new VpnDataServiceTestHarness();
+        h.ServerQ.Setup(q => q.GetById(404, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServer?)null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            h.Create().DeleteVpnServer(404, CancellationToken.None));
+
+        h.Presence.Verify(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        h.PublicIpLookup.Verify(p => p.Invalidate(It.IsAny<int>()), Times.Never);
+    }
 }

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceTestHarness.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceTestHarness.cs
@@ -13,6 +13,7 @@ using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 
@@ -35,6 +36,8 @@ internal sealed class VpnDataServiceTestHarness
     public Mock<IMicroserviceInfoService> MicroserviceInfo { get; } = new(MockBehavior.Loose);
     public Mock<IOpenVpnMicroserviceClientFactory> MicroserviceFactory { get; } = new(MockBehavior.Loose);
     public Mock<IOpenVpnEventClientFactory> EventFactory { get; } = new(MockBehavior.Loose);
+    public Mock<IVpnNodePublicIpLookup> PublicIpLookup { get; } = new(MockBehavior.Loose);
+    public Mock<IVpnServerClientPresenceService> Presence { get; } = new(MockBehavior.Loose);
 
     public List<QuotaPlanAllowedServer> QuotaLinksAdded { get; } = [];
     public List<VpnServerTag> TagsAdded { get; } = [];
@@ -81,7 +84,9 @@ internal sealed class VpnDataServiceTestHarness
         StatusCache.Object,
         MicroserviceInfo.Object,
         MicroserviceFactory.Object,
-        EventFactory.Object);
+        EventFactory.Object,
+        PublicIpLookup.Object,
+        Presence.Object);
 
     public void SetupInsertServer(string name, int assignedId, VpnServer? returnEntity = null)
     {

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceTestHarness.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceTestHarness.cs
@@ -14,7 +14,6 @@ using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.Helpers;
-using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 
 namespace DataGateMonitor.Tests.Services.Api;
@@ -22,7 +21,6 @@ namespace DataGateMonitor.Tests.Services.Api;
 internal sealed class VpnDataServiceTestHarness
 {
     public Mock<ILogger<IVpnDataService>> Log { get; } = new();
-    public Mock<IExternalIpAddressService> Ip { get; } = new(MockBehavior.Strict);
     public Mock<IQuotaPlanQueryService> QuotaPlanQ { get; } = new(MockBehavior.Strict);
     public Mock<IVpnServerQueryService> ServerQ { get; } = new(MockBehavior.Strict);
     public Mock<IVpnServerOvpnFileConfigQueryService> CfgQ { get; } = new(MockBehavior.Strict);
@@ -71,7 +69,6 @@ internal sealed class VpnDataServiceTestHarness
 
     public VpnDataService Create() => new(
         Log.Object,
-        Ip.Object,
         QuotaPlanQ.Object,
         ServerQ.Object,
         CfgQ.Object,

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
@@ -14,6 +14,7 @@ using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.Cache;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using Xunit;
@@ -77,7 +78,9 @@ public class VpnDataServiceTests
             statusCacheGeneration.Object,
             microserviceInfo.Object,
             microserviceFactory.Object,
-            eventFactory.Object);
+            eventFactory.Object,
+            Mock.Of<IVpnNodePublicIpLookup>(),
+            Mock.Of<IVpnServerClientPresenceService>());
 
         return (svc, log, ip, quotaPlanQ, serverQ, cfgQ, trx, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, notification, statusCacheGeneration, microserviceInfo, microserviceFactory, eventFactory);
     }

--- a/DataGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnDataServiceTests.cs
@@ -15,8 +15,10 @@ using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.Helpers;
-using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+using DataGateMonitor.SharedModels.Enums;
 using Xunit;
 
 namespace DataGateMonitor.Tests.Services.Api;
@@ -25,7 +27,6 @@ public class VpnDataServiceTests
 {
     private static (VpnDataService svc,
         Mock<ILogger<IVpnDataService>> log,
-        Mock<IExternalIpAddressService> ip,
         Mock<IQuotaPlanQueryService> quotaPlanQ,
         Mock<IVpnServerQueryService> serverQ,
         Mock<IVpnServerOvpnFileConfigQueryService> cfgQ,
@@ -42,7 +43,6 @@ public class VpnDataServiceTests
         CreateService()
     {
         var log = new Mock<ILogger<IVpnDataService>>();
-        var ip = new Mock<IExternalIpAddressService>(MockBehavior.Strict);
         var serverQ = new Mock<IVpnServerQueryService>(MockBehavior.Strict);
         var cfgQ = new Mock<IVpnServerOvpnFileConfigQueryService>(MockBehavior.Strict);
         var trx = new Mock<ITransactionRunner>(MockBehavior.Strict);
@@ -65,7 +65,6 @@ public class VpnDataServiceTests
 
         var svc = new VpnDataService(
             log.Object,
-            ip.Object,
             quotaPlanQ.Object,
             serverQ.Object,
             cfgQ.Object,
@@ -82,13 +81,13 @@ public class VpnDataServiceTests
             Mock.Of<IVpnNodePublicIpLookup>(),
             Mock.Of<IVpnServerClientPresenceService>());
 
-        return (svc, log, ip, quotaPlanQ, serverQ, cfgQ, trx, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, notification, statusCacheGeneration, microserviceInfo, microserviceFactory, eventFactory);
+        return (svc, log, quotaPlanQ, serverQ, cfgQ, trx, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, notification, statusCacheGeneration, microserviceInfo, microserviceFactory, eventFactory);
     }
 
     [Fact]
     public async Task AddVpnServer_DoesNotCreateDefaultConfig_DuringInitialInsert()
     {
-        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
         var server = new VpnServer { Id = 0, IsDefault = false, ServerName = "Srv" };
 
         var before = DateTimeOffset.UtcNow;
@@ -114,14 +113,13 @@ public class VpnDataServiceTests
         cfgCmd.Verify(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Never);
         serverCmd.Verify(c => c.Add(It.IsAny<VpnServer>(), true, It.IsAny<CancellationToken>()), Times.Once);
         serverQ.Verify(q => q.GetById(101, It.IsAny<CancellationToken>()), Times.Once);
-        ip.Verify(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>()), Times.Never);
         cfgQ.Verify(q => q.AnyByVpnServerId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task AddVpnServer_Links_DefaultQuotaPlan_When_List_Empty_And_Default_Exists()
     {
-        var (svc, _, ip, quotaPlanQ, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
+        var (svc, _, quotaPlanQ, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
         quotaPlanQ.Setup(q => q.GetDefault(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new QuotaPlan { Id = 42, Name = "Default" });
 
@@ -148,14 +146,13 @@ public class VpnDataServiceTests
             true,
             It.IsAny<CancellationToken>()), Times.Once);
         cfgCmd.Verify(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Never);
-        ip.Verify(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>()), Times.Never);
         cfgQ.Verify(q => q.AnyByVpnServerId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task AddVpnServer_Unsets_Previous_Default_When_IsDefault_True()
     {
-        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
         var server = new VpnServer { Id = 0, IsDefault = true, ServerName = "DefaultSrv" };
 
         serverQ.Setup(q => q.AnyByServerName("DefaultSrv", It.IsAny<CancellationToken>())).ReturnsAsync(false);
@@ -182,18 +179,16 @@ public class VpnDataServiceTests
                 It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
                 It.IsAny<CancellationToken>()), Times.Once);
         cfgCmd.Verify(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
-        ip.Verify(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>()), Times.Never);
         cfgQ.Verify(q => q.AnyByVpnServerId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public async Task UpdateVpnServer_Updates_Entity_And_Adds_Config_When_Missing()
     {
-        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, cfgQ, _, serverCmd, cfgCmd, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
         var server = new VpnServer { Id = 51, IsDefault = false, ServerName = "Srv" };
 
         cfgQ.Setup(q => q.AnyByVpnServerId(51, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("198.51.100.5");
         serverQ.Setup(q => q.AnyByServerNameExceptId("Srv", 51, It.IsAny<CancellationToken>())).ReturnsAsync(false);
         cfgCmd.Setup(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((VpnServerOvpnFileConfig e, bool _, CancellationToken _) => e);
@@ -216,11 +211,10 @@ public class VpnDataServiceTests
     [Fact]
     public async Task UpdateVpnServer_Unsets_Other_Defaults_When_IsDefault_True()
     {
-        var (svc, _, ip, _, serverQ, cfgQ, _, serverCmd, _, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, cfgQ, _, serverCmd, _, quotaPlanCmd, tagCmd, _, _, _, _, _) = CreateService();
         var server = new VpnServer { Id = 9, IsDefault = true, ServerName = "Srv" };
 
         cfgQ.Setup(q => q.AnyByVpnServerId(9, It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("ignored");
         serverQ.Setup(q => q.AnyByServerNameExceptId("Srv", 9, It.IsAny<CancellationToken>())).ReturnsAsync(false);
 
         serverCmd.Setup(c => c.UpdateWhere(
@@ -246,7 +240,7 @@ public class VpnDataServiceTests
     [Fact]
     public async Task DeleteVpnServer_Performs_SoftDelete_WithUpdateWhere()
     {
-        var (svc, _, _, _, serverQ, _, _, serverCmd, _, _, _, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, _, _, serverCmd, _, _, _, _, _, _, _, _) = CreateService();
         var entity = new VpnServer { Id = 77, ServerName = "Srv" };
         serverQ.Setup(q => q.GetById(77, It.IsAny<CancellationToken>())).ReturnsAsync(entity);
         serverCmd.Setup(c => c.UpdateWhere(
@@ -267,7 +261,7 @@ public class VpnDataServiceTests
     [Fact]
     public async Task DeleteVpnServer_Throws_When_NotFound()
     {
-        var (svc, _, _, _, serverQ, _, _, _, _, _, _, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, _, _, _, _, _, _, _, _, _, _, _) = CreateService();
         serverQ.Setup(q => q.GetById(555, It.IsAny<CancellationToken>())).ReturnsAsync((VpnServer?)null);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.DeleteVpnServer(555, CancellationToken.None));
@@ -277,13 +271,21 @@ public class VpnDataServiceTests
     [Fact]
     public async Task RunPostAddSetupAsync_CreatesDefaultConfig_ForOpenVpnServer()
     {
-        var (svc, _, ip, _, serverQ, cfgQ, _, _, cfgCmd, _, _, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, cfgQ, _, _, cfgCmd, _, _, _, _, microserviceInfo, _, _) = CreateService();
         serverQ.Setup(q => q.GetById(88, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new VpnServer { Id = 88, ServerName = "srv88" });
+            .ReturnsAsync(new VpnServer { Id = 88, ServerName = "srv88", ServerType = VpnServerType.OpenVpn });
         cfgQ.Setup(q => q.AnyByVpnServerId(88, It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
-        ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>()))
-            .ReturnsAsync("203.0.113.99");
+        microserviceInfo.Setup(m => m.GetInfoAsync(88, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                ServerType = VpnServerType.OpenVpn,
+                OpenVpn = new RootOpenVpnInfoResponse
+                {
+                    PublicIp = "203.0.113.99",
+                    Config = new ConfigInfoResponse { Port = "1297", Proto = "tcp" }
+                }
+            });
         cfgCmd.Setup(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()))
             .ReturnsAsync((VpnServerOvpnFileConfig e, bool _, CancellationToken _) => e);
 
@@ -291,14 +293,18 @@ public class VpnDataServiceTests
 
         Assert.Equal(88, result.VpnServerId);
         Assert.True(result.CreatedDefaultConfig);
-        cfgCmd.Verify(c => c.Add(It.Is<VpnServerOvpnFileConfig>(x => x.VpnServerId == 88 && x.VpnServerIp == "203.0.113.99"),
+        cfgCmd.Verify(c => c.Add(It.Is<VpnServerOvpnFileConfig>(x =>
+                x.VpnServerId == 88
+                && x.VpnServerIp == "203.0.113.99"
+                && x.VpnServerPort == 1297
+                && x.ConfigTemplate.Contains("proto tcp")),
             true, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task RunPostAddSetupAsync_ReturnsFalse_WhenDefaultConfigAlreadyExists()
     {
-        var (svc, _, ip, _, serverQ, cfgQ, _, _, cfgCmd, _, _, _, _, _, _, _) = CreateService();
+        var (svc, _, _, serverQ, cfgQ, _, _, cfgCmd, _, _, _, _, microserviceInfo, _, _) = CreateService();
         serverQ.Setup(q => q.GetById(89, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new VpnServer { Id = 89, ServerName = "srv89" });
         cfgQ.Setup(q => q.AnyByVpnServerId(89, It.IsAny<CancellationToken>()))
@@ -309,6 +315,6 @@ public class VpnDataServiceTests
         Assert.Equal(89, result.VpnServerId);
         Assert.False(result.CreatedDefaultConfig);
         cfgCmd.Verify(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Never);
-        ip.Verify(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>()), Times.Never);
+        microserviceInfo.Verify(m => m.GetInfoAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/VpnServerLifecycleState.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnServerLifecycleState.cs
@@ -13,7 +13,6 @@ using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
 using DataGateMonitor.Services.Helpers;
-using DataGateMonitor.Services.Helpers.Interfaces;
 using Microsoft.Extensions.Logging;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using DataGateMonitor.SharedModels.Enums;
@@ -247,12 +246,8 @@ internal sealed class VpnServerLifecycleEnvironment
                 return cfg;
             });
 
-        var ip = new Mock<IExternalIpAddressService>();
-        ip.Setup(x => x.GetRemoteIpAddress(It.IsAny<CancellationToken>())).ReturnsAsync("203.0.113.50");
-
         return new VpnDataService(
             Mock.Of<ILogger<IVpnDataService>>(),
-            ip.Object,
             quotaPlanQ.Object,
             serverQ.Object,
             cfgQ.Object,

--- a/DataGateMonitor.Tests/Services/Api/VpnServerLifecycleState.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnServerLifecycleState.cs
@@ -12,6 +12,7 @@ using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.Helpers.Interfaces;
 using Microsoft.Extensions.Logging;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
@@ -264,6 +265,8 @@ internal sealed class VpnServerLifecycleEnvironment
             Mock.Of<IStatusCacheGenerationService>(),
             Mock.Of<IMicroserviceInfoService>(),
             Mock.Of<IOpenVpnMicroserviceClientFactory>(),
-            Mock.Of<IOpenVpnEventClientFactory>());
+            Mock.Of<IOpenVpnEventClientFactory>(),
+            Mock.Of<IVpnNodePublicIpLookup>(),
+            Mock.Of<IVpnServerClientPresenceService>());
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/VpnServerOvpnFileConfigServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnServerOvpnFileConfigServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -6,6 +7,9 @@ using Moq;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+using DataGateMonitor.SharedModels.Enums;
 using DataGateMonitor.Services.Api;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 
@@ -170,5 +174,182 @@ public class VpnServerOvpnFileConfigServiceTests
         Assert.Contains(serverId.ToString(), ex.Message);
         q.VerifyAll();
         cmd.Verify(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddOrUpdate_AutoDetect_Applies_OpenVpn_Port_And_Proto_From_MicroserviceInfo()
+    {
+        var (svc, _, q, cmd, microserviceInfo) = CreateService();
+        var serverId = 400;
+        var existing = new VpnServerOvpnFileConfig
+        {
+            Id = 9,
+            VpnServerId = serverId,
+            VpnServerIp = "10.0.0.1",
+            VpnServerPort = 1194,
+            ConfigTemplate = "client\nproto udp\nremote server 1194"
+        };
+
+        microserviceInfo.Setup(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                ServerType = VpnServerType.OpenVpn,
+                OpenVpn = new RootOpenVpnInfoResponse
+                {
+                    Config = new ConfigInfoResponse
+                    {
+                        Port = "443",
+                        Proto = "tcp"
+                    }
+                }
+            });
+        q.SetupSequence(x => x.GetByVpnServerIdId(serverId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing)
+            .ReturnsAsync(existing);
+        cmd.Setup(c => c.Update(existing, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var incoming = new VpnServerOvpnFileConfig
+        {
+            VpnServerId = serverId,
+            VpnServerIp = "20.0.0.2",
+            VpnServerPort = 1194,
+            ConfigTemplate = "client\nproto udp\nremote server 1194"
+        };
+
+        var result = await svc.AddOrUpdateVpnServerOvpnFileConfigByServerId(incoming, true, CancellationToken.None);
+
+        Assert.Same(existing, result);
+        Assert.Equal(443, existing.VpnServerPort);
+        Assert.Contains("proto tcp", existing.ConfigTemplate);
+        Assert.DoesNotContain("proto udp", existing.ConfigTemplate);
+        microserviceInfo.Verify(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()), Times.Once);
+        q.VerifyAll();
+        cmd.VerifyAll();
+    }
+
+    [Fact]
+    public async Task AddOrUpdate_AutoDetect_Keeps_Provided_Settings_When_InfoService_Throws()
+    {
+        var (svc, _, q, cmd, microserviceInfo) = CreateService();
+        var serverId = 500;
+        var existing = new VpnServerOvpnFileConfig
+        {
+            Id = 10,
+            VpnServerId = serverId,
+            VpnServerIp = "10.0.0.1",
+            VpnServerPort = 1194,
+            ConfigTemplate = "proto udp"
+        };
+
+        microserviceInfo.Setup(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("info unavailable"));
+        q.SetupSequence(x => x.GetByVpnServerIdId(serverId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing)
+            .ReturnsAsync(existing);
+        cmd.Setup(c => c.Update(existing, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var incoming = new VpnServerOvpnFileConfig
+        {
+            VpnServerId = serverId,
+            VpnServerIp = "20.0.0.2",
+            VpnServerPort = 1195,
+            ConfigTemplate = "proto udp"
+        };
+
+        var result = await svc.AddOrUpdateVpnServerOvpnFileConfigByServerId(incoming, true, CancellationToken.None);
+
+        Assert.Same(existing, result);
+        Assert.Equal(1195, existing.VpnServerPort);
+        Assert.Equal("proto udp", existing.ConfigTemplate);
+        microserviceInfo.Verify(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()), Times.Once);
+        q.VerifyAll();
+        cmd.VerifyAll();
+    }
+
+    [Fact]
+    public async Task AddOrUpdate_Does_Not_Call_InfoService_When_AutoDetect_Disabled()
+    {
+        var (svc, _, q, cmd, microserviceInfo) = CreateService();
+        var serverId = 600;
+        var existing = new VpnServerOvpnFileConfig
+        {
+            Id = 11,
+            VpnServerId = serverId,
+            VpnServerIp = "10.0.0.1",
+            VpnServerPort = 1194,
+            ConfigTemplate = "proto udp"
+        };
+
+        q.SetupSequence(x => x.GetByVpnServerIdId(serverId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing)
+            .ReturnsAsync(existing);
+        cmd.Setup(c => c.Update(existing, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var incoming = new VpnServerOvpnFileConfig
+        {
+            VpnServerId = serverId,
+            VpnServerIp = "20.0.0.2",
+            VpnServerPort = 1195,
+            ConfigTemplate = "proto udp"
+        };
+
+        await svc.AddOrUpdateVpnServerOvpnFileConfigByServerId(incoming, false, CancellationToken.None);
+
+        microserviceInfo.Verify(m => m.GetInfoAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        q.VerifyAll();
+        cmd.VerifyAll();
+    }
+
+    [Fact]
+    public async Task AddOrUpdate_AutoDetect_TimesOut_And_Still_Updates_Config()
+    {
+        var (svc, _, q, cmd, microserviceInfo) = CreateService();
+        var serverId = 700;
+        var existing = new VpnServerOvpnFileConfig
+        {
+            Id = 12,
+            VpnServerId = serverId,
+            VpnServerIp = "10.0.0.1",
+            VpnServerPort = 1194,
+            ConfigTemplate = "proto udp"
+        };
+
+        microserviceInfo.Setup(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()))
+            .Returns<int, CancellationToken>((_, token) =>
+                Task.Delay(Timeout.InfiniteTimeSpan, token)
+                    .ContinueWith<VpnMicroserviceDiagnosticsDto>(
+                        _ => throw new OperationCanceledException(token),
+                        CancellationToken.None,
+                        TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default));
+        q.SetupSequence(x => x.GetByVpnServerIdId(serverId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing)
+            .ReturnsAsync(existing);
+        cmd.Setup(c => c.Update(existing, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var incoming = new VpnServerOvpnFileConfig
+        {
+            VpnServerId = serverId,
+            VpnServerIp = "20.0.0.2",
+            VpnServerPort = 1195,
+            ConfigTemplate = "proto udp"
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = await svc.AddOrUpdateVpnServerOvpnFileConfigByServerId(incoming, true, CancellationToken.None);
+        stopwatch.Stop();
+
+        Assert.Same(existing, result);
+        Assert.Equal("20.0.0.2", existing.VpnServerIp);
+        Assert.Equal(1195, existing.VpnServerPort);
+        Assert.Equal("proto udp", existing.ConfigTemplate);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
+        microserviceInfo.Verify(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()), Times.Once);
+        q.VerifyAll();
+        cmd.VerifyAll();
     }
 }

--- a/DataGateMonitor.Tests/Services/Api/VpnServerOvpnFileConfigServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnServerOvpnFileConfigServiceTests.cs
@@ -178,7 +178,7 @@ public class VpnServerOvpnFileConfigServiceTests
     }
 
     [Fact]
-    public async Task AddOrUpdate_AutoDetect_Applies_OpenVpn_Port_And_Proto_From_MicroserviceInfo()
+    public async Task AddOrUpdate_AutoDetect_Applies_OpenVpn_Port_Proto_And_PublicIp_When_Ip_Empty()
     {
         var (svc, _, q, cmd, microserviceInfo) = CreateService();
         var serverId = 400;
@@ -197,6 +197,61 @@ public class VpnServerOvpnFileConfigServiceTests
                 ServerType = VpnServerType.OpenVpn,
                 OpenVpn = new RootOpenVpnInfoResponse
                 {
+                    PublicIp = "203.0.113.50",
+                    Config = new ConfigInfoResponse
+                    {
+                        Port = "443",
+                        Proto = "tcp"
+                    }
+                }
+            });
+        q.SetupSequence(x => x.GetByVpnServerIdId(serverId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing)
+            .ReturnsAsync(existing);
+        cmd.Setup(c => c.Update(existing, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var incoming = new VpnServerOvpnFileConfig
+        {
+            VpnServerId = serverId,
+            VpnServerIp = "",
+            VpnServerPort = 1194,
+            ConfigTemplate = "client\nproto udp\nremote server 1194"
+        };
+
+        var result = await svc.AddOrUpdateVpnServerOvpnFileConfigByServerId(incoming, true, CancellationToken.None);
+
+        Assert.Same(existing, result);
+        Assert.Equal("203.0.113.50", existing.VpnServerIp);
+        Assert.Equal(443, existing.VpnServerPort);
+        Assert.Contains("proto tcp", existing.ConfigTemplate);
+        Assert.DoesNotContain("proto udp", existing.ConfigTemplate);
+        microserviceInfo.Verify(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()), Times.Once);
+        q.VerifyAll();
+        cmd.VerifyAll();
+    }
+
+    [Fact]
+    public async Task AddOrUpdate_AutoDetect_Applies_OpenVpn_Port_And_Proto_From_MicroserviceInfo()
+    {
+        var (svc, _, q, cmd, microserviceInfo) = CreateService();
+        var serverId = 401;
+        var existing = new VpnServerOvpnFileConfig
+        {
+            Id = 9,
+            VpnServerId = serverId,
+            VpnServerIp = "10.0.0.1",
+            VpnServerPort = 1194,
+            ConfigTemplate = "client\nproto udp\nremote server 1194"
+        };
+
+        microserviceInfo.Setup(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                ServerType = VpnServerType.OpenVpn,
+                OpenVpn = new RootOpenVpnInfoResponse
+                {
+                    PublicIp = "203.0.113.50",
                     Config = new ConfigInfoResponse
                     {
                         Port = "443",
@@ -221,6 +276,7 @@ public class VpnServerOvpnFileConfigServiceTests
         var result = await svc.AddOrUpdateVpnServerOvpnFileConfigByServerId(incoming, true, CancellationToken.None);
 
         Assert.Same(existing, result);
+        Assert.Equal("20.0.0.2", existing.VpnServerIp);
         Assert.Equal(443, existing.VpnServerPort);
         Assert.Contains("proto tcp", existing.ConfigTemplate);
         Assert.DoesNotContain("proto udp", existing.ConfigTemplate);

--- a/DataGateMonitor.Tests/Services/Api/VpnServerOvpnFileConfigServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Api/VpnServerOvpnFileConfigServiceTests.cs
@@ -22,13 +22,14 @@ public class VpnServerOvpnFileConfigServiceTests
         Mock<IVpnServerOvpnFileConfigQueryService> q,
         Mock<ICommandService<VpnServerOvpnFileConfig, int>> cmd,
         Mock<IMicroserviceInfoService> microserviceInfo)
-        CreateService()
+        CreateService(TimeSpan? openVpnAutoDetectTimeout = null)
     {
         var logger = new Mock<ILogger<VpnServerOvpnFileConfigService>>();
         var q = new Mock<IVpnServerOvpnFileConfigQueryService>(MockBehavior.Strict);
         var cmd = new Mock<ICommandService<VpnServerOvpnFileConfig, int>>(MockBehavior.Strict);
         var microserviceInfo = new Mock<IMicroserviceInfoService>(MockBehavior.Loose);
-        var svc = new VpnServerOvpnFileConfigService(logger.Object, q.Object, cmd.Object, microserviceInfo.Object);
+        var svc = new VpnServerOvpnFileConfigService(
+            logger.Object, q.Object, cmd.Object, microserviceInfo.Object, openVpnAutoDetectTimeout);
         return (svc, logger, q, cmd, microserviceInfo);
     }
 
@@ -306,7 +307,7 @@ public class VpnServerOvpnFileConfigServiceTests
     [Fact]
     public async Task AddOrUpdate_AutoDetect_TimesOut_And_Still_Updates_Config()
     {
-        var (svc, _, q, cmd, microserviceInfo) = CreateService();
+        var (svc, _, q, cmd, microserviceInfo) = CreateService(TimeSpan.FromMilliseconds(50));
         var serverId = 700;
         var existing = new VpnServerOvpnFileConfig
         {
@@ -347,9 +348,40 @@ public class VpnServerOvpnFileConfigServiceTests
         Assert.Equal("20.0.0.2", existing.VpnServerIp);
         Assert.Equal(1195, existing.VpnServerPort);
         Assert.Equal("proto udp", existing.ConfigTemplate);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(10));
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2));
         microserviceInfo.Verify(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()), Times.Once);
         q.VerifyAll();
         cmd.VerifyAll();
+    }
+
+    [Fact]
+    public async Task AddOrUpdate_AutoDetect_Propagates_Caller_Cancellation()
+    {
+        var (svc, _, q, cmd, microserviceInfo) = CreateService();
+        var serverId = 800;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        microserviceInfo.Setup(m => m.GetInfoAsync(serverId, It.IsAny<CancellationToken>()))
+            .Returns<int, CancellationToken>((_, token) =>
+            {
+                token.ThrowIfCancellationRequested();
+                return Task.FromResult<VpnMicroserviceDiagnosticsDto?>(null)!;
+            });
+
+        var incoming = new VpnServerOvpnFileConfig
+        {
+            VpnServerId = serverId,
+            VpnServerIp = "20.0.0.2",
+            VpnServerPort = 1195,
+            ConfigTemplate = "proto udp"
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            svc.AddOrUpdateVpnServerOvpnFileConfigByServerId(incoming, true, cts.Token));
+
+        q.Verify(x => x.GetByVpnServerIdId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        cmd.Verify(c => c.Update(It.IsAny<VpnServerOvpnFileConfig>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+        cmd.Verify(c => c.Add(It.IsAny<VpnServerOvpnFileConfig>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnBackgroundServiceDisabledServersTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnBackgroundServiceDisabledServersTests.cs
@@ -1,0 +1,174 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.BackgroundServices;
+using DataGateMonitor.Services.BackgroundServices.Interfaces;
+using DataGateMonitor.Services.Cache;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Helpers;
+using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
+using DataGateMonitor.Services.StatusStreamLogs;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.BackgroundServices;
+
+public class OpenVpnBackgroundServiceDisabledServersTests : IDisposable
+{
+    public OpenVpnBackgroundServiceDisabledServersTests() => ResetInstanceCount();
+
+    public void Dispose() => ResetInstanceCount();
+
+    private static void ResetInstanceCount()
+    {
+        var field = typeof(OpenVpnBackgroundService).GetField(
+            "_instanceCount", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(null, 0);
+    }
+
+    private static async Task InvokeRunOpenVpnTaskAsync(OpenVpnBackgroundService sut, int nextRunSeconds)
+    {
+        var method = typeof(OpenVpnBackgroundService).GetMethod(
+            "RunOpenVpnTask", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var task = (Task)method!.Invoke(sut, [nextRunSeconds, CancellationToken.None])!;
+        await task;
+    }
+
+    private static (OpenVpnBackgroundService Sut, Mock<IVpnServerClientPresenceService> Presence, Mock<IVpnServerService> VpnService, VpnServerStatusManager Status)
+        CreateSut(List<VpnServer> servers, MockBehavior presenceBehavior = MockBehavior.Loose)
+    {
+        var serverQ = new Mock<IVpnServerQueryService>();
+        serverQ.Setup(q => q.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(servers);
+
+        var presence = new Mock<IVpnServerClientPresenceService>(presenceBehavior);
+        if (presenceBehavior != MockBehavior.Strict)
+        {
+            presence.Setup(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+        }
+
+        var vpnService = new Mock<IVpnServerService>();
+        vpnService.Setup(s => s.SaveVpnServerStatusLogAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        vpnService.Setup(s => s.SaveConnectedClientsAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
+        serverCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var conflog = new Mock<IVpnServerConflogService>();
+        conflog.Setup(c => c.FetchAndSaveIfChangedByServerIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerConflog?)null);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(serverQ.Object);
+        services.AddSingleton(presence.Object);
+        services.AddSingleton(vpnService.Object);
+        services.AddSingleton(serverCmd.Object);
+        services.AddSingleton(conflog.Object);
+        services.AddSingleton(Mock.Of<IServerOpenVpnNotificationService>());
+        services.AddSingleton(Mock.Of<ILogger<OpenVpnServerProcessor>>());
+        services.AddSingleton(Mock.Of<ILogger<XrayServerProcessor>>());
+        var sp = services.BuildServiceProvider();
+
+        var logStore = new Mock<IStatusStreamLogStore>();
+        logStore.Setup(s => s.AppendAsync(It.IsAny<StatusStreamLogEntry>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["OpenVpnPolling:MaxDegreeOfParallelism"] = "1"
+        }).Build();
+
+        var statusManager = new VpnServerStatusManager();
+        var sut = new OpenVpnBackgroundService(
+            Mock.Of<ILogger<OpenVpnBackgroundService>>(),
+            sp,
+            new VpnServerProcessorFactory(sp),
+            statusManager,
+            Mock.Of<IStatusCacheGenerationService>(),
+            logStore.Object,
+            config);
+
+        return (sut, presence, vpnService, statusManager);
+    }
+
+    [Fact]
+    public async Task RunOpenVpnTask_MarksDisabledServersDisconnected_AndDoesNotPollThem()
+    {
+        var enabled = new VpnServer
+        {
+            Id = 1,
+            ServerName = "on",
+            ApiUrl = "https://on.example/",
+            IsDisable = false,
+            ServerType = VpnServerType.OpenVpn
+        };
+        var disabledA = new VpnServer
+        {
+            Id = 2,
+            ServerName = "off-a",
+            ApiUrl = "https://a.example/",
+            IsDisable = true,
+            ServerType = VpnServerType.OpenVpn
+        };
+        var disabledB = new VpnServer
+        {
+            Id = 3,
+            ServerName = "off-b",
+            ApiUrl = "https://b.example/",
+            IsDisable = true,
+            ServerType = VpnServerType.Xray
+        };
+
+        var (sut, presence, vpnService, status) = CreateSut([enabled, disabledA, disabledB]);
+        await InvokeRunOpenVpnTaskAsync(sut, nextRunSeconds: 30);
+
+        presence.Verify(p => p.MarkAllDisconnectedAsync(2, It.IsAny<CancellationToken>()), Times.Once);
+        presence.Verify(p => p.MarkAllDisconnectedAsync(3, It.IsAny<CancellationToken>()), Times.Once);
+        presence.Verify(p => p.MarkAllDisconnectedAsync(1, It.IsAny<CancellationToken>()), Times.Never);
+
+        Assert.Equal(ServiceStatus.Idle, status.GetStatus(2).Status);
+        Assert.Equal(ServiceStatus.Idle, status.GetStatus(3).Status);
+
+        vpnService.Verify(
+            s => s.SaveConnectedClientsAsync(It.Is<VpnServer>(v => v.Id == 1), It.IsAny<CancellationToken>()),
+            Times.Once);
+        vpnService.Verify(
+            s => s.SaveConnectedClientsAsync(It.Is<VpnServer>(v => v.Id == 2 || v.Id == 3), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunOpenVpnTask_WhenOnlyEnabled_DoesNotCallPresenceFromDisableLoop()
+    {
+        var enabled = new VpnServer
+        {
+            Id = 5,
+            ServerName = "on",
+            ApiUrl = "https://on.example/",
+            IsDisable = false,
+            ServerType = VpnServerType.OpenVpn
+        };
+
+        var (sut, presence, _, _) = CreateSut([enabled], MockBehavior.Strict);
+        await InvokeRunOpenVpnTaskAsync(sut, 30);
+
+        presence.Verify(
+            p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnServerProcessorTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/OpenVpnServerProcessorTests.cs
@@ -3,6 +3,7 @@ using DataGateMonitor.Models;
 using DataGateMonitor.Services.BackgroundServices;
 using DataGateMonitor.Services.BackgroundServices.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -27,10 +28,15 @@ public class OpenVpnServerProcessorTests
         conflog.Setup(x => x.FetchAndSaveIfChangedByServerIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((VpnServerConflog?)null);
 
+        var presence = new Mock<IVpnServerClientPresenceService>();
+        presence.Setup(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
         var services = new ServiceCollection();
         services.AddSingleton(vpnService.Object);
         services.AddSingleton(serverCmd.Object);
         services.AddSingleton(conflog.Object);
+        services.AddSingleton(presence.Object);
         var sp = services.BuildServiceProvider();
 
         return (new OpenVpnServerProcessor(NullLogger<OpenVpnServerProcessor>.Instance, sp), vpnService, serverCmd);

--- a/DataGateMonitor.Tests/Services/BackgroundServices/VpnServerConnectedClientsCounterBehaviorTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/VpnServerConnectedClientsCounterBehaviorTests.cs
@@ -1,0 +1,403 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
+using DataGateMonitor.DataBase.Services.Query.IssuedXrayClientLinkTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerStatusLogTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.XrayNode;
+using DataGateMonitor.Services.BackgroundServices;
+using DataGateMonitor.Services.BackgroundServices.Interfaces;
+using DataGateMonitor.Services.Cache;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.GeoLite.Interfaces;
+using DataGateMonitor.Services.Helpers;
+using DataGateMonitor.Services.Helpers.Interfaces;
+using DataGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
+using DataGateMonitor.Services.XrayNode;
+using DataGateMonitor.SharedModels.DataGateMonitor.GeoLite.Dto;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Linq.Expressions;
+
+namespace DataGateMonitor.Tests.Services.BackgroundServices;
+
+/// <summary>
+/// Behavioral coverage for per-server online counters: successful polls write N,
+/// empty polls / disconnect / disable paths write 0, and servers stay isolated.
+/// </summary>
+public class VpnServerConnectedClientsCounterBehaviorTests
+{
+    private readonly Mock<ILogger<IVpnServerService>> _ovpnLogger = new();
+    private readonly Mock<IOpenVpnClientService> _clients = new(MockBehavior.Strict);
+    private readonly Mock<IOpenVpnSummaryStatService> _summary = new(MockBehavior.Loose);
+    private readonly Mock<IOpenVpnVersionService> _version = new(MockBehavior.Loose);
+    private readonly Mock<IOpenVpnStateService> _state = new(MockBehavior.Loose);
+    private readonly Mock<IIssuedOvpnFileQueryService> _issuedFiles = new(MockBehavior.Loose);
+    private readonly Mock<IVpnServerStatusLogQueryService> _statusQuery = new(MockBehavior.Loose);
+    private readonly Mock<IVpnServerOvpnFileConfigQueryService> _ovpnConfig = new(MockBehavior.Loose);
+    private readonly Mock<IVpnNodePublicIpLookup> _publicIp = new(MockBehavior.Loose);
+    private readonly Mock<ITransactionRunner> _tx = new(MockBehavior.Strict);
+    private readonly Mock<IUserQueryService> _users = new(MockBehavior.Loose);
+    private readonly Mock<ICommandService<VpnServer, int>> _serverCmd = new(MockBehavior.Loose);
+    private readonly Mock<ICommandService<VpnServerClient, int>> _clientCmd = new(MockBehavior.Loose);
+    private readonly Mock<ICommandService<VpnServerStatusLog, int>> _statusCmd = new(MockBehavior.Loose);
+    private readonly Mock<ICommandService<VpnServerClientTraffic, int>> _trafficCmd = new(MockBehavior.Loose);
+    private readonly Mock<IVpnServerClientUpsertService> _upsert = new(MockBehavior.Loose);
+    private readonly Mock<IConnectedClientsCounterStore> _counter = new(MockBehavior.Strict);
+
+    private readonly Dictionary<int, int> _countsByServer = new();
+
+    public VpnServerConnectedClientsCounterBehaviorTests()
+    {
+        _tx.Setup(t => t.RunAsync(It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            .Returns<Func<CancellationToken, Task>, CancellationToken>(async (f, ct) => await f(ct));
+
+        _counter
+            .Setup(c => c.SetAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, int, CancellationToken>((id, n, _) => _countsByServer[id] = n)
+            .Returns(Task.CompletedTask);
+
+        _clientCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        _clientCmd.Setup(c => c.SaveChanges(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+        _trafficCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClientTraffic, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClientTraffic>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        _trafficCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerClientTraffic>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerClientTraffic e, bool _, CancellationToken _) => e);
+        _trafficCmd.Setup(c => c.SaveChanges(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+        _upsert.Setup(u => u.UpsertAsync(It.IsAny<VpnServerClientUpsertPayload>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _issuedFiles
+            .Setup(q => q.GetExternalIdByCommonName(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        _users.Setup(q => q.GetByExternalId(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+    }
+
+    private VpnServerService CreateOpenVpnSut() => new(
+        _ovpnLogger.Object,
+        _clients.Object,
+        _summary.Object,
+        _version.Object,
+        _state.Object,
+        _issuedFiles.Object,
+        _statusQuery.Object,
+        _ovpnConfig.Object,
+        _publicIp.Object,
+        _tx.Object,
+        _users.Object,
+        _serverCmd.Object,
+        _clientCmd.Object,
+        _statusCmd.Object,
+        _trafficCmd.Object,
+        _upsert.Object,
+        _counter.Object);
+
+    private VpnServerClientPresenceService CreatePresenceSut() => new(
+        _clientCmd.Object,
+        _counter.Object,
+        Mock.Of<ILogger<VpnServerClientPresenceService>>());
+
+    private static VpnServer OpenVpnServer(int id = 7) => new()
+    {
+        Id = id,
+        ServerName = $"ovpn-{id}",
+        ApiUrl = $"https://ovpn-{id}.example/",
+        ServerType = VpnServerType.OpenVpn
+    };
+
+    private static VpnServer XrayServer(int id = 11) => new()
+    {
+        Id = id,
+        ServerName = $"xray-{id}",
+        ApiUrl = $"https://xray-{id}.example/",
+        ServerType = VpnServerType.Xray
+    };
+
+    private static VpnServerClient MgmtClient(string cn, string remoteIp, DateTimeOffset since) => new()
+    {
+        CommonName = cn,
+        RemoteIp = remoteIp,
+        ConnectedSince = since,
+        BytesReceived = 10,
+        BytesSent = 20
+    };
+
+    private void SetupOpenVpnClients(VpnServer server, params VpnServerClient[] clients)
+    {
+        _clients
+            .Setup(c => c.GetClientsFromManagementAsync(server, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OpenVpnManagementStatusResult { Clients = clients.ToList() });
+    }
+
+    private XrayVpnClientSyncService CreateXraySyncSut()
+    {
+        var xrayLinks = new Mock<IIssuedXrayClientLinkQueryService>(MockBehavior.Loose);
+        xrayLinks
+            .Setup(q => q.GetExternalIdByCommonName(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var geo = new Mock<IGeoLiteQueryService>(MockBehavior.Loose);
+        geo.Setup(g => g.GetGeoInfoAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OpenVpnGeoInfo?)null);
+
+        return new XrayVpnClientSyncService(
+            Mock.Of<ILogger<XrayVpnClientSyncService>>(),
+            xrayLinks.Object,
+            _issuedFiles.Object,
+            _users.Object,
+            geo.Object,
+            _tx.Object,
+            _clientCmd.Object,
+            _trafficCmd.Object,
+            _upsert.Object,
+            _counter.Object);
+    }
+
+    [Fact]
+    public async Task OpenVpn_SaveConnectedClients_SetsRedisCounterToClientCount()
+    {
+        var server = OpenVpnServer();
+        var since = DateTimeOffset.Parse("2024-06-01T12:00:00Z");
+        SetupOpenVpnClients(
+            server,
+            MgmtClient("a", "198.51.100.1:1194", since),
+            MgmtClient("b", "198.51.100.2:1194", since),
+            MgmtClient("c", "198.51.100.3:1194", since));
+
+        await CreateOpenVpnSut().SaveConnectedClientsAsync(server, CancellationToken.None);
+
+        Assert.Equal(3, _countsByServer[7]);
+        _counter.Verify(c => c.SetAsync(7, 3, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OpenVpn_SaveConnectedClients_WhenNoClients_SetsRedisCounterToZero()
+    {
+        var server = OpenVpnServer();
+        SetupOpenVpnClients(server);
+
+        await CreateOpenVpnSut().SaveConnectedClientsAsync(server, CancellationToken.None);
+
+        Assert.Equal(0, _countsByServer[7]);
+        _counter.Verify(c => c.SetAsync(7, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OpenVpn_SaveConnectedClients_WhenCountDrops_UpdatesCounterToNewCount()
+    {
+        var server = OpenVpnServer();
+        var since = DateTimeOffset.Parse("2024-06-01T12:00:00Z");
+        SetupOpenVpnClients(
+            server,
+            MgmtClient("a", "198.51.100.1:1194", since),
+            MgmtClient("b", "198.51.100.2:1194", since),
+            MgmtClient("c", "198.51.100.3:1194", since));
+        await CreateOpenVpnSut().SaveConnectedClientsAsync(server, CancellationToken.None);
+        Assert.Equal(3, _countsByServer[7]);
+
+        SetupOpenVpnClients(server, MgmtClient("a", "198.51.100.1:1194", since));
+        await CreateOpenVpnSut().SaveConnectedClientsAsync(server, CancellationToken.None);
+
+        Assert.Equal(1, _countsByServer[7]);
+        _counter.Verify(c => c.SetAsync(7, 3, It.IsAny<CancellationToken>()), Times.Once);
+        _counter.Verify(c => c.SetAsync(7, 1, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Xray_SyncConnectedClients_SetsRedisCounterToClientCount()
+    {
+        var server = XrayServer();
+        var since = DateTimeOffset.Parse("2024-06-01T12:00:00Z");
+        var clients = new List<XrayNodeClientDto>
+        {
+            new() { Email = "u1@ex", RemoteAddress = "203.0.113.1:443", ConnectedSince = since },
+            new() { Email = "u2@ex", RemoteAddress = "203.0.113.2:443", ConnectedSince = since },
+        };
+
+        await CreateXraySyncSut().SyncConnectedClientsAsync(server, clients, CancellationToken.None);
+
+        Assert.Equal(2, _countsByServer[11]);
+        _counter.Verify(c => c.SetAsync(11, 2, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task OnlineThenServerGoesUnreachable_MarkAllDisconnected_ZerosOnlyThatServerCounter()
+    {
+        var onlineServer = OpenVpnServer(7);
+        var otherServer = OpenVpnServer(8);
+        var since = DateTimeOffset.Parse("2024-06-01T12:00:00Z");
+
+        SetupOpenVpnClients(
+            onlineServer,
+            MgmtClient("a", "198.51.100.1:1194", since),
+            MgmtClient("b", "198.51.100.2:1194", since));
+        await CreateOpenVpnSut().SaveConnectedClientsAsync(onlineServer, CancellationToken.None);
+
+        SetupOpenVpnClients(otherServer, MgmtClient("x", "198.51.100.9:1194", since));
+        await CreateOpenVpnSut().SaveConnectedClientsAsync(otherServer, CancellationToken.None);
+
+        Assert.Equal(2, _countsByServer[7]);
+        Assert.Equal(1, _countsByServer[8]);
+
+        _clientCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        await CreatePresenceSut().MarkAllDisconnectedAsync(7, CancellationToken.None);
+
+        Assert.Equal(0, _countsByServer[7]);
+        Assert.Equal(1, _countsByServer[8]);
+    }
+
+    [Fact]
+    public async Task OpenVpnProcessor_Success_DoesNotClearPresence_AndSavesClients()
+    {
+        var vpnServerService = new Mock<IVpnServerService>(MockBehavior.Strict);
+        vpnServerService.Setup(s => s.SaveVpnServerStatusLogAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        vpnServerService.Setup(s => s.SaveConnectedClientsAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var presence = new Mock<IVpnServerClientPresenceService>(MockBehavior.Strict);
+        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
+        serverCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(vpnServerService.Object);
+        services.AddSingleton(serverCmd.Object);
+        services.AddSingleton(presence.Object);
+        services.AddSingleton(Mock.Of<IVpnServerConflogService>());
+        var sp = services.BuildServiceProvider();
+
+        var sut = new OpenVpnServerProcessor(Mock.Of<ILogger<OpenVpnServerProcessor>>(), sp);
+        await sut.ProcessServerAsync(OpenVpnServer(), CancellationToken.None);
+
+        vpnServerService.Verify(s => s.SaveConnectedClientsAsync(It.Is<VpnServer>(v => v.Id == 7), It.IsAny<CancellationToken>()), Times.Once);
+        presence.Verify(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task XrayProcessor_Success_DoesNotClearPresence_AndSyncsClients()
+    {
+        var payload = new XrayNodeClientsResponse
+        {
+            Clients =
+            [
+                new XrayNodeClientDto
+                {
+                    Email = "u@ex",
+                    RemoteAddress = "203.0.113.1:443",
+                    ConnectedSince = DateTimeOffset.UtcNow
+                }
+            ]
+        };
+
+        var xrayApi = new Mock<IXrayNodeApiClient>(MockBehavior.Strict);
+        xrayApi.Setup(a => a.GetActiveClientsAsync("https://xray-11.example", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(payload);
+
+        var sync = new Mock<IXrayVpnClientSyncService>(MockBehavior.Strict);
+        sync.Setup(s => s.SyncConnectedClientsAsync(
+                It.IsAny<VpnServer>(),
+                payload.Clients,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var presence = new Mock<IVpnServerClientPresenceService>(MockBehavior.Strict);
+        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
+        serverCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var statusLog = new Mock<IXrayVpnServerStatusLogService>(MockBehavior.Loose);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(xrayApi.Object);
+        services.AddSingleton(sync.Object);
+        services.AddSingleton(serverCmd.Object);
+        services.AddSingleton(presence.Object);
+        services.AddSingleton(statusLog.Object);
+        var sp = services.BuildServiceProvider();
+
+        var sut = new XrayServerProcessor(Mock.Of<ILogger<XrayServerProcessor>>(), sp);
+        await sut.ProcessServerAsync(XrayServer(), CancellationToken.None);
+
+        sync.Verify(s => s.SyncConnectedClientsAsync(
+            It.Is<VpnServer>(v => v.Id == 11),
+            payload.Clients,
+            It.IsAny<CancellationToken>()), Times.Once);
+        presence.Verify(p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OpenVpnProcessor_OnlineThenOffline_ZerosCounterViaPresence()
+    {
+        var server = OpenVpnServer(21);
+        var since = DateTimeOffset.Parse("2024-06-01T12:00:00Z");
+        SetupOpenVpnClients(
+            server,
+            MgmtClient("a", "198.51.100.1:1194", since),
+            MgmtClient("b", "198.51.100.2:1194", since));
+        await CreateOpenVpnSut().SaveConnectedClientsAsync(server, CancellationToken.None);
+        Assert.Equal(2, _countsByServer[21]);
+
+        var vpnServerService = new Mock<IVpnServerService>();
+        vpnServerService
+            .Setup(s => s.SaveVpnServerStatusLogAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("node offline"));
+
+        var realPresence = CreatePresenceSut();
+        _clientCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
+        serverCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(vpnServerService.Object);
+        services.AddSingleton(serverCmd.Object);
+        services.AddSingleton<IVpnServerClientPresenceService>(realPresence);
+        services.AddSingleton(Mock.Of<IVpnServerConflogService>());
+        var sp = services.BuildServiceProvider();
+
+        var sut = new OpenVpnServerProcessor(Mock.Of<ILogger<OpenVpnServerProcessor>>(), sp);
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            sut.ProcessServerAsync(server, CancellationToken.None));
+
+        Assert.Equal(0, _countsByServer[21]);
+    }
+}

--- a/DataGateMonitor.Tests/Services/BackgroundServices/VpnServerProcessorPresenceOnFailureTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/VpnServerProcessorPresenceOnFailureTests.cs
@@ -1,0 +1,92 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.BackgroundServices;
+using DataGateMonitor.Services.BackgroundServices.Interfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Helpers;
+using DataGateMonitor.Services.XrayNode;
+using DataGateMonitor.Models.XrayNode;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Linq.Expressions;
+
+namespace DataGateMonitor.Tests.Services.BackgroundServices;
+
+public class VpnServerProcessorPresenceOnFailureTests
+{
+    [Fact]
+    public async Task OpenVpnServerProcessor_OnFailure_MarksServerOffline_AndDisconnectsClients()
+    {
+        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
+        serverCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var vpnServerService = new Mock<IVpnServerService>();
+        vpnServerService
+            .Setup(s => s.SaveVpnServerStatusLogAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("node down"));
+
+        var presence = new Mock<IVpnServerClientPresenceService>();
+        presence.Setup(p => p.MarkAllDisconnectedAsync(7, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(vpnServerService.Object);
+        services.AddSingleton(serverCmd.Object);
+        services.AddSingleton(presence.Object);
+        services.AddSingleton(Mock.Of<IVpnServerConflogService>());
+        var sp = services.BuildServiceProvider();
+
+        var sut = new OpenVpnServerProcessor(Mock.Of<ILogger<OpenVpnServerProcessor>>(), sp);
+        var server = new VpnServer { Id = 7, ServerName = "s", ApiUrl = "https://s.example/" };
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            sut.ProcessServerAsync(server, CancellationToken.None));
+
+        presence.Verify(p => p.MarkAllDisconnectedAsync(7, It.IsAny<CancellationToken>()), Times.Once);
+        serverCmd.Verify(c => c.UpdateWhere(
+            It.IsAny<Expression<Func<VpnServer, bool>>>(),
+            It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+            It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task XrayServerProcessor_OnFailure_MarksServerOffline_AndDisconnectsClients()
+    {
+        var serverCmd = new Mock<ICommandService<VpnServer, int>>();
+        serverCmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var xrayApi = new Mock<IXrayNodeApiClient>();
+        xrayApi.Setup(a => a.GetActiveClientsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("xray down"));
+
+        var presence = new Mock<IVpnServerClientPresenceService>();
+        presence.Setup(p => p.MarkAllDisconnectedAsync(11, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(xrayApi.Object);
+        services.AddSingleton(Mock.Of<IXrayVpnClientSyncService>());
+        services.AddSingleton(serverCmd.Object);
+        services.AddSingleton(presence.Object);
+        services.AddSingleton(Mock.Of<IXrayVpnServerStatusLogService>());
+        var sp = services.BuildServiceProvider();
+
+        var sut = new XrayServerProcessor(Mock.Of<ILogger<XrayServerProcessor>>(), sp);
+        var server = new VpnServer { Id = 11, ServerName = "x", ApiUrl = "https://x.example/" };
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            sut.ProcessServerAsync(server, CancellationToken.None));
+
+        presence.Verify(p => p.MarkAllDisconnectedAsync(11, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Services/BackgroundServices/VpnServerServiceStatusLogPublicIpTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/VpnServerServiceStatusLogPublicIpTests.cs
@@ -1,0 +1,181 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
+using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerStatusLogTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.Helpers.OpenVpnManagementInterfaces;
+using DataGateMonitor.Services.BackgroundServices;
+using DataGateMonitor.Services.BackgroundServices.Interfaces;
+using DataGateMonitor.Services.Cache;
+using DataGateMonitor.Services.Helpers;
+using DataGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.BackgroundServices;
+
+public class VpnServerServiceStatusLogPublicIpTests
+{
+    private readonly Mock<ILogger<IVpnServerService>> _logger = new();
+    private readonly Mock<IOpenVpnClientService> _clients = new(MockBehavior.Loose);
+    private readonly Mock<IOpenVpnSummaryStatService> _summary = new();
+    private readonly Mock<IOpenVpnVersionService> _version = new();
+    private readonly Mock<IOpenVpnStateService> _state = new();
+    private readonly Mock<IIssuedOvpnFileQueryService> _issuedFiles = new(MockBehavior.Loose);
+    private readonly Mock<IVpnServerStatusLogQueryService> _statusQuery = new();
+    private readonly Mock<IVpnServerOvpnFileConfigQueryService> _ovpnConfig = new();
+    private readonly Mock<IVpnNodePublicIpLookup> _publicIp = new();
+    private readonly Mock<ITransactionRunner> _tx = new(MockBehavior.Loose);
+    private readonly Mock<IUserQueryService> _users = new(MockBehavior.Loose);
+    private readonly Mock<ICommandService<VpnServer, int>> _serverCmd = new(MockBehavior.Loose);
+    private readonly Mock<ICommandService<VpnServerClient, int>> _clientCmd = new(MockBehavior.Loose);
+    private readonly Mock<ICommandService<VpnServerStatusLog, int>> _statusCmd = new();
+    private readonly Mock<ICommandService<VpnServerClientTraffic, int>> _trafficCmd = new(MockBehavior.Loose);
+    private readonly Mock<IVpnServerClientUpsertService> _upsert = new(MockBehavior.Loose);
+    private readonly Mock<IConnectedClientsCounterStore> _counter = new(MockBehavior.Loose);
+
+    private VpnServerService CreateSut() => new(
+        _logger.Object,
+        _clients.Object,
+        _summary.Object,
+        _version.Object,
+        _state.Object,
+        _issuedFiles.Object,
+        _statusQuery.Object,
+        _ovpnConfig.Object,
+        _publicIp.Object,
+        _tx.Object,
+        _users.Object,
+        _serverCmd.Object,
+        _clientCmd.Object,
+        _statusCmd.Object,
+        _trafficCmd.Object,
+        _upsert.Object,
+        _counter.Object);
+
+    private static VpnServer Server(int id = 7) => new()
+    {
+        Id = id,
+        ServerName = "Norway",
+        ApiUrl = "https://s5.datagateapp.com/",
+        ServerType = VpnServerType.OpenVpn
+    };
+
+    private void SetupHappyPathState()
+    {
+        _state.Setup(s => s.GetStateAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OpenVpnState
+            {
+                UpSince = DateTimeOffset.UtcNow.AddHours(-1),
+                Connected = true,
+                Success = true,
+                ServerLocalIp = "10.51.15.1",
+                ServerRemoteIp = string.Empty
+            });
+        _version.Setup(v => v.GetVersionAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("2.7.4");
+        _summary.Setup(s => s.GetSummaryStatsAsync(It.IsAny<VpnServer>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OpenVpnSummaryStats { BytesIn = 10, BytesOut = 20 });
+        _statusQuery
+            .Setup(q => q.GetBySessionIdAndVpnServerId(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerStatusLog?)null);
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+    }
+
+    [Fact]
+    public async Task SaveVpnServerStatusLogAsync_UsesNodePublicIp_OverConfigAndApiUrl()
+    {
+        SetupHappyPathState();
+        _ovpnConfig.Setup(q => q.GetByVpnServerIdId(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServerOvpnFileConfig { VpnServerId = 7, VpnServerIp = "212.147.232.154" });
+        _publicIp.Setup(p => p.GetAsync(7, VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("198.51.100.50");
+
+        VpnServerStatusLog? saved = null;
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<VpnServerStatusLog, bool, CancellationToken>((e, _, _) => saved = e)
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+
+        await CreateSut().SaveVpnServerStatusLogAsync(Server(), CancellationToken.None);
+
+        Assert.NotNull(saved);
+        Assert.Equal("198.51.100.50", saved!.ServerRemoteIp);
+        Assert.Equal("10.51.15.1", saved.ServerLocalIp);
+    }
+
+    [Fact]
+    public async Task SaveVpnServerStatusLogAsync_WhenLookupReturnsNull_FallsBackToConfigIp()
+    {
+        SetupHappyPathState();
+        _ovpnConfig.Setup(q => q.GetByVpnServerIdId(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServerOvpnFileConfig { VpnServerId = 7, VpnServerIp = "212.147.232.154" });
+        _publicIp.Setup(p => p.GetAsync(7, VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        VpnServerStatusLog? saved = null;
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<VpnServerStatusLog, bool, CancellationToken>((e, _, _) => saved = e)
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+
+        await CreateSut().SaveVpnServerStatusLogAsync(Server(), CancellationToken.None);
+
+        Assert.Equal("212.147.232.154", saved!.ServerRemoteIp);
+    }
+
+    [Fact]
+    public async Task SaveVpnServerStatusLogAsync_WhenNoPublicIpOrConfig_FallsBackToApiUrlHost()
+    {
+        SetupHappyPathState();
+        _ovpnConfig.Setup(q => q.GetByVpnServerIdId(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerOvpnFileConfig?)null);
+        _publicIp.Setup(p => p.GetAsync(7, VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        VpnServerStatusLog? saved = null;
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<VpnServerStatusLog, bool, CancellationToken>((e, _, _) => saved = e)
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+
+        await CreateSut().SaveVpnServerStatusLogAsync(Server(), CancellationToken.None);
+
+        Assert.Equal("s5.datagateapp.com", saved!.ServerRemoteIp);
+    }
+
+    [Fact]
+    public async Task SaveVpnServerStatusLogAsync_UpdatesExistingLog_RemoteIp()
+    {
+        SetupHappyPathState();
+        var existing = new VpnServerStatusLog
+        {
+            Id = 1,
+            VpnServerId = 7,
+            SessionId = Guid.NewGuid(),
+            ServerRemoteIp = "5.22.212.200",
+            ServerLocalIp = "10.51.15.1"
+        };
+        _statusQuery
+            .Setup(q => q.GetBySessionIdAndVpnServerId(It.IsAny<Guid>(), 7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _ovpnConfig.Setup(q => q.GetByVpnServerIdId(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServerOvpnFileConfig { VpnServerId = 7, VpnServerIp = "212.147.232.154" });
+        _publicIp.Setup(p => p.GetAsync(7, VpnServerType.OpenVpn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("203.0.113.9");
+        _statusCmd
+            .Setup(c => c.Update(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        await CreateSut().SaveVpnServerStatusLogAsync(Server(), CancellationToken.None);
+
+        Assert.Equal("203.0.113.9", existing.ServerRemoteIp);
+        _statusCmd.Verify(c => c.Update(existing, true, It.IsAny<CancellationToken>()), Times.Once);
+        _statusCmd.Verify(c => c.Add(It.IsAny<VpnServerStatusLog>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/DataGateMonitor.Tests/Services/BackgroundServices/XrayServerProcessorEdgeCaseTests.cs
+++ b/DataGateMonitor.Tests/Services/BackgroundServices/XrayServerProcessorEdgeCaseTests.cs
@@ -1,0 +1,144 @@
+using System.Linq.Expressions;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.XrayNode;
+using DataGateMonitor.Services.BackgroundServices;
+using DataGateMonitor.Services.Helpers;
+using DataGateMonitor.Services.XrayNode;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.BackgroundServices;
+
+public class XrayServerProcessorEdgeCaseTests
+{
+    private static ServiceProvider BuildSp(
+        Mock<IXrayNodeApiClient> api,
+        Mock<IXrayVpnClientSyncService> sync,
+        Mock<ICommandService<VpnServer, int>> serverCmd,
+        Mock<IVpnServerClientPresenceService> presence,
+        Mock<IXrayVpnServerStatusLogService>? statusLog = null)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(api.Object);
+        services.AddSingleton(sync.Object);
+        services.AddSingleton(serverCmd.Object);
+        services.AddSingleton(presence.Object);
+        services.AddSingleton((statusLog ?? new Mock<IXrayVpnServerStatusLogService>(MockBehavior.Loose)).Object);
+        return services.BuildServiceProvider();
+    }
+
+    private static Mock<ICommandService<VpnServer, int>> ServerCmd()
+    {
+        var cmd = new Mock<ICommandService<VpnServer, int>>();
+        cmd.Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServer, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServer>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        return cmd;
+    }
+
+    [Fact]
+    public async Task ProcessServerAsync_WhenClientsPayloadNull_MarksOfflineAndDisconnects()
+    {
+        var api = new Mock<IXrayNodeApiClient>(MockBehavior.Strict);
+        api.Setup(a => a.GetActiveClientsAsync("https://x.example", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((XrayNodeClientsResponse?)null);
+
+        var sync = new Mock<IXrayVpnClientSyncService>(MockBehavior.Strict);
+        var presence = new Mock<IVpnServerClientPresenceService>();
+        presence.Setup(p => p.MarkAllDisconnectedAsync(11, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var serverCmd = ServerCmd();
+
+        var sut = new XrayServerProcessor(
+            Mock.Of<ILogger<XrayServerProcessor>>(),
+            BuildSp(api, sync, serverCmd, presence));
+        var server = new VpnServer
+        {
+            Id = 11,
+            ServerName = "x",
+            ApiUrl = "https://x.example/",
+            ServerType = VpnServerType.Xray
+        };
+
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            sut.ProcessServerAsync(server, CancellationToken.None));
+
+        presence.Verify(p => p.MarkAllDisconnectedAsync(11, It.IsAny<CancellationToken>()), Times.Once);
+        sync.Verify(
+            s => s.SyncConnectedClientsAsync(
+                It.IsAny<VpnServer>(),
+                It.IsAny<IReadOnlyList<XrayNodeClientDto>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessServerAsync_WhenApiUrlEmpty_MarksOfflineAndDisconnects()
+    {
+        var api = new Mock<IXrayNodeApiClient>(MockBehavior.Strict);
+        var sync = new Mock<IXrayVpnClientSyncService>(MockBehavior.Strict);
+        var presence = new Mock<IVpnServerClientPresenceService>();
+        presence.Setup(p => p.MarkAllDisconnectedAsync(12, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var serverCmd = ServerCmd();
+
+        var sut = new XrayServerProcessor(
+            Mock.Of<ILogger<XrayServerProcessor>>(),
+            BuildSp(api, sync, serverCmd, presence));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ProcessServerAsync(
+                new VpnServer { Id = 12, ServerName = "x", ApiUrl = "  ", ServerType = VpnServerType.Xray },
+                CancellationToken.None));
+
+        presence.Verify(p => p.MarkAllDisconnectedAsync(12, It.IsAny<CancellationToken>()), Times.Once);
+        api.Verify(
+            a => a.GetActiveClientsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessServerAsync_OnSuccess_DoesNotClearPresence()
+    {
+        var payload = new XrayNodeClientsResponse { Clients = [] };
+        var api = new Mock<IXrayNodeApiClient>(MockBehavior.Strict);
+        api.Setup(a => a.GetActiveClientsAsync("https://x.example", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(payload);
+
+        var sync = new Mock<IXrayVpnClientSyncService>(MockBehavior.Strict);
+        sync.Setup(s => s.SyncConnectedClientsAsync(
+                It.IsAny<VpnServer>(),
+                payload.Clients,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var presence = new Mock<IVpnServerClientPresenceService>(MockBehavior.Strict);
+        var serverCmd = ServerCmd();
+        var statusLog = new Mock<IXrayVpnServerStatusLogService>();
+        statusLog.Setup(s => s.TryAppendOrUpdateAsync(
+                It.IsAny<VpnServer>(),
+                payload,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = new XrayServerProcessor(
+            Mock.Of<ILogger<XrayServerProcessor>>(),
+            BuildSp(api, sync, serverCmd, presence, statusLog));
+
+        await sut.ProcessServerAsync(
+            new VpnServer { Id = 11, ServerName = "x", ApiUrl = "https://x.example/", ServerType = VpnServerType.Xray },
+            CancellationToken.None);
+
+        sync.Verify(s => s.SyncConnectedClientsAsync(
+            It.IsAny<VpnServer>(), payload.Clients, It.IsAny<CancellationToken>()), Times.Once);
+        presence.Verify(
+            p => p.MarkAllDisconnectedAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Cache/RedisConnectedClientsCounterStoreTests.cs
+++ b/DataGateMonitor.Tests/Services/Cache/RedisConnectedClientsCounterStoreTests.cs
@@ -1,0 +1,37 @@
+using DataGateMonitor.Services.Cache;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.Cache;
+
+public class RedisConnectedClientsCounterStoreTests
+{
+    private static RedisConnectedClientsCounterStore CreateSut(IConfiguration? configuration = null) => new(
+        configuration ?? new ConfigurationBuilder().Build(),
+        Mock.Of<ILogger<RedisConnectedClientsCounterStore>>());
+
+    [Fact]
+    public async Task SetAsync_WhenVpnServerIdInvalid_DoesNotThrow()
+    {
+        var sut = CreateSut();
+        await sut.SetAsync(0, 5, CancellationToken.None);
+        await sut.SetAsync(-1, 5, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task SetAsync_WhenRedisNotConfigured_IsNoOp()
+    {
+        var sut = CreateSut();
+        await sut.SetAsync(7, 3, CancellationToken.None);
+        var map = await sut.GetManyAsync([7], CancellationToken.None);
+        Assert.Empty(map);
+    }
+
+    [Fact]
+    public async Task GetManyAsync_WhenEmptyIds_ReturnsEmpty()
+    {
+        var map = await CreateSut().GetManyAsync([], CancellationToken.None);
+        Assert.Empty(map);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Cache/RedisConnectedClientsCounterStoreTests.cs
+++ b/DataGateMonitor.Tests/Services/Cache/RedisConnectedClientsCounterStoreTests.cs
@@ -2,36 +2,236 @@ using DataGateMonitor.Services.Cache;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
+using StackExchange.Redis;
 
 namespace DataGateMonitor.Tests.Services.Cache;
 
-public class RedisConnectedClientsCounterStoreTests
+/// <summary>Redis optional: store must no-op when the database provider returns null.</summary>
+public class RedisConnectedClientsCounterStoreWithoutRedisTests
 {
-    private static RedisConnectedClientsCounterStore CreateSut(IConfiguration? configuration = null) => new(
-        configuration ?? new ConfigurationBuilder().Build(),
+    private static RedisConnectedClientsCounterStore CreateSut(IRedisDatabaseProvider provider) => new(
+        provider,
         Mock.Of<ILogger<RedisConnectedClientsCounterStore>>());
 
-    [Fact]
-    public async Task SetAsync_WhenVpnServerIdInvalid_DoesNotThrow()
+    private static IRedisDatabaseProvider UnavailableProvider()
     {
-        var sut = CreateSut();
+        var provider = new Mock<IRedisDatabaseProvider>(MockBehavior.Strict);
+        provider
+            .Setup(p => p.GetDatabaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IDatabase?)null);
+        return provider.Object;
+    }
+
+    [Fact]
+    public async Task SetAsync_WhenVpnServerIdInvalid_DoesNotTouchRedis()
+    {
+        var provider = new Mock<IRedisDatabaseProvider>(MockBehavior.Strict);
+        var sut = CreateSut(provider.Object);
+
         await sut.SetAsync(0, 5, CancellationToken.None);
         await sut.SetAsync(-1, 5, CancellationToken.None);
+
+        provider.Verify(p => p.GetDatabaseAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task SetAsync_WhenRedisNotConfigured_IsNoOp()
+    public async Task SetAsync_WhenRedisUnavailable_IsNoOp()
     {
-        var sut = CreateSut();
+        var sut = CreateSut(UnavailableProvider());
         await sut.SetAsync(7, 3, CancellationToken.None);
-        var map = await sut.GetManyAsync([7], CancellationToken.None);
-        Assert.Empty(map);
+        Assert.Empty(await sut.GetManyAsync([7], CancellationToken.None));
     }
 
     [Fact]
-    public async Task GetManyAsync_WhenEmptyIds_ReturnsEmpty()
+    public async Task GetManyAsync_WhenEmptyIds_ReturnsEmpty_WithoutCallingRedis()
     {
-        var map = await CreateSut().GetManyAsync([], CancellationToken.None);
+        var provider = new Mock<IRedisDatabaseProvider>(MockBehavior.Strict);
+        var map = await CreateSut(provider.Object).GetManyAsync([], CancellationToken.None);
         Assert.Empty(map);
+        provider.Verify(p => p.GetDatabaseAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetManyAsync_WhenRedisUnavailable_ReturnsEmpty()
+    {
+        var map = await CreateSut(UnavailableProvider()).GetManyAsync([7, 8], CancellationToken.None);
+        Assert.Empty(map);
+    }
+}
+
+/// <summary>Redis present: verify key shape, TTL, clamp, and soft-fail on Redis errors.</summary>
+public class RedisConnectedClientsCounterStoreWithRedisTests
+{
+    private static (RedisConnectedClientsCounterStore Sut, Mock<IDatabase> Db) CreateSut()
+    {
+        var db = new Mock<IDatabase>(MockBehavior.Strict);
+        var provider = new Mock<IRedisDatabaseProvider>(MockBehavior.Strict);
+        provider
+            .Setup(p => p.GetDatabaseAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(db.Object);
+
+        return (new RedisConnectedClientsCounterStore(
+            provider.Object,
+            Mock.Of<ILogger<RedisConnectedClientsCounterStore>>()), db);
+    }
+
+    private static void SetupStringSet(Mock<IDatabase> db, Action<RedisKey, RedisValue, TimeSpan?>? capture = null)
+    {
+        db.Setup(d => d.StringSetAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<When>(),
+                It.IsAny<CommandFlags>()))
+            .Callback<RedisKey, RedisValue, TimeSpan?, When, CommandFlags>((key, value, expiry, _, _) =>
+                capture?.Invoke(key, value, expiry))
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task SetAsync_WritesNonNegativeCount_WithPrefixKeyAndTtl()
+    {
+        var (sut, db) = CreateSut();
+        RedisKey? capturedKey = null;
+        RedisValue capturedValue = default;
+        TimeSpan? capturedTtl = null;
+        SetupStringSet(db, (key, value, expiry) =>
+        {
+            capturedKey = key;
+            capturedValue = value;
+            capturedTtl = expiry;
+        });
+
+        await sut.SetAsync(7, 3, CancellationToken.None);
+
+        Assert.Equal($"{RedisConnectedClientsCounterStore.KeyPrefix}7", capturedKey.ToString());
+        Assert.Equal("3", capturedValue.ToString());
+        Assert.Equal(RedisConnectedClientsCounterStore.CounterTtl, capturedTtl);
+    }
+
+    [Fact]
+    public async Task SetAsync_ClampsNegativeCountToZero()
+    {
+        var (sut, db) = CreateSut();
+        RedisValue capturedValue = default;
+        SetupStringSet(db, (_, value, _) => capturedValue = value);
+
+        await sut.SetAsync(7, -5, CancellationToken.None);
+
+        Assert.Equal("0", capturedValue.ToString());
+    }
+
+    [Fact]
+    public async Task SetAsync_WhenWriteThrows_DoesNotPropagate()
+    {
+        var (sut, db) = CreateSut();
+        db.Setup(d => d.StringSetAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<RedisValue>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<When>(),
+                It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "down"));
+
+        await sut.SetAsync(7, 1, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task GetManyAsync_ReturnsParsedCounts_SkipsMissingAndGarbage()
+    {
+        var (sut, db) = CreateSut();
+        db.Setup(d => d.StringGetAsync(It.IsAny<RedisKey[]>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(new RedisValue[] { "3", RedisValue.Null, "bad", "-2" });
+
+        var map = await sut.GetManyAsync([7, 8, 9, 10], CancellationToken.None);
+
+        Assert.Equal(2, map.Count);
+        Assert.Equal(3, map[7]);
+        Assert.Equal(0, map[10]);
+        Assert.False(map.ContainsKey(8));
+        Assert.False(map.ContainsKey(9));
+    }
+
+    [Fact]
+    public async Task GetManyAsync_WhenReadThrows_ReturnsEmpty()
+    {
+        var (sut, db) = CreateSut();
+        db.Setup(d => d.StringGetAsync(It.IsAny<RedisKey[]>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "down"));
+
+        Assert.Empty(await sut.GetManyAsync([7], CancellationToken.None));
+    }
+}
+
+public class ConfigurationRedisDatabaseProviderTests
+{
+    private static IConfiguration ConfigWithRedis(string? connectionString)
+    {
+        var dict = new Dictionary<string, string?>();
+        if (connectionString is not null)
+            dict["ConnectionStrings:Redis"] = connectionString;
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+
+    [Fact]
+    public async Task GetDatabaseAsync_WhenNotConfigured_ReturnsNull_WithoutConnecting()
+    {
+        var connector = new Mock<IRedisMultiplexerConnector>(MockBehavior.Strict);
+        var sut = new ConfigurationRedisDatabaseProvider(
+            ConfigWithRedis(null),
+            Mock.Of<ILogger<ConfigurationRedisDatabaseProvider>>(),
+            connector.Object);
+
+        Assert.Null(await sut.GetDatabaseAsync(CancellationToken.None));
+        connector.Verify(
+            c => c.ConnectAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetDatabaseAsync_WhenConnectFails_ReturnsNull_AndDoesNotRetry()
+    {
+        var calls = 0;
+        var connector = new Mock<IRedisMultiplexerConnector>(MockBehavior.Strict);
+        connector
+            .Setup(c => c.ConnectAsync("localhost:6379", It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                calls++;
+                return Task.FromException<IConnectionMultiplexer>(
+                    new RedisConnectionException(ConnectionFailureType.UnableToConnect, "down"));
+            });
+
+        var sut = new ConfigurationRedisDatabaseProvider(
+            ConfigWithRedis("localhost:6379"),
+            Mock.Of<ILogger<ConfigurationRedisDatabaseProvider>>(),
+            connector.Object);
+
+        Assert.Null(await sut.GetDatabaseAsync(CancellationToken.None));
+        Assert.Null(await sut.GetDatabaseAsync(CancellationToken.None));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task GetDatabaseAsync_WhenConnected_ReturnsDatabase()
+    {
+        var db = Mock.Of<IDatabase>();
+        var mux = new Mock<IConnectionMultiplexer>(MockBehavior.Strict);
+        mux.SetupGet(m => m.IsConnected).Returns(true);
+        mux.Setup(m => m.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(db);
+
+        var connector = new Mock<IRedisMultiplexerConnector>(MockBehavior.Strict);
+        connector
+            .Setup(c => c.ConnectAsync("localhost:6379", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mux.Object);
+
+        var sut = new ConfigurationRedisDatabaseProvider(
+            ConfigWithRedis("localhost:6379"),
+            Mock.Of<ILogger<ConfigurationRedisDatabaseProvider>>(),
+            connector.Object);
+
+        Assert.Same(db, await sut.GetDatabaseAsync(CancellationToken.None));
+        Assert.Same(db, await sut.GetDatabaseAsync(CancellationToken.None));
+        connector.Verify(c => c.ConnectAsync("localhost:6379", It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/DataGateMonitor.Tests/Services/Cache/VpnServerConnectedCountOverlayTests.cs
+++ b/DataGateMonitor.Tests/Services/Cache/VpnServerConnectedCountOverlayTests.cs
@@ -1,0 +1,75 @@
+using Moq;
+using DataGateMonitor.Services.Cache;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Responses;
+
+namespace DataGateMonitor.Tests.Services.Cache;
+
+public class VpnServerConnectedCountOverlayTests
+{
+    [Fact]
+    public async Task ApplyAsync_V1_Overwrites_Connected_Counts_From_Redis()
+    {
+        var store = new Mock<IConnectedClientsCounterStore>(MockBehavior.Strict);
+        store.Setup(s => s.GetManyAsync(It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int> { [5] = 42, [7] = 0 });
+
+        var items = new List<VpnServerWithStatusDto>
+        {
+            new()
+            {
+                VpnServerResponses = new VpnServerResponse
+                {
+                    VpnServer = new VpnServerDto { Id = 5, ServerName = "a" }
+                },
+                CountConnectedClients = 1
+            },
+            new()
+            {
+                VpnServerResponses = new VpnServerResponse
+                {
+                    VpnServer = new VpnServerDto { Id = 7, ServerName = "b" }
+                },
+                CountConnectedClients = 9
+            },
+            new()
+            {
+                VpnServerResponses = new VpnServerResponse
+                {
+                    VpnServer = new VpnServerDto { Id = 9, ServerName = "c" }
+                },
+                CountConnectedClients = 3
+            }
+        };
+
+        await VpnServerConnectedCountOverlay.ApplyAsync(items, store.Object);
+
+        Assert.Equal(42, items[0].CountConnectedClients);
+        Assert.Equal(0, items[1].CountConnectedClients);
+        Assert.Equal(3, items[2].CountConnectedClients); // unchanged when Redis miss
+        store.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ApplyAsync_Empty_Or_Null_Map_Is_NoOp()
+    {
+        var store = new Mock<IConnectedClientsCounterStore>();
+        store.Setup(s => s.GetManyAsync(It.IsAny<IEnumerable<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Dictionary<int, int>?)null!);
+
+        var items = new List<VpnServerWithStatusV2Dto>
+        {
+            new()
+            {
+                VpnServerResponses = new VpnServerV2Response
+                {
+                    VpnServer = new VpnServerV2Dto { Id = 1, ServerName = "x" }
+                },
+                CountConnectedClients = 5
+            }
+        };
+
+        await VpnServerConnectedCountOverlay.ApplyAsync(items, store.Object);
+        Assert.Equal(5, items[0].CountConnectedClients);
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/MicroserviceInfoServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/MicroserviceInfoServiceTests.cs
@@ -1,0 +1,53 @@
+using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
+using DataGateMonitor.Services.DataGateOpenVpnManager;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.DataGateOpenVpnManager;
+
+public class MicroserviceInfoServiceTests
+{
+    [Fact]
+    public async Task GetInfoAsync_WhenServerMissing_Throws()
+    {
+        var query = new Mock<IVpnServerQueryService>();
+        query.Setup(q => q.GetById(9, It.IsAny<CancellationToken>())).ReturnsAsync((VpnServer?)null);
+
+        var sut = new MicroserviceInfoService(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IMicroserviceTokenService>(),
+            query.Object,
+            NullLogger<MicroserviceInfoService>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetInfoAsync(9, CancellationToken.None));
+        Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetInfoAsync_WhenApiUrlMissing_Throws()
+    {
+        var query = new Mock<IVpnServerQueryService>();
+        query.Setup(q => q.GetById(3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServer
+            {
+                Id = 3,
+                ServerName = "x",
+                ApiUrl = "  ",
+                ServerType = VpnServerType.OpenVpn
+            });
+
+        var sut = new MicroserviceInfoService(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IMicroserviceTokenService>(),
+            query.Object,
+            NullLogger<MicroserviceInfoService>.Instance);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.GetInfoAsync(3, CancellationToken.None));
+        Assert.Contains("API URL", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OvpnFileApiServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OvpnFileApiServiceTests.cs
@@ -16,6 +16,8 @@ using DataGateMonitor.Models;
 using DataGateMonitor.Services.DataGateOpenVpnManager;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.OvpnFileApi;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Services.VpnAccess;
 using DataGateMonitor.SharedModels.Auth;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Requests;
@@ -478,6 +480,7 @@ public class OvpnFileApiServiceTests
         Mock<IUserIdentityLinkQueryService>? identityLinkQuery = null,
         Mock<IUserQuotaPlanQueryService>? userQuotaPlanQuery = null,
         Mock<IQuotaPlanAllowedServerQueryService>? quotaPlanAllowedServerQuery = null,
+        Mock<IUserQueryService>? userQuery = null,
         Mock<IVpnServerOvpnFileConfigQueryService>? configQuery = null,
         Mock<ICommandService<IssuedOvpnFile, int>>? fileCommand = null)
     {
@@ -495,6 +498,13 @@ public class OvpnFileApiServiceTests
         identityLinkQuery ??= new Mock<IUserIdentityLinkQueryService>(MockBehavior.Loose);
         userQuotaPlanQuery ??= new Mock<IUserQuotaPlanQueryService>(MockBehavior.Loose);
         quotaPlanAllowedServerQuery ??= new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Loose);
+        userQuery ??= new Mock<IUserQueryService>(MockBehavior.Loose);
+
+        IVpnServerQuotaPlanAccessGuard accessGuard = new VpnServerQuotaPlanAccessGuard(
+            identityLinkQuery.Object,
+            userQuotaPlanQuery.Object,
+            quotaPlanAllowedServerQuery.Object,
+            userQuery.Object);
 
         return new OvpnFileApiService(
             ovpnClient.Object,
@@ -504,8 +514,7 @@ public class OvpnFileApiServiceTests
             fileQuery.Object,
             tokenQuery.Object,
             identityLinkQuery.Object,
-            userQuotaPlanQuery.Object,
-            quotaPlanAllowedServerQuery.Object,
+            accessGuard,
             fileCommand.Object,
             tokenCommand.Object,
             serverQuery.Object,

--- a/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OvpnFileApiServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateOpenVpnManager/OvpnFileApiServiceTests.cs
@@ -332,7 +332,7 @@ public class OvpnFileApiServiceTests
         }, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*not allowed*active quota plan*");
+            .WithMessage("VpnServerNotAllowedByQuotaPlan");
         ovpnClient.Verify(c => c.AddOvpnFile(It.IsAny<int>(), It.IsAny<GenerateOvpnFileRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         fileCommand.Verify(c => c.Add(It.IsAny<IssuedOvpnFile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/DataGateMonitor.Tests/Services/DataGateXRayManager/ClientLinks/XrayClientLinkServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateXRayManager/ClientLinks/XrayClientLinkServiceTests.cs
@@ -13,6 +13,8 @@ using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.DataGateXRayManager.ClientLinks;
 using DataGateMonitor.Services.Others.Notifications.OvpnFileApi;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Services.VpnAccess;
 using DataGateMonitor.SharedModels.Auth;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
 using DataGateMonitor.SharedModels.Enums;
@@ -319,7 +321,8 @@ public class XrayClientLinkServiceTests
         Mock<IOvpnFileNotificationService>? notification = null,
         Mock<IUserIdentityLinkQueryService>? identityLinkQuery = null,
         Mock<IUserQuotaPlanQueryService>? userQuotaPlanQuery = null,
-        Mock<IQuotaPlanAllowedServerQueryService>? quotaPlanAllowedServerQuery = null)
+        Mock<IQuotaPlanAllowedServerQueryService>? quotaPlanAllowedServerQuery = null,
+        Mock<IUserQueryService>? userQuery = null)
     {
         microserviceClient ??= new Mock<IXrayClientLinkMicroserviceClient>(MockBehavior.Loose);
         var logger = Mock.Of<ILogger<XrayClientLinkService>>();
@@ -334,6 +337,13 @@ public class XrayClientLinkServiceTests
         identityLinkQuery ??= new Mock<IUserIdentityLinkQueryService>(MockBehavior.Loose);
         userQuotaPlanQuery ??= new Mock<IUserQuotaPlanQueryService>(MockBehavior.Loose);
         quotaPlanAllowedServerQuery ??= new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Loose);
+        userQuery ??= new Mock<IUserQueryService>(MockBehavior.Loose);
+
+        IVpnServerQuotaPlanAccessGuard accessGuard = new VpnServerQuotaPlanAccessGuard(
+            identityLinkQuery.Object,
+            userQuotaPlanQuery.Object,
+            quotaPlanAllowedServerQuery.Object,
+            userQuery.Object);
 
         return new XrayClientLinkService(
             microserviceClient.Object,
@@ -343,8 +353,7 @@ public class XrayClientLinkServiceTests
             linkQuery.Object,
             tokenQuery.Object,
             identityLinkQuery.Object,
-            userQuotaPlanQuery.Object,
-            quotaPlanAllowedServerQuery.Object,
+            accessGuard,
             linkCommand.Object,
             tokenCommand.Object,
             serverQuery.Object,

--- a/DataGateMonitor.Tests/Services/DataGateXRayManager/ClientLinks/XrayClientLinkServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/DataGateXRayManager/ClientLinks/XrayClientLinkServiceTests.cs
@@ -276,7 +276,7 @@ public class XrayClientLinkServiceTests
         }, CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*not allowed*active quota plan*");
+            .WithMessage("VpnServerNotAllowedByQuotaPlan");
         microserviceClient.Verify(c => c.AddClientLink(It.IsAny<int>(), It.IsAny<GenerateClientLinkMicroserviceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
         linkCommand.Verify(c => c.Add(It.IsAny<IssuedXrayClientLink>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/DataGateMonitor.Tests/Services/Helpers/ExternalIpAddressServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Helpers/ExternalIpAddressServiceTests.cs
@@ -130,6 +130,50 @@ public class ExternalIpAddressServiceTests
         Assert.Equal("127.0.0.1", result);
     }
 
+    [Fact]
+    public async Task GetRemoteIpAddress_WhenHtmlReturned_UsesNextService()
+    {
+        const string url1 = "https://service1.test/ip";
+        const string url2 = "https://service2.test/ip";
+
+        var config = BuildConfigWithServices(url1, url2);
+        var handler = new FakeHttpMessageHandler((request, _) =>
+        {
+            var body = request.RequestUri!.ToString() == url1
+                ? "<html>error</html>"
+                : "203.0.113.55";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            });
+        });
+
+        var result = await new ExternalIpAddressService(_logger.Object, config, new HttpClient(handler))
+            .GetRemoteIpAddress(CancellationToken.None);
+
+        Assert.Equal("203.0.113.55", result);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("0.0.0.0")]
+    [InlineData("::1")]
+    [InlineData("<html>nope</html>")]
+    [InlineData("not-an-ip")]
+    public void TryParsePublicIp_RejectsInvalid(string raw)
+    {
+        Assert.False(ExternalIpAddressService.TryParsePublicIp(raw, out _));
+    }
+
+    [Theory]
+    [InlineData("203.0.113.10", "203.0.113.10")]
+    [InlineData("  198.51.100.1 \n", "198.51.100.1")]
+    public void TryParsePublicIp_AcceptsPublicIpv4(string raw, string expected)
+    {
+        Assert.True(ExternalIpAddressService.TryParsePublicIp(raw, out var ip));
+        Assert.Equal(expected, ip);
+    }
+
     // Simple fake handler to control HttpClient responses in tests
     private sealed class FakeHttpMessageHandler : HttpMessageHandler
     {

--- a/DataGateMonitor.Tests/Services/Helpers/VpnNodePublicIpLookupTests.cs
+++ b/DataGateMonitor.Tests/Services/Helpers/VpnNodePublicIpLookupTests.cs
@@ -1,0 +1,136 @@
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Helpers;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+using DataGateMonitor.SharedModels.DataGateOpenVpnManager.Info;
+using DataGateMonitor.SharedModels.DataGateXRayManager.Info;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.Helpers;
+
+public class VpnNodePublicIpLookupTests
+{
+    private readonly Mock<IMicroserviceInfoService> _info = new();
+    private readonly Mock<ILogger<VpnNodePublicIpLookup>> _logger = new();
+
+    private VpnNodePublicIpLookup CreateSut(IMemoryCache? cache = null) => new(
+        _info.Object,
+        cache ?? new MemoryCache(new MemoryCacheOptions()),
+        _logger.Object);
+
+    [Fact]
+    public async Task GetAsync_ReturnsOpenVpnPublicIp_AndCaches()
+    {
+        var calls = 0;
+        _info.Setup(i => i.GetInfoAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                calls++;
+                return new VpnMicroserviceDiagnosticsDto
+                {
+                    OpenVpn = new RootOpenVpnInfoResponse { PublicIp = "198.51.100.10" }
+                };
+            });
+
+        var sut = CreateSut();
+        Assert.Equal("198.51.100.10", await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        Assert.Equal("198.51.100.10", await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsXrayPublicIp()
+    {
+        _info.Setup(i => i.GetInfoAsync(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                Xray = new RootXrayInfoResponse { PublicIp = "203.0.113.5" }
+            });
+
+        Assert.Equal("203.0.113.5",
+            await CreateSut().GetAsync(11, VpnServerType.Xray, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenInfoFails_CachesNegative_AndDoesNotRetryImmediately()
+    {
+        var calls = 0;
+        _info.Setup(i => i.GetInfoAsync(7, It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                calls++;
+                return Task.FromException<VpnMicroserviceDiagnosticsDto>(new HttpRequestException("down"));
+            });
+
+        var sut = CreateSut();
+        Assert.Null(await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        Assert.Null(await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task GetAsync_WhenPublicIpMissing_CachesEmpty()
+    {
+        var calls = 0;
+        _info.Setup(i => i.GetInfoAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                calls++;
+                return new VpnMicroserviceDiagnosticsDto { OpenVpn = new RootOpenVpnInfoResponse() };
+            });
+
+        var sut = CreateSut();
+        Assert.Null(await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        Assert.Null(await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task Invalidate_ClearsCache_SoNextCallRefetches()
+    {
+        var calls = 0;
+        _info.Setup(i => i.GetInfoAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                calls++;
+                return new VpnMicroserviceDiagnosticsDto
+                {
+                    OpenVpn = new RootOpenVpnInfoResponse { PublicIp = $"203.0.113.{calls}" }
+                };
+            });
+
+        var sut = CreateSut();
+        Assert.Equal("203.0.113.1", await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        sut.Invalidate(7);
+        Assert.Equal("203.0.113.2", await sut.GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task GetAsync_TrimsPublicIpWhitespace()
+    {
+        _info.Setup(i => i.GetInfoAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                OpenVpn = new RootOpenVpnInfoResponse { PublicIp = "  203.0.113.8 \n" }
+            });
+
+        Assert.Equal("203.0.113.8",
+            await CreateSut().GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetAsync_OpenVpnLookup_DoesNotReadXrayPublicIp()
+    {
+        _info.Setup(i => i.GetInfoAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnMicroserviceDiagnosticsDto
+            {
+                Xray = new RootXrayInfoResponse { PublicIp = "203.0.113.1" },
+                OpenVpn = new RootOpenVpnInfoResponse { PublicIp = null }
+            });
+
+        Assert.Null(await CreateSut().GetAsync(7, VpnServerType.OpenVpn, CancellationToken.None));
+    }
+}

--- a/DataGateMonitor.Tests/Services/Helpers/VpnServerApiUrlHelperTests.cs
+++ b/DataGateMonitor.Tests/Services/Helpers/VpnServerApiUrlHelperTests.cs
@@ -82,6 +82,17 @@ public class VpnServerApiUrlHelperTests
     }
 
     [Fact]
+    public void ResolveReportedRemoteIp_AcceptsPublicIpv6()
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp: "2001:db8::1",
+            configVpnServerIp: "1.2.3.4",
+            apiUrl: "https://s5.datagateapp.com/");
+
+        Assert.Equal("2001:db8::1", result);
+    }
+
+    [Fact]
     public void ResolveReportedRemoteIp_WhenNothingUsable_ReturnsEmpty()
     {
         var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(null, null, "not-a-url");

--- a/DataGateMonitor.Tests/Services/Helpers/VpnServerApiUrlHelperTests.cs
+++ b/DataGateMonitor.Tests/Services/Helpers/VpnServerApiUrlHelperTests.cs
@@ -1,0 +1,114 @@
+using DataGateMonitor.Services.Helpers;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Services.Helpers;
+
+public class VpnServerApiUrlHelperTests
+{
+    [Fact]
+    public void ResolveReportedRemoteIp_PrefersNodePublicIp()
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp: "212.147.232.154",
+            configVpnServerIp: "10.0.0.1",
+            apiUrl: "https://s5.datagateapp.com/");
+
+        Assert.Equal("212.147.232.154", result);
+    }
+
+    [Fact]
+    public void ResolveReportedRemoteIp_FallsBackToConfigIp()
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp: null,
+            configVpnServerIp: "212.147.232.154",
+            apiUrl: "https://s5.datagateapp.com/");
+
+        Assert.Equal("212.147.232.154", result);
+    }
+
+    [Fact]
+    public void ResolveReportedRemoteIp_FallsBackToApiUrlHost()
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp: " ",
+            configVpnServerIp: null,
+            apiUrl: "https://s5.datagateapp.com/");
+
+        Assert.Equal("s5.datagateapp.com", result);
+    }
+
+    [Theory]
+    [InlineData("0.0.0.0")]
+    [InlineData("::")]
+    [InlineData("-")]
+    [InlineData("N/A")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("127.0.0.1")]
+    [InlineData("::1")]
+    public void ResolveReportedRemoteIp_IgnoresUnusableNodePublicIp(string bad)
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp: bad,
+            configVpnServerIp: "164.215.15.224",
+            apiUrl: "http://example.test:5010/");
+
+        Assert.Equal("164.215.15.224", result);
+    }
+
+    [Fact]
+    public void ResolveReportedRemoteIp_IgnoresUnusableConfig_UsesApiUrl()
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp: null,
+            configVpnServerIp: "0.0.0.0",
+            apiUrl: "http://164.215.15.224:5010/");
+
+        Assert.Equal("164.215.15.224", result);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("::1")]
+    public void ResolveReportedRemoteIp_IgnoresLoopbackConfig_UsesApiUrlHost(string loopback)
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp: null,
+            configVpnServerIp: loopback,
+            apiUrl: "https://s5.datagateapp.com/");
+
+        Assert.Equal("s5.datagateapp.com", result);
+    }
+
+    [Fact]
+    public void ResolveReportedRemoteIp_WhenNothingUsable_ReturnsEmpty()
+    {
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(null, null, "not-a-url");
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void TryHostFromApiUrl_ParsesAbsoluteHttpUrl()
+    {
+        Assert.Equal("s5.datagateapp.com", VpnServerApiUrlHelper.TryHostFromApiUrl("https://s5.datagateapp.com/"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("relative/path")]
+    public void TryHostFromApiUrl_RejectsInvalid(string? url)
+    {
+        Assert.Null(VpnServerApiUrlHelper.TryHostFromApiUrl(url));
+    }
+
+    [Fact]
+    public void ResolveReportedRemoteIp_TruncatesLongValues()
+    {
+        var longIp = new string('1', 300);
+        var result = VpnServerApiUrlHelper.ResolveReportedRemoteIp(longIp, null, null);
+        Assert.Equal(255, result.Length);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Helpers/VpnServerClientPresenceServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Helpers/VpnServerClientPresenceServiceTests.cs
@@ -1,0 +1,62 @@
+using System.Linq.Expressions;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Cache;
+using DataGateMonitor.Services.Helpers;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.Helpers;
+
+public class VpnServerClientPresenceServiceTests
+{
+    private readonly Mock<ICommandService<VpnServerClient, int>> _clientCmd = new();
+    private readonly Mock<IConnectedClientsCounterStore> _counter = new();
+    private readonly Mock<ILogger<VpnServerClientPresenceService>> _logger = new();
+
+    private VpnServerClientPresenceService CreateSut() => new(
+        _clientCmd.Object,
+        _counter.Object,
+        _logger.Object);
+
+    [Fact]
+    public async Task MarkAllDisconnectedAsync_UpdatesConnectedSessions_AndZerosRedis()
+    {
+        Expression<Func<VpnServerClient, bool>>? capturedPredicate = null;
+        _clientCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Expression<Func<VpnServerClient, bool>>, Action<UpdateSettersBuilder<VpnServerClient>>, CancellationToken>(
+                (pred, _, _) => capturedPredicate = pred)
+            .ReturnsAsync(3);
+        _counter.Setup(c => c.SetAsync(42, 0, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        await CreateSut().MarkAllDisconnectedAsync(42, CancellationToken.None);
+
+        Assert.NotNull(capturedPredicate);
+        var compiled = capturedPredicate!.Compile();
+        Assert.True(compiled(new VpnServerClient { VpnServerId = 42, IsConnected = true }));
+        Assert.False(compiled(new VpnServerClient { VpnServerId = 42, IsConnected = false }));
+        Assert.False(compiled(new VpnServerClient { VpnServerId = 99, IsConnected = true }));
+        _counter.Verify(c => c.SetAsync(42, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkAllDisconnectedAsync_WhenNoConnectedRows_StillZerosRedis()
+    {
+        _clientCmd
+            .Setup(c => c.UpdateWhere(
+                It.IsAny<Expression<Func<VpnServerClient, bool>>>(),
+                It.IsAny<Action<UpdateSettersBuilder<VpnServerClient>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        _counter.Setup(c => c.SetAsync(55, 0, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+
+        await CreateSut().MarkAllDisconnectedAsync(55, CancellationToken.None);
+
+        _counter.Verify(c => c.SetAsync(55, 0, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Helpers/VpnSessionIdGeneratorTests.cs
+++ b/DataGateMonitor.Tests/Services/Helpers/VpnSessionIdGeneratorTests.cs
@@ -5,27 +5,21 @@ namespace DataGateMonitor.Tests.Services.Helpers;
 public class VpnSessionIdGeneratorTests
 {
     [Fact]
-    public void FromCommonNameRemoteConnectedSince_LoopbackLegacyAndOpenVpn27Canonical_Match()
+    public void FromCommonNameRemoteConnectedSince_IsDeterministic()
     {
-        var since = new DateTimeOffset(2026, 6, 30, 10, 42, 50, TimeSpan.Zero);
-        const string cn = "adg-75-test";
-
-        var legacy = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(cn, "127.0.0.1:53188", since);
-        var openVpn27 = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(cn, "tcp4-server:127.0.0.1:53188", since);
-
-        Assert.Equal(legacy, openVpn27);
-        Assert.NotEqual(Guid.Empty, legacy);
+        var since = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        var a = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince("cn", "1.2.3.4:1194", since);
+        var b = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince("cn", "1.2.3.4:1194", since);
+        Assert.Equal(a, b);
     }
 
     [Fact]
-    public void FromCommonNameRemoteConnectedSince_DifferentRemoteIp_ProducesDifferentSessionId()
+    public void FromCommonNameRemoteConnectedSince_ChangesWithConnectedSince()
     {
-        var since = new DateTimeOffset(2026, 6, 30, 10, 42, 50, TimeSpan.Zero);
-        const string cn = "adg-75-test";
-
-        var a = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(cn, "127.0.0.1:53188", since);
-        var b = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(cn, "127.0.0.1:53189", since);
-
+        var a = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(
+            "cn", "1.2.3.4", new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var b = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(
+            "cn", "1.2.3.4", new DateTimeOffset(2024, 1, 1, 0, 0, 1, TimeSpan.Zero));
         Assert.NotEqual(a, b);
     }
 }

--- a/DataGateMonitor.Tests/Services/Performance/PerformanceSampleStoreTests.cs
+++ b/DataGateMonitor.Tests/Services/Performance/PerformanceSampleStoreTests.cs
@@ -1,0 +1,76 @@
+using DataGateMonitor.Services.Performance;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DataGateMonitor.Tests.Services.Performance;
+
+public class PerformanceSampleStoreTests
+{
+    private static PerformanceSampleStore CreateStore(int maxEntries = 5) =>
+        new(
+            new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PerformanceMonitoring:MaxEntries"] = maxEntries.ToString()
+            }).Build(),
+            Options.Create(new PerformanceMonitoringOptions { MaxEntries = maxEntries }),
+            NullLogger<PerformanceSampleStore>.Instance);
+
+    [Fact]
+    public async Task AppendHttp_ThenGetLatest_ReturnsNewestFirst_AndTrims()
+    {
+        var store = CreateStore(maxEntries: 3);
+
+        for (var i = 1; i <= 5; i++)
+        {
+            await store.AppendHttpAsync(new PerformanceHttpSample
+            {
+                RequestId = $"r{i}",
+                Method = "GET",
+                Path = $"/api/x/{i}",
+                StatusCode = 200,
+                DurationMs = 100 + i
+            });
+        }
+
+        var latest = await store.GetHttpLatestAsync(10);
+        Assert.Equal(3, latest.Count);
+        Assert.Equal("r5", latest[0].RequestId);
+        Assert.Equal("r4", latest[1].RequestId);
+        Assert.Equal("r3", latest[2].RequestId);
+    }
+
+    [Fact]
+    public async Task AppendDb_AndClear_WorksIndependentlyOfHttp()
+    {
+        var store = CreateStore();
+
+        await store.AppendHttpAsync(new PerformanceHttpSample
+        {
+            RequestId = "h1",
+            Method = "GET",
+            Path = "/api/a",
+            StatusCode = 200,
+            DurationMs = 300
+        });
+        await store.AppendDbAsync(new PerformanceDbSample
+        {
+            RequestId = "h1",
+            DurationMs = 150,
+            CommandType = "Text",
+            Sql = "SELECT 1",
+            Succeeded = true
+        });
+
+        Assert.Single(await store.GetHttpLatestAsync(10));
+        Assert.Single(await store.GetDbLatestAsync(10));
+
+        await store.ClearDbAsync();
+        Assert.Single(await store.GetHttpLatestAsync(10));
+        Assert.Empty(await store.GetDbLatestAsync(10));
+
+        await store.ClearAllAsync();
+        Assert.Empty(await store.GetHttpLatestAsync(10));
+    }
+}

--- a/DataGateMonitor.Tests/Services/Performance/PerformanceSampleStoreTests.cs
+++ b/DataGateMonitor.Tests/Services/Performance/PerformanceSampleStoreTests.cs
@@ -42,6 +42,58 @@ public class PerformanceSampleStoreTests
     }
 
     [Fact]
+    public async Task GetLatest_Clamps_Limit_To_MaxEntries()
+    {
+        var store = CreateStore(maxEntries: 2);
+        await store.AppendHttpAsync(new PerformanceHttpSample
+        {
+            RequestId = "a",
+            Method = "GET",
+            Path = "/api/a",
+            StatusCode = 200,
+            DurationMs = 300
+        });
+        await store.AppendHttpAsync(new PerformanceHttpSample
+        {
+            RequestId = "b",
+            Method = "GET",
+            Path = "/api/b",
+            StatusCode = 200,
+            DurationMs = 300
+        });
+
+        var latest = await store.GetHttpLatestAsync(10_000);
+        Assert.Equal(2, latest.Count);
+    }
+
+    [Fact]
+    public async Task ClearHttp_Leaves_Db_Samples()
+    {
+        var store = CreateStore();
+
+        await store.AppendHttpAsync(new PerformanceHttpSample
+        {
+            RequestId = "h1",
+            Method = "GET",
+            Path = "/api/a",
+            StatusCode = 200,
+            DurationMs = 300
+        });
+        await store.AppendDbAsync(new PerformanceDbSample
+        {
+            RequestId = "h1",
+            DurationMs = 150,
+            CommandType = "Text",
+            Sql = "SELECT 1",
+            Succeeded = true
+        });
+
+        await store.ClearHttpAsync();
+        Assert.Empty(await store.GetHttpLatestAsync(10));
+        Assert.Single(await store.GetDbLatestAsync(10));
+    }
+
+    [Fact]
     public async Task AppendDb_AndClear_WorksIndependentlyOfHttp()
     {
         var store = CreateStore();
@@ -72,5 +124,26 @@ public class PerformanceSampleStoreTests
 
         await store.ClearAllAsync();
         Assert.Empty(await store.GetHttpLatestAsync(10));
+    }
+
+    [Fact]
+    public async Task Concurrent_Appends_Do_Not_Throw_And_Respect_Cap()
+    {
+        var store = CreateStore(maxEntries: 20);
+        var tasks = Enumerable.Range(0, 100).Select(i =>
+            store.AppendHttpAsync(new PerformanceHttpSample
+            {
+                RequestId = $"c{i}",
+                Method = "GET",
+                Path = $"/api/c/{i}",
+                StatusCode = 200,
+                DurationMs = 200 + i
+            }));
+
+        var ex = await Record.ExceptionAsync(() => Task.WhenAll(tasks));
+        Assert.Null(ex);
+
+        var latest = await store.GetHttpLatestAsync(100);
+        Assert.Equal(20, latest.Count);
     }
 }

--- a/DataGateMonitor.Tests/Services/TelegramBot/TelegramAdminAlertServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/TelegramBot/TelegramAdminAlertServiceTests.cs
@@ -1,0 +1,32 @@
+using DataGateMonitor.Services.TelegramBot;
+using DataGateMonitor.Services.TelegramBot.Interfaces;
+
+namespace DataGateMonitor.Tests.Services.TelegramBot;
+
+public class TelegramAdminAlertServiceTests
+{
+    [Fact]
+    public void BuildAccountsLinkedCaption_IncludesTelegramAndLinkedDetails()
+    {
+        var text = TelegramAdminAlertService.BuildAccountsLinkedCaption(new TelegramAccountsLinkedAlert
+        {
+            TelegramId = 1067153884,
+            TelegramUsername = "TATYANA_VI",
+            TelegramDisplayName = "Tatyana",
+            LinkedProviderLabel = "Google",
+            LinkedDisplayName = "Tatyana Google",
+            LinkedEmail = "tatyana@gmail.com",
+            LinkedExternalId = "google-sub",
+            SurvivorUserId = 10,
+            MergedUserId = 20,
+        });
+
+        Assert.Contains("Accounts linked", text);
+        Assert.Contains("1067153884", text);
+        Assert.Contains("@TATYANA_VI", text);
+        Assert.Contains("Google", text);
+        Assert.Contains("tatyana@gmail.com", text);
+        Assert.Contains("Survivor user #: 10", text);
+        Assert.Contains("Merged user #: 20", text);
+    }
+}

--- a/DataGateMonitor.Tests/Services/TelegramBot/TelegramChannelMembershipCheckerTests.cs
+++ b/DataGateMonitor.Tests/Services/TelegramBot/TelegramChannelMembershipCheckerTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.TelegramBot;
+
+namespace DataGateMonitor.Tests.Services.TelegramBot;
+
+public class TelegramChannelMembershipCheckerTests
+{
+    private readonly Mock<IHttpClientFactory> _httpClientFactory = new();
+    private readonly Mock<ILogger<TelegramChannelMembershipChecker>> _logger = new();
+
+    private TelegramChannelMembershipChecker CreateSut(string? botToken = "test-token")
+        => new(
+            _httpClientFactory.Object,
+            Options.Create(new TelegramChannelSettings
+            {
+                BotToken = botToken,
+                RequiredChannelUsername = "datagateapp",
+            }),
+            _logger.Object);
+
+    private void SetupHttpClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+    {
+        var client = new HttpClient(new FakeHttpMessageHandler(handler));
+        _httpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+    }
+
+    [Theory]
+    [InlineData("Bad Request: PARTICIPANT_ID_INVALID", true)]
+    [InlineData("Bad Request: user not found", true)]
+    [InlineData("Bad Request: member not found", true)]
+    [InlineData("Forbidden: bot is not a member of the channel chat", false)]
+    [InlineData("Unauthorized", false)]
+    public void IsExpectedNonMembershipDescription_ClassifiesTelegramErrors(string description, bool expected)
+        => Assert.Equal(expected, TelegramChannelMembershipChecker.IsExpectedNonMembershipDescription(description));
+
+    [Fact]
+    public async Task IsSubscribedAsync_WhenParticipantIdInvalid_ReturnsFalseAndLogsDebug()
+    {
+        SetupHttpClient(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("""{"ok":false,"description":"Bad Request: PARTICIPANT_ID_INVALID"}"""),
+        }));
+
+        var sut = CreateSut();
+        var result = await sut.IsSubscribedAsync(7848353335, CancellationToken.None);
+
+        Assert.False(result);
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Debug,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("not a member", StringComparison.Ordinal)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task IsSubscribedAsync_WhenBotForbidden_ReturnsFalseAndLogsWarning()
+    {
+        SetupHttpClient(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent(
+                """{"ok":false,"description":"Forbidden: bot is not a member of the channel chat"}"""),
+        }));
+
+        var sut = CreateSut();
+        var result = await sut.IsSubscribedAsync(123, CancellationToken.None);
+
+        Assert.False(result);
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("getChatMember failed", StringComparison.Ordinal)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task IsSubscribedAsync_WhenMember_ReturnsTrue()
+    {
+        SetupHttpClient(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true,"result":{"status":"member"}}"""),
+        }));
+
+        var sut = CreateSut();
+        var result = await sut.IsSubscribedAsync(123, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request);
+    }
+}

--- a/DataGateMonitor.Tests/Services/TelegramBot/TelegramChannelMembershipCheckerTests.cs
+++ b/DataGateMonitor.Tests/Services/TelegramBot/TelegramChannelMembershipCheckerTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -11,6 +12,7 @@ public class TelegramChannelMembershipCheckerTests
 {
     private readonly Mock<IHttpClientFactory> _httpClientFactory = new();
     private readonly Mock<ILogger<TelegramChannelMembershipChecker>> _logger = new();
+    private readonly IMemoryCache _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
     private TelegramChannelMembershipChecker CreateSut(string? botToken = "test-token")
         => new(
@@ -20,6 +22,7 @@ public class TelegramChannelMembershipCheckerTests
                 BotToken = botToken,
                 RequiredChannelUsername = "datagateapp",
             }),
+            _memoryCache,
             _logger.Object);
 
     private void SetupHttpClient(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)

--- a/DataGateMonitor.Tests/Services/TelegramBot/TelegramDirectMessageSenderTests.cs
+++ b/DataGateMonitor.Tests/Services/TelegramBot/TelegramDirectMessageSenderTests.cs
@@ -74,6 +74,42 @@ public class TelegramDirectMessageSenderTests
     }
 
     [Fact]
+    public async Task TrySendPhotoAsync_WhenPhotoMissing_FallsBackToText()
+    {
+        SetupHttpClient(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"ok":true,"result":{}}"""),
+        }));
+
+        var sut = CreateSut();
+        var result = await sut.TrySendPhotoAsync(123, null, "caption only", ct: CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task TrySendPhotoAsync_WhenTelegramAcceptsPhoto_ReturnsTrue()
+    {
+        SetupHttpClient(req =>
+        {
+            Assert.Contains("sendPhoto", req.RequestUri!.AbsoluteUri, StringComparison.Ordinal);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""{"ok":true,"result":{}}"""),
+            });
+        });
+
+        var sut = CreateSut();
+        var result = await sut.TrySendPhotoAsync(
+            123,
+            [0xFF, 0xD8, 0xFF],
+            "with photo",
+            ct: CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
     public async Task TrySendMessageAsync_WhenHttpThrows_ReturnsFalseWithoutThrowing()
     {
         SetupHttpClient(_ => throw new HttpRequestException("network down"));

--- a/DataGateMonitor.Tests/Services/Users/FreeTierAccessComplianceServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierAccessComplianceServiceTests.cs
@@ -9,6 +9,7 @@ using DataGateMonitor.Services.Users;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.QuotaPlanTable;
 using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
 using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
@@ -21,22 +22,29 @@ public class FreeTierAccessComplianceServiceTests
     private readonly Mock<IQuotaPlanQueryService> _quotaPlanQuery = new();
     private readonly Mock<IUserIdentityLinkQueryService> _identityLinkQuery = new();
     private readonly Mock<ITelegramChannelMembershipChecker> _channelChecker = new();
+    private readonly Mock<IFreeTierUnsubscribedUserReminderService> _reminder = new();
     private readonly Mock<IAppNotificationFacade> _notifications = new();
     private readonly Mock<ISettingsService> _settingsService = new();
     private readonly MemoryCache _memoryCache = new(new MemoryCacheOptions());
 
     private FreeTierAccessComplianceService CreateSut()
-        => new(
+    {
+        _reminder
+            .Setup(r => r.TryRemindAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        return new(
             _quotaAssignmentQuery.Object,
             _quotaPlanQuery.Object,
             _identityLinkQuery.Object,
             _channelChecker.Object,
+            _reminder.Object,
             _notifications.Object,
             _settingsService.Object,
             _memoryCache,
             Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
             Mock.Of<ILogger<FreeTierAccessComplianceService>>());
-
+    }
     private void SetupGraceSettings(bool enabled, int minutes = 5)
     {
         _settingsService
@@ -111,7 +119,7 @@ public class FreeTierAccessComplianceServiceTests
     }
 
     [Fact]
-    public async Task IsCompliant_WhenMergedTelegramGoogleAccountOnDefaultPlan()
+    public async Task IsNotCompliant_WhenMergedTelegramGoogleAccount_WithoutChannelSubscription()
     {
         _quotaAssignmentQuery
             .Setup(q => q.GetActiveByUserId(10, It.IsAny<CancellationToken>()))
@@ -126,6 +134,51 @@ public class FreeTierAccessComplianceServiceTests
                 new UserIdentityLink { Provider = "telegram", ExternalId = "12345" },
                 new UserIdentityLink { Provider = "google", ExternalId = "google-sub" },
             ]);
+        _channelChecker
+            .Setup(c => c.IsSubscribedAsync(12345, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        SetupGraceSettings(enabled: false);
+        _notifications
+            .Setup(n => n.FreeTierAccessNonCompliant(
+                10,
+                QuotaPlanNames.Default,
+                12345,
+                true,
+                false,
+                "merge",
+                "@DataGateVPNBot",
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        var result = await sut.AuditAndNotifyIfNeededAsync(10, "merge", ct: CancellationToken.None);
+
+        Assert.True(result.IsApplicable);
+        Assert.False(result.IsCompliant);
+        Assert.True(result.IsMergedAccount);
+        Assert.False(result.IsChannelSubscribed);
+        _notifications.VerifyAll();
+    }
+
+    [Fact]
+    public async Task IsCompliant_WhenMergedAndSubscribedToChannel()
+    {
+        _quotaAssignmentQuery
+            .Setup(q => q.GetActiveByUserId(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserQuotaPlan { UserId = 10, QuotaPlanId = 2 });
+        _quotaPlanQuery
+            .Setup(q => q.GetById(2, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new QuotaPlan { Id = 2, Name = QuotaPlanNames.Default });
+        _identityLinkQuery
+            .Setup(q => q.GetListByUserId(10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new UserIdentityLink { Provider = "telegram", ExternalId = "12345" },
+                new UserIdentityLink { Provider = "google", ExternalId = "google-sub" },
+            ]);
+        _channelChecker
+            .Setup(c => c.IsSubscribedAsync(12345, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         var sut = CreateSut();
         var result = await sut.AuditAndNotifyIfNeededAsync(10, "merge", ct: CancellationToken.None);
@@ -133,6 +186,7 @@ public class FreeTierAccessComplianceServiceTests
         Assert.True(result.IsApplicable);
         Assert.True(result.IsCompliant);
         Assert.True(result.IsMergedAccount);
+        Assert.True(result.IsChannelSubscribed);
         _notifications.VerifyNoOtherCalls();
     }
 
@@ -312,7 +366,7 @@ public class FreeTierAccessComplianceServiceTests
     }
 
     [Fact]
-    public async Task GetStatusAsync_WhenCompliant_DoesNotNotifyAdmins()
+    public async Task GetStatusAsync_WhenMergedAndSubscribed_IsCompliant()
     {
         _quotaAssignmentQuery
             .Setup(q => q.GetActiveByUserId(10, It.IsAny<CancellationToken>()))
@@ -327,6 +381,9 @@ public class FreeTierAccessComplianceServiceTests
                 new UserIdentityLink { Provider = "telegram", ExternalId = "12345" },
                 new UserIdentityLink { Provider = "google", ExternalId = "sub" },
             ]);
+        _channelChecker
+            .Setup(c => c.IsSubscribedAsync(12345, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         var sut = CreateSut();
         var status = await sut.GetStatusAsync(10, CancellationToken.None);
@@ -334,6 +391,7 @@ public class FreeTierAccessComplianceServiceTests
         Assert.True(status.IsApplicable);
         Assert.True(status.IsCompliant);
         Assert.True(status.IsMergedAccount);
+        Assert.True(status.IsChannelSubscribed);
         Assert.Equal("@DataGateVPNBot", status.RequiredChannel);
         _notifications.VerifyNoOtherCalls();
     }
@@ -433,7 +491,7 @@ public class FreeTierAccessComplianceServiceTests
     }
 
     [Fact]
-    public async Task RegisterConnectionAsync_WhenCompliant_ReturnsCompliantStatusWithoutGrace()
+    public async Task RegisterConnectionAsync_WhenMergedAndSubscribed_ReturnsCompliantStatusWithoutGrace()
     {
         _quotaAssignmentQuery
             .Setup(q => q.GetActiveByUserId(71, It.IsAny<CancellationToken>()))
@@ -448,6 +506,9 @@ public class FreeTierAccessComplianceServiceTests
                 new UserIdentityLink { Provider = "telegram", ExternalId = "12345" },
                 new UserIdentityLink { Provider = "google", ExternalId = "sub" },
             ]);
+        _channelChecker
+            .Setup(c => c.IsSubscribedAsync(12345, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         var sut = CreateSut();
         var status = await sut.RegisterConnectionAsync(71, "android-connect", CancellationToken.None);
@@ -561,6 +622,59 @@ public class FreeTierAccessComplianceServiceTests
         Assert.True(result.IsApplicable);
         Assert.True(result.IsCompliant);
         Assert.True(result.IsGracePeriod);
+    }
+
+    [Fact]
+    public async Task AuditAndNotify_WhenUnsubscribed_InvokesUserReminder()
+    {
+        SetupFreePlanUser(80, 8080);
+        SetupGraceSettings(enabled: false);
+        _notifications
+            .Setup(n => n.FreeTierAccessNonCompliant(
+                It.IsAny<int>(),
+                It.IsAny<string>(),
+                It.IsAny<long?>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var sut = CreateSut();
+        await sut.AuditAndNotifyIfNeededAsync(80, "bot-files", ct: CancellationToken.None);
+
+        _reminder.Verify(
+            r => r.TryRemindAsync(8080, "bot-files", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_WhenUnsubscribed_DoesNotInvokeUserReminder()
+    {
+        SetupFreePlanUser(81, 8081);
+        SetupGraceSettings(enabled: false);
+
+        var sut = CreateSut();
+        await sut.GetStatusAsync(81, CancellationToken.None);
+
+        _reminder.Verify(
+            r => r.TryRemindAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AuditAndNotify_WhenSubscribed_DoesNotInvokeUserReminder()
+    {
+        SetupFreePlanUser(82, 8082);
+        _channelChecker.Setup(c => c.IsSubscribedAsync(8082, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var sut = CreateSut();
+        await sut.AuditAndNotifyIfNeededAsync(82, "bot", ct: CancellationToken.None);
+
+        _reminder.Verify(
+            r => r.TryRemindAsync(It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Users/FreeTierEnforcementOverviewServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierEnforcementOverviewServiceTests.cs
@@ -142,6 +142,82 @@ public class FreeTierEnforcementOverviewServiceTests
     }
 
     [Fact]
+    public async Task GetUnsubscribedConnectedAsync_IncludesGraceUserWhoIsOnlineButNotSubscribed()
+    {
+        SetupCommonPlans();
+        _userQuotaPlanQueryService.Setup(x => x.GetAllActive(It.IsAny<CancellationToken>())).ReturnsAsync(
+        [
+            new UserQuotaPlan { UserId = 42, QuotaPlanId = 1 },
+        ]);
+        // Grace: compliant for disconnect, but still not subscribed.
+        _complianceService
+            .Setup(x => x.EvaluateAccessForEnforcementAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierAccessComplianceResult
+            {
+                IsApplicable = true,
+                IsCompliant = true,
+                IsGracePeriod = true,
+                IsChannelSubscribed = false,
+                ActivePlanName = QuotaPlanNames.Free,
+                TelegramId = 555,
+            });
+        _userQueryService
+            .Setup(x => x.GetById(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 42, DisplayName = "Grace" });
+        _userIdentityLinkQueryService
+            .Setup(x => x.GetListByUserId(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }]);
+        _issuedOvpnFileQueryService
+            .Setup(x => x.GetAllByExternalId("555", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new IssuedOvpnFile { Id = 1, VpnServerId = 100, CommonName = "cn-42", ExternalId = "555" }]);
+        _vpnServerClientQueryService.Setup(x => x.GetAllConnected(It.IsAny<CancellationToken>())).ReturnsAsync(
+        [
+            new VpnServerClient { VpnServerId = 100, CommonName = "cn-42", IsConnected = true },
+        ]);
+
+        var sut = CreateSut();
+        var digest = await sut.GetUnsubscribedConnectedAsync(CancellationToken.None);
+        var disconnectCandidates = await sut.GetCandidatesAsync(CancellationToken.None);
+
+        Assert.Single(digest.Candidates);
+        Assert.Equal(42, digest.Candidates[0].UserId);
+        Assert.Empty(disconnectCandidates.Candidates);
+    }
+
+    [Fact]
+    public async Task GetUnsubscribedConnectedAsync_ExcludesOfflineUnsubscribedUsers()
+    {
+        SetupCommonPlans();
+        _userQuotaPlanQueryService.Setup(x => x.GetAllActive(It.IsAny<CancellationToken>())).ReturnsAsync(
+        [
+            new UserQuotaPlan { UserId = 42, QuotaPlanId = 1 },
+        ]);
+        _complianceService
+            .Setup(x => x.EvaluateAccessForEnforcementAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierAccessComplianceResult
+            {
+                IsApplicable = true,
+                IsCompliant = false,
+                IsChannelSubscribed = false,
+                TelegramId = 555,
+            });
+        _userQueryService
+            .Setup(x => x.GetById(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 42, DisplayName = "Offline" });
+        _userIdentityLinkQueryService
+            .Setup(x => x.GetListByUserId(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }]);
+        _issuedOvpnFileQueryService
+            .Setup(x => x.GetAllByExternalId("555", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new IssuedOvpnFile { Id = 1, VpnServerId = 100, CommonName = "cn-42", ExternalId = "555" }]);
+
+        var sut = CreateSut();
+        var digest = await sut.GetUnsubscribedConnectedAsync(CancellationToken.None);
+
+        Assert.Empty(digest.Candidates);
+    }
+
+    [Fact]
     public async Task GetDisconnectLogAsync_MapsPagedResultToDto()
     {
         var now = DateTimeOffset.UtcNow;

--- a/DataGateMonitor.Tests/Services/Users/FreeTierEnforcementOverviewServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierEnforcementOverviewServiceTests.cs
@@ -132,6 +132,8 @@ public class FreeTierEnforcementOverviewServiceTests
         var candidate = result.Candidates[0];
         Assert.Equal(42, candidate.UserId);
         Assert.Equal("Bob", candidate.DisplayName);
+        Assert.Equal("bob@example.com", candidate.Email);
+        Assert.Equal(["telegram"], candidate.IdentityProviders);
         Assert.True(candidate.IsConnected);
         Assert.Equal(100, candidate.VpnServerId);
         Assert.Equal("cn-42", candidate.CommonName);
@@ -139,6 +141,89 @@ public class FreeTierEnforcementOverviewServiceTests
         Assert.Equal(connectedSince, candidate.ConnectedSince);
         Assert.Equal(1, result.ConnectedCount);
         Assert.Equal(1, result.TotalCount);
+        _userIdentityLinkQueryService.Verify(
+            x => x.GetListByUserId(42, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCandidatesAsync_GoogleOnly_SetsIdentityProvidersAndEmail()
+    {
+        SetupCommonPlans();
+        _userQuotaPlanQueryService.Setup(x => x.GetAllActive(It.IsAny<CancellationToken>())).ReturnsAsync(
+        [
+            new UserQuotaPlan { UserId = 150, QuotaPlanId = 1 },
+        ]);
+        _complianceService
+            .Setup(x => x.EvaluateAccessForEnforcementAsync(150, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierAccessComplianceResult
+            {
+                IsApplicable = true,
+                IsCompliant = false,
+                ActivePlanName = QuotaPlanNames.Free,
+                IsMergedAccount = false,
+            });
+        _userQueryService
+            .Setup(x => x.GetById(150, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 150, DisplayName = "Tatyana", Email = "t@example.com" });
+        _userIdentityLinkQueryService
+            .Setup(x => x.GetListByUserId(150, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new UserIdentityLink { UserId = 150, Provider = "google", ExternalId = "g-sub" }]);
+        _issuedOvpnFileQueryService
+            .Setup(x => x.GetAllByExternalId("g-sub", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var sut = CreateSut();
+        var result = await sut.GetCandidatesAsync(CancellationToken.None);
+
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal(["google"], candidate.IdentityProviders);
+        Assert.Equal("t@example.com", candidate.Email);
+        Assert.Null(candidate.TelegramId);
+        Assert.False(candidate.IsMergedAccount);
+    }
+
+    [Fact]
+    public async Task GetCandidatesAsync_MergedGoogleAndTelegram_ListsBothProviders()
+    {
+        SetupCommonPlans();
+        _userQuotaPlanQueryService.Setup(x => x.GetAllActive(It.IsAny<CancellationToken>())).ReturnsAsync(
+        [
+            new UserQuotaPlan { UserId = 7, QuotaPlanId = 1 },
+        ]);
+        _complianceService
+            .Setup(x => x.EvaluateAccessForEnforcementAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierAccessComplianceResult
+            {
+                IsApplicable = true,
+                IsCompliant = false,
+                ActivePlanName = QuotaPlanNames.Free,
+                TelegramId = 111,
+                IsMergedAccount = true,
+            });
+        _userQueryService
+            .Setup(x => x.GetById(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 7, DisplayName = "Alice", Email = "alice@gmail.com" });
+        _userIdentityLinkQueryService
+            .Setup(x => x.GetListByUserId(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new UserIdentityLink { UserId = 7, Provider = "telegram", ExternalId = "111" },
+                new UserIdentityLink { UserId = 7, Provider = "google", ExternalId = "g" },
+            ]);
+        _issuedOvpnFileQueryService
+            .Setup(x => x.GetAllByExternalId(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var sut = CreateSut();
+        var result = await sut.GetCandidatesAsync(CancellationToken.None);
+
+        var candidate = Assert.Single(result.Candidates);
+        Assert.Equal(["google", "telegram"], candidate.IdentityProviders);
+        Assert.True(candidate.IsMergedAccount);
+        _userIdentityLinkQueryService.Verify(
+            x => x.GetListByUserId(7, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Users/FreeTierEnforcementOverviewServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierEnforcementOverviewServiceTests.cs
@@ -54,6 +54,23 @@ public class FreeTierEnforcementOverviewServiceTests
             .ReturnsAsync([new VpnServer { Id = 100, ServerName = "srv-100" }]);
         _vpnServerClientQueryService.Setup(x => x.GetAllConnected(It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
+        _userQueryService
+            .Setup(x => x.GetByIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, User>());
+        _userIdentityLinkQueryService
+            .Setup(x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<UserIdentityLink>>());
+        _userQueryService
+            .Setup(x => x.GetByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, User>(StringComparer.Ordinal));
+        _issuedOvpnFileQueryService
+            .Setup(x => x.GetAllByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, List<IssuedOvpnFile>>(StringComparer.Ordinal));
+        _issuedOvpnFileQueryService
+            .Setup(x => x.GetActiveByServerAndCommonNames(
+                It.IsAny<IReadOnlyCollection<(int, string)>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
     }
 
     [Fact]
@@ -110,14 +127,23 @@ public class FreeTierEnforcementOverviewServiceTests
                 TelegramId = 555,
             });
         _userQueryService
-            .Setup(x => x.GetById(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = 42, DisplayName = "Bob", Email = "bob@example.com" });
+            .Setup(x => x.GetByIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, User>
+            {
+                [42] = new User { Id = 42, DisplayName = "Bob", Email = "bob@example.com" },
+            });
         _userIdentityLinkQueryService
-            .Setup(x => x.GetListByUserId(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }]);
+            .Setup(x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<UserIdentityLink>>
+            {
+                [42] = [new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }],
+            });
         _issuedOvpnFileQueryService
-            .Setup(x => x.GetAllByExternalId("555", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new IssuedOvpnFile { Id = 1, VpnServerId = 100, CommonName = "cn-42", ExternalId = "555" }]);
+            .Setup(x => x.GetAllByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, List<IssuedOvpnFile>>(StringComparer.Ordinal)
+            {
+                ["555"] = [new IssuedOvpnFile { Id = 1, VpnServerId = 100, CommonName = "cn-42", ExternalId = "555" }],
+            });
 
         var connectedSince = DateTimeOffset.UtcNow.AddMinutes(-10);
         _vpnServerClientQueryService.Setup(x => x.GetAllConnected(It.IsAny<CancellationToken>())).ReturnsAsync(
@@ -142,7 +168,7 @@ public class FreeTierEnforcementOverviewServiceTests
         Assert.Equal(1, result.ConnectedCount);
         Assert.Equal(1, result.TotalCount);
         _userIdentityLinkQueryService.Verify(
-            x => x.GetListByUserId(42, It.IsAny<CancellationToken>()),
+            x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -164,14 +190,17 @@ public class FreeTierEnforcementOverviewServiceTests
                 IsMergedAccount = false,
             });
         _userQueryService
-            .Setup(x => x.GetById(150, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = 150, DisplayName = "Tatyana", Email = "t@example.com" });
+            .Setup(x => x.GetByIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, User>
+            {
+                [150] = new User { Id = 150, DisplayName = "Tatyana", Email = "t@example.com" },
+            });
         _userIdentityLinkQueryService
-            .Setup(x => x.GetListByUserId(150, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new UserIdentityLink { UserId = 150, Provider = "google", ExternalId = "g-sub" }]);
-        _issuedOvpnFileQueryService
-            .Setup(x => x.GetAllByExternalId("g-sub", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+            .Setup(x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<UserIdentityLink>>
+            {
+                [150] = [new UserIdentityLink { UserId = 150, Provider = "google", ExternalId = "g-sub" }],
+            });
 
         var sut = CreateSut();
         var result = await sut.GetCandidatesAsync(CancellationToken.None);
@@ -202,18 +231,21 @@ public class FreeTierEnforcementOverviewServiceTests
                 IsMergedAccount = true,
             });
         _userQueryService
-            .Setup(x => x.GetById(7, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = 7, DisplayName = "Alice", Email = "alice@gmail.com" });
+            .Setup(x => x.GetByIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, User>
+            {
+                [7] = new User { Id = 7, DisplayName = "Alice", Email = "alice@gmail.com" },
+            });
         _userIdentityLinkQueryService
-            .Setup(x => x.GetListByUserId(7, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
-            [
-                new UserIdentityLink { UserId = 7, Provider = "telegram", ExternalId = "111" },
-                new UserIdentityLink { UserId = 7, Provider = "google", ExternalId = "g" },
-            ]);
-        _issuedOvpnFileQueryService
-            .Setup(x => x.GetAllByExternalId(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+            .Setup(x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<UserIdentityLink>>
+            {
+                [7] =
+                [
+                    new UserIdentityLink { UserId = 7, Provider = "telegram", ExternalId = "111" },
+                    new UserIdentityLink { UserId = 7, Provider = "google", ExternalId = "g" },
+                ],
+            });
 
         var sut = CreateSut();
         var result = await sut.GetCandidatesAsync(CancellationToken.None);
@@ -222,7 +254,7 @@ public class FreeTierEnforcementOverviewServiceTests
         Assert.Equal(["google", "telegram"], candidate.IdentityProviders);
         Assert.True(candidate.IsMergedAccount);
         _userIdentityLinkQueryService.Verify(
-            x => x.GetListByUserId(7, It.IsAny<CancellationToken>()),
+            x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -247,17 +279,32 @@ public class FreeTierEnforcementOverviewServiceTests
                 TelegramId = 555,
             });
         _userQueryService
-            .Setup(x => x.GetById(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = 42, DisplayName = "Grace" });
+            .Setup(x => x.GetByIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, User>
+            {
+                [42] = new User { Id = 42, DisplayName = "Grace" },
+            });
         _userIdentityLinkQueryService
-            .Setup(x => x.GetListByUserId(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }]);
-        _issuedOvpnFileQueryService
-            .Setup(x => x.GetAllByExternalId("555", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new IssuedOvpnFile { Id = 1, VpnServerId = 100, CommonName = "cn-42", ExternalId = "555" }]);
+            .Setup(x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<UserIdentityLink>>
+            {
+                [42] = [new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }],
+            });
+        _userQueryService
+            .Setup(x => x.GetByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, User>(StringComparer.Ordinal)
+            {
+                ["555"] = new User { Id = 42, DisplayName = "Grace" },
+            });
         _vpnServerClientQueryService.Setup(x => x.GetAllConnected(It.IsAny<CancellationToken>())).ReturnsAsync(
         [
-            new VpnServerClient { VpnServerId = 100, CommonName = "cn-42", IsConnected = true },
+            new VpnServerClient
+            {
+                VpnServerId = 100,
+                CommonName = "cn-42",
+                ExternalId = "555",
+                IsConnected = true,
+            },
         ]);
 
         var sut = CreateSut();
@@ -267,6 +314,10 @@ public class FreeTierEnforcementOverviewServiceTests
         Assert.Single(digest.Candidates);
         Assert.Equal(42, digest.Candidates[0].UserId);
         Assert.Empty(disconnectCandidates.Candidates);
+        // Digest evaluates only connected free-tier users (not every Free/Default account).
+        _complianceService.Verify(
+            x => x.EvaluateAccessForEnforcementAsync(42, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
     }
 
     [Fact]
@@ -287,19 +338,66 @@ public class FreeTierEnforcementOverviewServiceTests
                 TelegramId = 555,
             });
         _userQueryService
-            .Setup(x => x.GetById(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = 42, DisplayName = "Offline" });
+            .Setup(x => x.GetByIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, User>
+            {
+                [42] = new User { Id = 42, DisplayName = "Offline" },
+            });
         _userIdentityLinkQueryService
-            .Setup(x => x.GetListByUserId(42, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }]);
+            .Setup(x => x.GetListByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, List<UserIdentityLink>>
+            {
+                [42] = [new UserIdentityLink { UserId = 42, Provider = "telegram", ExternalId = "555" }],
+            });
         _issuedOvpnFileQueryService
-            .Setup(x => x.GetAllByExternalId("555", It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new IssuedOvpnFile { Id = 1, VpnServerId = 100, CommonName = "cn-42", ExternalId = "555" }]);
+            .Setup(x => x.GetAllByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, List<IssuedOvpnFile>>(StringComparer.Ordinal)
+            {
+                ["555"] = [new IssuedOvpnFile { Id = 1, VpnServerId = 100, CommonName = "cn-42", ExternalId = "555" }],
+            });
 
         var sut = CreateSut();
         var digest = await sut.GetUnsubscribedConnectedAsync(CancellationToken.None);
 
         Assert.Empty(digest.Candidates);
+        _complianceService.Verify(
+            x => x.EvaluateAccessForEnforcementAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetUnsubscribedConnectedAsync_SkipsComplianceForPaidConnectedUsers()
+    {
+        SetupCommonPlans();
+        _userQuotaPlanQueryService.Setup(x => x.GetAllActive(It.IsAny<CancellationToken>())).ReturnsAsync(
+        [
+            new UserQuotaPlan { UserId = 42, QuotaPlanId = 1 },
+            new UserQuotaPlan { UserId = 99, QuotaPlanId = 3 },
+        ]);
+        _userQueryService
+            .Setup(x => x.GetByExternalIds(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, User>(StringComparer.Ordinal)
+            {
+                ["paid"] = new User { Id = 99, DisplayName = "Paid" },
+            });
+        _vpnServerClientQueryService.Setup(x => x.GetAllConnected(It.IsAny<CancellationToken>())).ReturnsAsync(
+        [
+            new VpnServerClient
+            {
+                VpnServerId = 100,
+                CommonName = "cn-paid",
+                ExternalId = "paid",
+                IsConnected = true,
+            },
+        ]);
+
+        var sut = CreateSut();
+        var digest = await sut.GetUnsubscribedConnectedAsync(CancellationToken.None);
+
+        Assert.Empty(digest.Candidates);
+        _complianceService.Verify(
+            x => x.EvaluateAccessForEnforcementAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Users/FreeTierOpenVpnSessionEnforcementServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierOpenVpnSessionEnforcementServiceTests.cs
@@ -1,59 +1,205 @@
+using Microsoft.Extensions.Logging;
+using Moq;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.Helpers;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
 using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.Users;
 using DataGateMonitor.Services.Users.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerClients.Responses;
 using DataGateMonitor.SharedModels.Enums;
-using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 
 namespace DataGateMonitor.Tests.Services.Users;
 
 public class FreeTierOpenVpnSessionEnforcementServiceTests
 {
-    private static FreeTierOpenVpnSessionEnforcementService CreateSut(Mock<ISettingsService> settings) =>
-        new(
-            Mock.Of<IVpnServerQueryService>(),
-            Mock.Of<IOpenVpnClientService>(),
-            Mock.Of<IIssuedOvpnFileQueryService>(),
-            Mock.Of<IUserQueryService>(),
-            Mock.Of<IFreeTierAccessComplianceService>(),
-            Mock.Of<IOpenVpnDisconnectExecutor>(),
-            Mock.Of<IFreeTierGraceDisconnectNotifier>(),
-            settings.Object,
-            NullLogger<FreeTierOpenVpnSessionEnforcementService>.Instance);
+    private readonly Mock<IVpnServerQueryService> _vpnServerQuery = new();
+    private readonly Mock<IOpenVpnClientService> _openVpnClientService = new();
+    private readonly Mock<IIssuedOvpnFileQueryService> _issuedOvpnFileQuery = new();
+    private readonly Mock<IUserQueryService> _userQuery = new();
+    private readonly Mock<IFreeTierAccessComplianceService> _complianceService = new();
+    private readonly Mock<IOpenVpnDisconnectExecutor> _disconnectExecutor = new();
+    private readonly Mock<IFreeTierGraceDisconnectNotifier> _graceDisconnectNotifier = new();
+    private readonly Mock<ISettingsService> _settingsService = new();
 
-    [Fact]
-    public async Task IsEnabledAsync_WhenTypeMissing_DefaultsTrue()
+    private FreeTierOpenVpnSessionEnforcementService CreateSut()
+        => new(
+            _vpnServerQuery.Object,
+            _openVpnClientService.Object,
+            _issuedOvpnFileQuery.Object,
+            _userQuery.Object,
+            _complianceService.Object,
+            _disconnectExecutor.Object,
+            _graceDisconnectNotifier.Object,
+            _settingsService.Object,
+            Mock.Of<ILogger<FreeTierOpenVpnSessionEnforcementService>>());
+
+    private void SetupEnforcementEnabled(bool revokeOnEnforcement = false)
     {
-        var settings = new Mock<ISettingsService>();
-        settings.Setup(s => s.GetValueAsync<string>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
-
-        Assert.True(await CreateSut(settings).IsEnabledAsync());
-    }
-
-    [Fact]
-    public async Task GetIntervalMinutesAsync_WhenTypeMissing_Defaults15()
-    {
-        var settings = new Mock<ISettingsService>();
-        settings.Setup(s => s.GetValueAsync<string>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
-
-        Assert.Equal(15, await CreateSut(settings).GetIntervalMinutesAsync());
-    }
-
-    [Fact]
-    public async Task EnforceAsync_WhenDisabled_ReturnsZero()
-    {
-        var settings = new Mock<ISettingsService>();
-        settings.Setup(s => s.GetValueAsync<string>(It.Is<string>(k => k.Contains("Type")), It.IsAny<CancellationToken>()))
+        _settingsService
+            .Setup(s => s.GetValueAsync<string>($"{FreeTierAccessSettingsKeys.EnforceOpenVpnSessions}_Type", It.IsAny<CancellationToken>()))
             .ReturnsAsync("bool");
-        settings.Setup(s => s.GetValueAsync<bool>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+        _settingsService
+            .Setup(s => s.GetValueAsync<bool>(FreeTierAccessSettingsKeys.EnforceOpenVpnSessions, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _settingsService
+            .Setup(s => s.GetValueAsync<string>($"{FreeTierAccessSettingsKeys.RevokeOvpnOnEnforcement}_Type", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bool");
+        _settingsService
+            .Setup(s => s.GetValueAsync<bool>(FreeTierAccessSettingsKeys.RevokeOvpnOnEnforcement, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(revokeOnEnforcement);
+    }
 
-        Assert.Equal(0, await CreateSut(settings).EnforceAsync());
+    private void SetupSingleConnectedClient(int userId, string commonName = "cn1", string externalId = "ext1")
+    {
+        var server = new VpnServer { Id = 1, ServerType = VpnServerType.OpenVpn, IsDisable = false, IsDeleted = false };
+        _vpnServerQuery.Setup(q => q.GetAll(false, false, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([server]);
+
+        _openVpnClientService
+            .Setup(s => s.GetClientsFromManagementAsync(server, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OpenVpnManagementStatusResult
+            {
+                Clients = [new VpnServerClient { CommonName = commonName, VpnServerId = 1 }],
+            });
+
+        _issuedOvpnFileQuery
+            .Setup(q => q.GetExternalIdByCommonName(commonName, 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(externalId);
+
+        _userQuery
+            .Setup(q => q.GetByExternalId(externalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = userId, DisplayName = "u" });
+    }
+
+    private void SetupNonCompliant(int userId, string planName = QuotaPlanNames.Free)
+    {
+        _complianceService
+            .Setup(s => s.EvaluateAccessForEnforcementAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierAccessComplianceResult
+            {
+                IsApplicable = true,
+                IsCompliant = false,
+                ActivePlanName = planName,
+            });
+    }
+
+    [Fact]
+    public async Task EnforceAsync_WhenDisconnectSucceeds_NotifiesUserAndRecordsOutcome()
+    {
+        SetupEnforcementEnabled();
+        SetupSingleConnectedClient(userId: 42);
+        SetupNonCompliant(42);
+
+        _disconnectExecutor
+            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new KillOpenVpnClientResponse { Success = true }, (int?)77));
+        _graceDisconnectNotifier
+            .Setup(n => n.NotifyAsync(42, QuotaPlanNames.Free, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierGraceDisconnectOutcome("telegram", true));
+
+        var sut = CreateSut();
+        var killed = await sut.EnforceAsync(CancellationToken.None);
+
+        Assert.Equal(1, killed);
+        _graceDisconnectNotifier.Verify(n => n.NotifyAsync(42, QuotaPlanNames.Free, It.IsAny<CancellationToken>()), Times.Once);
+        _disconnectExecutor.Verify(
+            e => e.UpdateNotificationOutcomeAsync(77, "telegram", true, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_WhenDisconnectFails_DoesNotNotifyUser()
+    {
+        SetupEnforcementEnabled();
+        SetupSingleConnectedClient(userId: 43);
+        SetupNonCompliant(43);
+
+        _disconnectExecutor
+            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new KillOpenVpnClientResponse { Success = false }, (int?)78));
+
+        var sut = CreateSut();
+        var killed = await sut.EnforceAsync(CancellationToken.None);
+
+        Assert.Equal(0, killed);
+        _graceDisconnectNotifier.Verify(
+            n => n.NotifyAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+        _disconnectExecutor.Verify(
+            e => e.UpdateNotificationOutcomeAsync(
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_WhenUserNotFlaggedForEnforcement_DoesNotDisconnectOrNotify()
+    {
+        SetupEnforcementEnabled();
+        SetupSingleConnectedClient(userId: 44);
+
+        _complianceService
+            .Setup(s => s.EvaluateAccessForEnforcementAsync(44, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierAccessComplianceResult { IsApplicable = true, IsCompliant = true });
+
+        var sut = CreateSut();
+        var killed = await sut.EnforceAsync(CancellationToken.None);
+
+        Assert.Equal(0, killed);
+        _disconnectExecutor.Verify(
+            e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        _graceDisconnectNotifier.Verify(
+            n => n.NotifyAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_WhenLogWriteFailed_SkipsOutcomeUpdate()
+    {
+        SetupEnforcementEnabled();
+        SetupSingleConnectedClient(userId: 46);
+        SetupNonCompliant(46);
+
+        _disconnectExecutor
+            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new KillOpenVpnClientResponse { Success = true }, (int?)null));
+        _graceDisconnectNotifier
+            .Setup(n => n.NotifyAsync(46, QuotaPlanNames.Free, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FreeTierGraceDisconnectOutcome("email", true));
+
+        var sut = CreateSut();
+        var killed = await sut.EnforceAsync(CancellationToken.None);
+
+        Assert.Equal(1, killed);
+        _graceDisconnectNotifier.Verify(n => n.NotifyAsync(46, QuotaPlanNames.Free, It.IsAny<CancellationToken>()), Times.Once);
+        _disconnectExecutor.Verify(
+            e => e.UpdateNotificationOutcomeAsync(
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnforceAsync_WhenNotifierThrows_StillCountsKillAndDoesNotPropagate()
+    {
+        SetupEnforcementEnabled();
+        SetupSingleConnectedClient(userId: 45);
+        SetupNonCompliant(45);
+
+        _disconnectExecutor
+            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((new KillOpenVpnClientResponse { Success = true }, (int?)79));
+        _graceDisconnectNotifier
+            .Setup(n => n.NotifyAsync(45, QuotaPlanNames.Free, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var sut = CreateSut();
+        var killed = await sut.EnforceAsync(CancellationToken.None);
+
+        Assert.Equal(1, killed);
+        _disconnectExecutor.Verify(
+            e => e.UpdateNotificationOutcomeAsync(
+                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/DataGateMonitor.Tests/Services/Users/FreeTierOpenVpnSessionEnforcementServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierOpenVpnSessionEnforcementServiceTests.cs
@@ -1,205 +1,59 @@
-using Microsoft.Extensions.Logging;
-using Moq;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
-using DataGateMonitor.Models;
-using DataGateMonitor.Models.Helpers;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
 using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.Users;
 using DataGateMonitor.Services.Users.Interfaces;
-using DataGateMonitor.SharedModels.DataGateMonitor.VpnServerClients.Responses;
 using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace DataGateMonitor.Tests.Services.Users;
 
 public class FreeTierOpenVpnSessionEnforcementServiceTests
 {
-    private readonly Mock<IVpnServerQueryService> _vpnServerQuery = new();
-    private readonly Mock<IOpenVpnClientService> _openVpnClientService = new();
-    private readonly Mock<IIssuedOvpnFileQueryService> _issuedOvpnFileQuery = new();
-    private readonly Mock<IUserQueryService> _userQuery = new();
-    private readonly Mock<IFreeTierAccessComplianceService> _complianceService = new();
-    private readonly Mock<IOpenVpnDisconnectExecutor> _disconnectExecutor = new();
-    private readonly Mock<IFreeTierGraceDisconnectNotifier> _graceDisconnectNotifier = new();
-    private readonly Mock<ISettingsService> _settingsService = new();
+    private static FreeTierOpenVpnSessionEnforcementService CreateSut(Mock<ISettingsService> settings) =>
+        new(
+            Mock.Of<IVpnServerQueryService>(),
+            Mock.Of<IOpenVpnClientService>(),
+            Mock.Of<IIssuedOvpnFileQueryService>(),
+            Mock.Of<IUserQueryService>(),
+            Mock.Of<IFreeTierAccessComplianceService>(),
+            Mock.Of<IOpenVpnDisconnectExecutor>(),
+            Mock.Of<IFreeTierGraceDisconnectNotifier>(),
+            settings.Object,
+            NullLogger<FreeTierOpenVpnSessionEnforcementService>.Instance);
 
-    private FreeTierOpenVpnSessionEnforcementService CreateSut()
-        => new(
-            _vpnServerQuery.Object,
-            _openVpnClientService.Object,
-            _issuedOvpnFileQuery.Object,
-            _userQuery.Object,
-            _complianceService.Object,
-            _disconnectExecutor.Object,
-            _graceDisconnectNotifier.Object,
-            _settingsService.Object,
-            Mock.Of<ILogger<FreeTierOpenVpnSessionEnforcementService>>());
-
-    private void SetupEnforcementEnabled(bool revokeOnEnforcement = false)
+    [Fact]
+    public async Task IsEnabledAsync_WhenTypeMissing_DefaultsTrue()
     {
-        _settingsService
-            .Setup(s => s.GetValueAsync<string>($"{FreeTierAccessSettingsKeys.EnforceOpenVpnSessions}_Type", It.IsAny<CancellationToken>()))
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetValueAsync<string>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        Assert.True(await CreateSut(settings).IsEnabledAsync());
+    }
+
+    [Fact]
+    public async Task GetIntervalMinutesAsync_WhenTypeMissing_Defaults15()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetValueAsync<string>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        Assert.Equal(15, await CreateSut(settings).GetIntervalMinutesAsync());
+    }
+
+    [Fact]
+    public async Task EnforceAsync_WhenDisabled_ReturnsZero()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetValueAsync<string>(It.Is<string>(k => k.Contains("Type")), It.IsAny<CancellationToken>()))
             .ReturnsAsync("bool");
-        _settingsService
-            .Setup(s => s.GetValueAsync<bool>(FreeTierAccessSettingsKeys.EnforceOpenVpnSessions, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-        _settingsService
-            .Setup(s => s.GetValueAsync<string>($"{FreeTierAccessSettingsKeys.RevokeOvpnOnEnforcement}_Type", It.IsAny<CancellationToken>()))
-            .ReturnsAsync("bool");
-        _settingsService
-            .Setup(s => s.GetValueAsync<bool>(FreeTierAccessSettingsKeys.RevokeOvpnOnEnforcement, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(revokeOnEnforcement);
-    }
+        settings.Setup(s => s.GetValueAsync<bool>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
 
-    private void SetupSingleConnectedClient(int userId, string commonName = "cn1", string externalId = "ext1")
-    {
-        var server = new VpnServer { Id = 1, ServerType = VpnServerType.OpenVpn, IsDisable = false, IsDeleted = false };
-        _vpnServerQuery.Setup(q => q.GetAll(false, false, null, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([server]);
-
-        _openVpnClientService
-            .Setup(s => s.GetClientsFromManagementAsync(server, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new OpenVpnManagementStatusResult
-            {
-                Clients = [new VpnServerClient { CommonName = commonName, VpnServerId = 1 }],
-            });
-
-        _issuedOvpnFileQuery
-            .Setup(q => q.GetExternalIdByCommonName(commonName, 1, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(externalId);
-
-        _userQuery
-            .Setup(q => q.GetByExternalId(externalId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = userId, DisplayName = "u" });
-    }
-
-    private void SetupNonCompliant(int userId, string planName = QuotaPlanNames.Free)
-    {
-        _complianceService
-            .Setup(s => s.EvaluateAccessForEnforcementAsync(userId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FreeTierAccessComplianceResult
-            {
-                IsApplicable = true,
-                IsCompliant = false,
-                ActivePlanName = planName,
-            });
-    }
-
-    [Fact]
-    public async Task EnforceAsync_WhenDisconnectSucceeds_NotifiesUserAndRecordsOutcome()
-    {
-        SetupEnforcementEnabled();
-        SetupSingleConnectedClient(userId: 42);
-        SetupNonCompliant(42);
-
-        _disconnectExecutor
-            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((new KillOpenVpnClientResponse { Success = true }, (int?)77));
-        _graceDisconnectNotifier
-            .Setup(n => n.NotifyAsync(42, QuotaPlanNames.Free, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FreeTierGraceDisconnectOutcome("telegram", true));
-
-        var sut = CreateSut();
-        var killed = await sut.EnforceAsync(CancellationToken.None);
-
-        Assert.Equal(1, killed);
-        _graceDisconnectNotifier.Verify(n => n.NotifyAsync(42, QuotaPlanNames.Free, It.IsAny<CancellationToken>()), Times.Once);
-        _disconnectExecutor.Verify(
-            e => e.UpdateNotificationOutcomeAsync(77, "telegram", true, It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task EnforceAsync_WhenDisconnectFails_DoesNotNotifyUser()
-    {
-        SetupEnforcementEnabled();
-        SetupSingleConnectedClient(userId: 43);
-        SetupNonCompliant(43);
-
-        _disconnectExecutor
-            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((new KillOpenVpnClientResponse { Success = false }, (int?)78));
-
-        var sut = CreateSut();
-        var killed = await sut.EnforceAsync(CancellationToken.None);
-
-        Assert.Equal(0, killed);
-        _graceDisconnectNotifier.Verify(
-            n => n.NotifyAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-        _disconnectExecutor.Verify(
-            e => e.UpdateNotificationOutcomeAsync(
-                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-    }
-
-    [Fact]
-    public async Task EnforceAsync_WhenUserNotFlaggedForEnforcement_DoesNotDisconnectOrNotify()
-    {
-        SetupEnforcementEnabled();
-        SetupSingleConnectedClient(userId: 44);
-
-        _complianceService
-            .Setup(s => s.EvaluateAccessForEnforcementAsync(44, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FreeTierAccessComplianceResult { IsApplicable = true, IsCompliant = true });
-
-        var sut = CreateSut();
-        var killed = await sut.EnforceAsync(CancellationToken.None);
-
-        Assert.Equal(0, killed);
-        _disconnectExecutor.Verify(
-            e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
-        _graceDisconnectNotifier.Verify(
-            n => n.NotifyAsync(It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task EnforceAsync_WhenLogWriteFailed_SkipsOutcomeUpdate()
-    {
-        SetupEnforcementEnabled();
-        SetupSingleConnectedClient(userId: 46);
-        SetupNonCompliant(46);
-
-        _disconnectExecutor
-            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((new KillOpenVpnClientResponse { Success = true }, (int?)null));
-        _graceDisconnectNotifier
-            .Setup(n => n.NotifyAsync(46, QuotaPlanNames.Free, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FreeTierGraceDisconnectOutcome("email", true));
-
-        var sut = CreateSut();
-        var killed = await sut.EnforceAsync(CancellationToken.None);
-
-        Assert.Equal(1, killed);
-        _graceDisconnectNotifier.Verify(n => n.NotifyAsync(46, QuotaPlanNames.Free, It.IsAny<CancellationToken>()), Times.Once);
-        _disconnectExecutor.Verify(
-            e => e.UpdateNotificationOutcomeAsync(
-                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
-            Times.Never);
-    }
-
-    [Fact]
-    public async Task EnforceAsync_WhenNotifierThrows_StillCountsKillAndDoesNotPropagate()
-    {
-        SetupEnforcementEnabled();
-        SetupSingleConnectedClient(userId: 45);
-        SetupNonCompliant(45);
-
-        _disconnectExecutor
-            .Setup(e => e.ExecuteWithLogIdAsync(It.IsAny<OpenVpnDisconnectRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((new KillOpenVpnClientResponse { Success = true }, (int?)79));
-        _graceDisconnectNotifier
-            .Setup(n => n.NotifyAsync(45, QuotaPlanNames.Free, It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("boom"));
-
-        var sut = CreateSut();
-        var killed = await sut.EnforceAsync(CancellationToken.None);
-
-        Assert.Equal(1, killed);
-        _disconnectExecutor.Verify(
-            e => e.UpdateNotificationOutcomeAsync(
-                It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        Assert.Equal(0, await CreateSut(settings).EnforceAsync());
     }
 }

--- a/DataGateMonitor.Tests/Services/Users/FreeTierUnsubscribedNotificationsTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierUnsubscribedNotificationsTests.cs
@@ -1,0 +1,271 @@
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.TelegramBot.Interfaces;
+using DataGateMonitor.Services.Users;
+using DataGateMonitor.Services.Users.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.Users;
+
+public class FreeTierUnsubscribedNotificationsTests
+{
+    private static void SetupBoolSetting(Mock<ISettingsService> settings, string key, bool value)
+    {
+        settings.Setup(s => s.GetValueAsync<string>($"{key}_Type", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bool");
+        settings.Setup(s => s.GetValueAsync<bool>(key, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(value);
+    }
+
+    [Fact]
+    public async Task Reminder_WhenDisabled_DoesNotSend()
+    {
+        var settings = new Mock<ISettingsService>();
+        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders, false);
+
+        var sender = new Mock<ITelegramDirectMessageSender>(MockBehavior.Strict);
+        var sut = new FreeTierUnsubscribedUserReminderService(
+            settings.Object,
+            sender.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
+            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+
+        await sut.TryRemindAsync(1, "test", CancellationToken.None);
+        sender.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Reminder_WhenEnabled_SendsOncePerCooldown()
+    {
+        var settings = new Mock<ISettingsService>();
+        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders, true);
+
+        var sender = new Mock<ITelegramDirectMessageSender>();
+        sender.Setup(s => s.TrySendMessageAsync(42, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var sut = new FreeTierUnsubscribedUserReminderService(
+            settings.Object,
+            sender.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
+            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+
+        await sut.TryRemindAsync(42, "first", CancellationToken.None);
+        await sut.TryRemindAsync(42, "second", CancellationToken.None);
+
+        sender.Verify(
+            s => s.TrySendMessageAsync(42, It.Is<string>(t => t.Contains("@DataGateVPNBot")), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Reminder_WhenSettingTypeMissing_DefaultsToEnabledAndSends()
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetValueAsync<string>(
+                $"{FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders}_Type",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var sender = new Mock<ITelegramDirectMessageSender>();
+        sender.Setup(s => s.TrySendMessageAsync(7, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var sut = new FreeTierUnsubscribedUserReminderService(
+            settings.Object,
+            sender.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
+            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+
+        await sut.TryRemindAsync(7, "default-on", CancellationToken.None);
+
+        sender.Verify(
+            s => s.TrySendMessageAsync(7, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Reminder_WhenSendFails_DoesNotSetCooldown()
+    {
+        var settings = new Mock<ISettingsService>();
+        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders, true);
+
+        var sender = new Mock<ITelegramDirectMessageSender>();
+        sender.Setup(s => s.TrySendMessageAsync(9, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sut = new FreeTierUnsubscribedUserReminderService(
+            settings.Object,
+            sender.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
+            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+
+        await sut.TryRemindAsync(9, "fail-1", CancellationToken.None);
+        await sut.TryRemindAsync(9, "fail-2", CancellationToken.None);
+
+        sender.Verify(
+            s => s.TrySendMessageAsync(9, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public void Digest_BuildMessage_IncludesOnlineUsers()
+    {
+        var text = FreeTierUnsubscribedVpnUsersDailyDigestService.BuildDigestMessage(
+            new DateOnly(2026, 8, 9),
+            1,
+            [
+                new FreeTierEnforcementCandidateDto
+                {
+                    UserId = 7,
+                    DisplayName = "Alice",
+                    TelegramId = 111,
+                    VpnServerName = "eu1",
+                    IsMergedAccount = true,
+                    IsChannelSubscribed = false,
+                    IsConnected = true,
+                },
+            ]);
+
+        Assert.Contains("Currently online: 1", text);
+        Assert.Contains("#7 Alice", text);
+        Assert.Contains("TG:111", text);
+        Assert.Contains("eu1", text);
+        Assert.Contains("merged", text);
+    }
+
+    [Fact]
+    public async Task Digest_WhenDisabled_DoesNotQueryOverviewOrSend()
+    {
+        var settings = new Mock<ISettingsService>();
+        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest, false);
+
+        var overview = new Mock<IFreeTierEnforcementOverviewService>(MockBehavior.Strict);
+        var sender = new Mock<ITelegramDirectMessageSender>(MockBehavior.Strict);
+        var telegramUsers = new Mock<ITelegramUserService>(MockBehavior.Strict);
+
+        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
+            settings.Object,
+            overview.Object,
+            telegramUsers.Object,
+            sender.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
+
+        await sut.TrySendDailyDigestAsync(CancellationToken.None);
+
+        overview.VerifyNoOtherCalls();
+        sender.VerifyNoOtherCalls();
+        telegramUsers.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Digest_WhenEnabled_SendsToAdmins_AndSkipsSecondCallSameDay()
+    {
+        var settings = new Mock<ISettingsService>();
+        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest, true);
+
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        overview.Setup(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetFreeTierEnforcementCandidatesResponse
+            {
+                Candidates =
+                [
+                    new FreeTierEnforcementCandidateDto
+                    {
+                        UserId = 1,
+                        DisplayName = "Bob",
+                        IsConnected = true,
+                        IsChannelSubscribed = false,
+                        TelegramId = 99,
+                    },
+                ],
+                TotalCount = 1,
+                ConnectedCount = 1,
+            });
+
+        var telegramUsers = new Mock<ITelegramUserService>();
+        telegramUsers.Setup(t => t.GetAdminsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new TelegramBotUser { TelegramId = 1001, IsAdmin = true }]);
+
+        var sender = new Mock<ITelegramDirectMessageSender>();
+        sender.Setup(s => s.TrySendMessageAsync(1001, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
+            settings.Object,
+            overview.Object,
+            telegramUsers.Object,
+            sender.Object,
+            new MemoryCache(new MemoryCacheOptions()),
+            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
+
+        await sut.TrySendDailyDigestAsync(CancellationToken.None);
+        await sut.TrySendDailyDigestAsync(CancellationToken.None);
+
+        overview.Verify(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()), Times.Once);
+        sender.Verify(
+            s => s.TrySendMessageAsync(1001, It.Is<string>(t => t.Contains("Bob")), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Digest_BuildDigestTextAsync_IgnoresEnableFlag()
+    {
+        var settings = new Mock<ISettingsService>(MockBehavior.Strict);
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        overview.Setup(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetFreeTierEnforcementCandidatesResponse
+            {
+                Candidates = [],
+                TotalCount = 0,
+                ConnectedCount = 0,
+            });
+
+        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
+            settings.Object,
+            overview.Object,
+            Mock.Of<ITelegramUserService>(),
+            Mock.Of<ITelegramDirectMessageSender>(),
+            new MemoryCache(new MemoryCacheOptions()),
+            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
+
+        var text = await sut.BuildDigestTextAsync(CancellationToken.None);
+
+        Assert.Contains("Currently online: 0", text);
+        overview.Verify(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()), Times.Once);
+        settings.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Digest_WhenAlreadySentToday_Skips()
+    {
+        var settings = new Mock<ISettingsService>();
+        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest, true);
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        cache.Set("free-tier-unsub-admin-digest:last-utc-date", DateOnly.FromDateTime(DateTime.UtcNow));
+
+        var overview = new Mock<IFreeTierEnforcementOverviewService>(MockBehavior.Strict);
+        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
+            settings.Object,
+            overview.Object,
+            Mock.Of<ITelegramUserService>(),
+            Mock.Of<ITelegramDirectMessageSender>(),
+            cache,
+            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
+
+        await sut.TrySendDailyDigestAsync(CancellationToken.None);
+        overview.VerifyNoOtherCalls();
+    }
+}

--- a/DataGateMonitor.Tests/Services/Users/FreeTierUnsubscribedNotificationsTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierUnsubscribedNotificationsTests.cs
@@ -1,10 +1,16 @@
+using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+using DataGateMonitor.Services.EmailTemplates;
 using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.TelegramBot.Interfaces;
 using DataGateMonitor.Services.Users;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -23,158 +29,185 @@ public class FreeTierUnsubscribedNotificationsTests
             .ReturnsAsync(value);
     }
 
+    private static FreeTierUnsubscribedUserReminderService CreateReminderSut(
+        Mock<ISettingsService> settings,
+        Mock<ITelegramDirectMessageSender> sender,
+        IMemoryCache? cache = null,
+        Mock<ILocalizationService>? localization = null,
+        Mock<IUserIdentityLinkQueryService>? links = null,
+        Mock<IUserQueryService>? users = null,
+        Mock<IEmailSenderService>? email = null,
+        Mock<ISystemTransactionalEmailService>? templates = null,
+        Mock<ISentEmailLogService>? sentLog = null)
+    {
+        var loc = localization ?? new Mock<ILocalizationService>();
+        loc.Setup(l => l.GetTextForTelegramUser(
+                FreeTierUnsubscribedUserReminderService.LocalizationKey,
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<DataGateMonitor.SharedModels.Enums.Language?>()))
+            .ReturnsAsync("📢 Please subscribe to {channel}\n{channelUrl}");
+
+        return new FreeTierUnsubscribedUserReminderService(
+            settings.Object,
+            sender.Object,
+            loc.Object,
+            (links ?? new Mock<IUserIdentityLinkQueryService>()).Object,
+            (users ?? new Mock<IUserQueryService>()).Object,
+            (email ?? new Mock<IEmailSenderService>()).Object,
+            (templates ?? new Mock<ISystemTransactionalEmailService>()).Object,
+            (sentLog ?? new Mock<ISentEmailLogService>()).Object,
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
+            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "datagateapp" }),
+            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+    }
+
     [Fact]
     public async Task Reminder_WhenDisabled_DoesNotSend()
     {
         var settings = new Mock<ISettingsService>();
         SetupBoolSetting(settings, FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders, false);
-
         var sender = new Mock<ITelegramDirectMessageSender>(MockBehavior.Strict);
-        var sut = new FreeTierUnsubscribedUserReminderService(
-            settings.Object,
-            sender.Object,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
-            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+        var sut = CreateReminderSut(settings, sender);
 
         await sut.TryRemindAsync(1, "test", CancellationToken.None);
         sender.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public async Task Reminder_WhenEnabled_SendsOncePerCooldown()
+    public async Task Reminder_WhenEnabled_SendsLocalizedTextOncePerCooldown()
     {
         var settings = new Mock<ISettingsService>();
         SetupBoolSetting(settings, FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders, true);
-
         var sender = new Mock<ITelegramDirectMessageSender>();
         sender.Setup(s => s.TrySendMessageAsync(42, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var sut = new FreeTierUnsubscribedUserReminderService(
-            settings.Object,
-            sender.Object,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
-            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
-
+        var sut = CreateReminderSut(settings, sender);
         await sut.TryRemindAsync(42, "first", CancellationToken.None);
         await sut.TryRemindAsync(42, "second", CancellationToken.None);
 
         sender.Verify(
-            s => s.TrySendMessageAsync(42, It.Is<string>(t => t.Contains("@DataGateVPNBot")), It.IsAny<CancellationToken>()),
+            s => s.TrySendMessageAsync(
+                42,
+                It.Is<string>(t => t.Contains("@datagateapp") && t.Contains("https://t.me/datagateapp")),
+                It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     [Fact]
-    public async Task Reminder_WhenSettingTypeMissing_DefaultsToEnabledAndSends()
+    public async Task ForceRemind_Telegram_ResolvesUserIdAndSendsEvenWhenDisabled()
     {
-        var settings = new Mock<ISettingsService>();
-        settings.Setup(s => s.GetValueAsync<string>(
-                $"{FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders}_Type",
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync((string?)null);
-
+        var settings = new Mock<ISettingsService>(MockBehavior.Strict);
         var sender = new Mock<ITelegramDirectMessageSender>();
-        sender.Setup(s => s.TrySendMessageAsync(7, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        sender.Setup(s => s.TrySendMessageAsync(439938925, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
-        var sut = new FreeTierUnsubscribedUserReminderService(
-            settings.Object,
-            sender.Object,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
-            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+        var links = new Mock<IUserIdentityLinkQueryService>();
+        links.Setup(l => l.GetListByUserId(22, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new UserIdentityLink { Provider = "telegram", ExternalId = "439938925", UserId = 22 },
+                new UserIdentityLink { Provider = "google", ExternalId = "g", UserId = 22 },
+            ]);
 
-        await sut.TryRemindAsync(7, "default-on", CancellationToken.None);
+        var sut = CreateReminderSut(settings, sender, links: links);
+        var result = await sut.ForceRemindAsync("22", FreeTierChannelSubscribeRemindChannel.Telegram, CancellationToken.None);
 
-        sender.Verify(
-            s => s.TrySendMessageAsync(7, It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Once);
+        Assert.True(result.Success);
+        Assert.Equal(FreeTierChannelSubscribeRemindChannel.Telegram, result.Channel);
+        Assert.Contains("439938925", result.Message);
+        settings.VerifyNoOtherCalls();
     }
 
     [Fact]
-    public async Task Reminder_WhenSendFails_DoesNotSetCooldown()
+    public async Task ForceRemind_Email_SendsAndLogs()
     {
-        var settings = new Mock<ISettingsService>();
-        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders, true);
+        var settings = new Mock<ISettingsService>(MockBehavior.Strict);
+        var users = new Mock<IUserQueryService>();
+        users.Setup(u => u.GetById(150, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 150, DisplayName = "Tatyana", Email = "t@example.com" });
 
-        var sender = new Mock<ITelegramDirectMessageSender>();
-        sender.Setup(s => s.TrySendMessageAsync(9, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+        var templates = new Mock<ISystemTransactionalEmailService>();
+        templates.Setup(t => t.GetFreeTierChannelSubscribeReminderAsync(
+                "Tatyana", "@datagateapp", "https://t.me/datagateapp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(("subj", "<html>body</html>"));
 
-        var sut = new FreeTierUnsubscribedUserReminderService(
-            settings.Object,
-            sender.Object,
-            new MemoryCache(new MemoryCacheOptions()),
-            Options.Create(new TelegramChannelSettings { RequiredChannelUsername = "DataGateVPNBot" }),
-            Mock.Of<ILogger<FreeTierUnsubscribedUserReminderService>>());
+        var email = new Mock<IEmailSenderService>();
+        var sentLog = new Mock<ISentEmailLogService>();
 
-        await sut.TryRemindAsync(9, "fail-1", CancellationToken.None);
-        await sut.TryRemindAsync(9, "fail-2", CancellationToken.None);
+        var sut = CreateReminderSut(
+            settings,
+            new Mock<ITelegramDirectMessageSender>(MockBehavior.Strict),
+            users: users,
+            email: email,
+            templates: templates,
+            sentLog: sentLog);
 
-        sender.Verify(
-            s => s.TrySendMessageAsync(9, It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Exactly(2));
+        var result = await sut.ForceRemindAsync("150", FreeTierChannelSubscribeRemindChannel.Email, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.Equal("t@example.com", result.Email);
+        email.Verify(e => e.SendAsync("t@example.com", "subj", "<html>body</html>", It.IsAny<CancellationToken>()), Times.Once);
+        sentLog.Verify(l => l.LogAsync(150, "t@example.com", "subj", "<html>body</html>", true, null, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public void Digest_BuildMessage_IncludesOnlineUsers()
+    public async Task ForceRemind_Email_WhenNoEmail_FailsWithoutSend()
+    {
+        var users = new Mock<IUserQueryService>();
+        users.Setup(u => u.GetById(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = 7, DisplayName = "NoMail", Email = null });
+        var email = new Mock<IEmailSenderService>(MockBehavior.Strict);
+
+        var sut = CreateReminderSut(
+            new Mock<ISettingsService>(MockBehavior.Strict),
+            new Mock<ITelegramDirectMessageSender>(MockBehavior.Strict),
+            users: users,
+            email: email);
+
+        var result = await sut.ForceRemindAsync("7", FreeTierChannelSubscribeRemindChannel.Email, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("no email", result.Message, StringComparison.OrdinalIgnoreCase);
+        email.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void Digest_BuildMessage_IncludesProvidersAndEmail()
     {
         var text = FreeTierUnsubscribedVpnUsersDailyDigestService.BuildDigestMessage(
             new DateOnly(2026, 8, 9),
-            1,
             [
+                new FreeTierEnforcementCandidateDto
+                {
+                    UserId = 150,
+                    DisplayName = "Татьяна Еленина",
+                    Email = "tatyana@example.com",
+                    IdentityProviders = ["google"],
+                    VpnServerName = "Helsinki 3",
+                    IsMergedAccount = false,
+                },
                 new FreeTierEnforcementCandidateDto
                 {
                     UserId = 7,
                     DisplayName = "Alice",
+                    Email = "alice@gmail.com",
+                    IdentityProviders = ["google", "telegram"],
                     TelegramId = 111,
                     VpnServerName = "eu1",
                     IsMergedAccount = true,
-                    IsChannelSubscribed = false,
-                    IsConnected = true,
                 },
             ]);
 
-        Assert.Contains("Currently online: 1", text);
-        Assert.Contains("#7 Alice", text);
-        Assert.Contains("TG:111", text);
-        Assert.Contains("eu1", text);
-        Assert.Contains("merged", text);
+        Assert.Contains("#150 Татьяна Еленина | google | tatyana@example.com | TG:— | Helsinki 3", text);
+        Assert.Contains("#7 Alice | google+telegram | alice@gmail.com | TG:111 | eu1", text);
+        Assert.Contains("/remind_channel_email", text);
     }
 
     [Fact]
-    public async Task Digest_WhenDisabled_DoesNotQueryOverviewOrSend()
+    public async Task Digest_BuildDigestAsync_ReturnsTextAndCandidates()
     {
-        var settings = new Mock<ISettingsService>();
-        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest, false);
-
-        var overview = new Mock<IFreeTierEnforcementOverviewService>(MockBehavior.Strict);
-        var sender = new Mock<ITelegramDirectMessageSender>(MockBehavior.Strict);
-        var telegramUsers = new Mock<ITelegramUserService>(MockBehavior.Strict);
-
-        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
-            settings.Object,
-            overview.Object,
-            telegramUsers.Object,
-            sender.Object,
-            new MemoryCache(new MemoryCacheOptions()),
-            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
-
-        await sut.TrySendDailyDigestAsync(CancellationToken.None);
-
-        overview.VerifyNoOtherCalls();
-        sender.VerifyNoOtherCalls();
-        telegramUsers.VerifyNoOtherCalls();
-    }
-
-    [Fact]
-    public async Task Digest_WhenEnabled_SendsToAdmins_AndSkipsSecondCallSameDay()
-    {
-        var settings = new Mock<ISettingsService>();
-        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest, true);
-
         var overview = new Mock<IFreeTierEnforcementOverviewService>();
         overview.Setup(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GetFreeTierEnforcementCandidatesResponse
@@ -185,87 +218,37 @@ public class FreeTierUnsubscribedNotificationsTests
                     {
                         UserId = 1,
                         DisplayName = "Bob",
+                        Email = "bob@example.com",
+                        IdentityProviders = ["google"],
                         IsConnected = true,
-                        IsChannelSubscribed = false,
-                        TelegramId = 99,
                     },
                 ],
-                TotalCount = 1,
-                ConnectedCount = 1,
-            });
-
-        var telegramUsers = new Mock<ITelegramUserService>();
-        telegramUsers.Setup(t => t.GetAdminsAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync([new TelegramBotUser { TelegramId = 1001, IsAdmin = true }]);
-
-        var sender = new Mock<ITelegramDirectMessageSender>();
-        sender.Setup(s => s.TrySendMessageAsync(1001, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
-            settings.Object,
-            overview.Object,
-            telegramUsers.Object,
-            sender.Object,
-            new MemoryCache(new MemoryCacheOptions()),
-            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
-
-        await sut.TrySendDailyDigestAsync(CancellationToken.None);
-        await sut.TrySendDailyDigestAsync(CancellationToken.None);
-
-        overview.Verify(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()), Times.Once);
-        sender.Verify(
-            s => s.TrySendMessageAsync(1001, It.Is<string>(t => t.Contains("Bob")), It.IsAny<CancellationToken>()),
-            Times.Once);
-    }
-
-    [Fact]
-    public async Task Digest_BuildDigestTextAsync_IgnoresEnableFlag()
-    {
-        var settings = new Mock<ISettingsService>(MockBehavior.Strict);
-        var overview = new Mock<IFreeTierEnforcementOverviewService>();
-        overview.Setup(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new GetFreeTierEnforcementCandidatesResponse
-            {
-                Candidates = [],
-                TotalCount = 0,
-                ConnectedCount = 0,
             });
 
         var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
-            settings.Object,
+            Mock.Of<ISettingsService>(),
             overview.Object,
             Mock.Of<ITelegramUserService>(),
             Mock.Of<ITelegramDirectMessageSender>(),
             new MemoryCache(new MemoryCacheOptions()),
             Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
 
-        var text = await sut.BuildDigestTextAsync(CancellationToken.None);
+        var digest = await sut.BuildDigestAsync(CancellationToken.None);
 
-        Assert.Contains("Currently online: 0", text);
-        overview.Verify(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()), Times.Once);
-        settings.VerifyNoOtherCalls();
+        Assert.Contains("Bob", digest.Text);
+        Assert.Contains("google", digest.Text);
+        Assert.Single(digest.Candidates);
+        Assert.Equal("bob@example.com", digest.Candidates[0].Email);
     }
 
     [Fact]
-    public async Task Digest_WhenAlreadySentToday_Skips()
+    public void ApplyPlaceholders_ReplacesChannelAndUrl()
     {
-        var settings = new Mock<ISettingsService>();
-        SetupBoolSetting(settings, FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest, true);
+        var text = FreeTierUnsubscribedUserReminderService.ApplyPlaceholders(
+            "go to {channel} via {channelUrl}",
+            "@datagateapp",
+            "https://t.me/datagateapp");
 
-        var cache = new MemoryCache(new MemoryCacheOptions());
-        cache.Set("free-tier-unsub-admin-digest:last-utc-date", DateOnly.FromDateTime(DateTime.UtcNow));
-
-        var overview = new Mock<IFreeTierEnforcementOverviewService>(MockBehavior.Strict);
-        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
-            settings.Object,
-            overview.Object,
-            Mock.Of<ITelegramUserService>(),
-            Mock.Of<ITelegramDirectMessageSender>(),
-            cache,
-            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
-
-        await sut.TrySendDailyDigestAsync(CancellationToken.None);
-        overview.VerifyNoOtherCalls();
+        Assert.Equal("go to @datagateapp via https://t.me/datagateapp", text);
     }
 }

--- a/DataGateMonitor.Tests/Services/Users/FreeTierUnsubscribedNotificationsTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/FreeTierUnsubscribedNotificationsTests.cs
@@ -203,6 +203,41 @@ public class FreeTierUnsubscribedNotificationsTests
         Assert.Contains("#150 Татьяна Еленина | google | tatyana@example.com | TG:— | Helsinki 3", text);
         Assert.Contains("#7 Alice | google+telegram | alice@gmail.com | TG:111 | eu1", text);
         Assert.Contains("/remind_channel_email", text);
+        Assert.Contains("TG #id", text);
+    }
+
+    [Fact]
+    public async Task Digest_LiveFetch_MarksDailySatisfied_SoBackgroundSkips()
+    {
+        var overview = new Mock<IFreeTierEnforcementOverviewService>();
+        overview.Setup(o => o.GetUnsubscribedConnectedAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetFreeTierEnforcementCandidatesResponse { Candidates = [] });
+
+        var sender = new Mock<ITelegramDirectMessageSender>(MockBehavior.Strict);
+        var telegramUsers = new Mock<ITelegramUserService>();
+        telegramUsers.Setup(t => t.GetAdminsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new DataGateMonitor.Models.TelegramBotUser { TelegramId = 1 }]);
+
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetValueAsync<string>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bool");
+        settings.Setup(s => s.GetValueAsync<bool>(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new FreeTierUnsubscribedVpnUsersDailyDigestService(
+            settings.Object,
+            overview.Object,
+            telegramUsers.Object,
+            sender.Object,
+            cache,
+            Mock.Of<ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService>>());
+
+        _ = await sut.BuildDigestAsync(CancellationToken.None);
+        sut.MarkDailyDigestSatisfiedForToday();
+        await sut.TrySendDailyDigestAsync(CancellationToken.None);
+
+        sender.VerifyNoOtherCalls();
     }
 
     [Fact]

--- a/DataGateMonitor.Tests/Services/Users/TelegramAccountLinkServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/TelegramAccountLinkServiceTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.Services.TelegramBot.Interfaces;
 using DataGateMonitor.Services.Users;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
@@ -51,11 +52,17 @@ public class TelegramAccountLinkServiceTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new MergeTelegramGoogleUsersResponse { SurvivorUserId = 10, MergedUserId = 20 });
 
+        var adminAlert = new Mock<ITelegramAdminAlertService>();
+        adminAlert
+            .Setup(a => a.NotifyAccountsLinkedAsync(It.IsAny<TelegramAccountsLinkedAlert>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
         var sut = CreateSut(
             userId: 20,
             telegramUserId: 10,
             links: [new UserIdentityLink { Provider = AuthIdentityProviders.Google, ExternalId = "g-sub" }],
-            merge: merge.Object);
+            merge: merge.Object,
+            adminAlert: adminAlert);
 
         var issued = await sut.RequestLinkCodeFromBotAsync(DefaultTelegramId, CancellationToken.None);
         var result = await sut.CompleteLinkFromAppAsync(20, issued.Code, CancellationToken.None);
@@ -65,6 +72,15 @@ public class TelegramAccountLinkServiceTests
             m => m.MergeTelegramGoogleAsync(
                 It.IsAny<MergeTelegramGoogleUsersRequest>(),
                 20,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        adminAlert.Verify(
+            a => a.NotifyAccountsLinkedAsync(
+                It.Is<TelegramAccountsLinkedAlert>(x =>
+                    x.TelegramId == DefaultTelegramId
+                    && x.LinkedProviderLabel == "Google"
+                    && x.SurvivorUserId == 10
+                    && x.MergedUserId == 20),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -162,6 +178,8 @@ public class TelegramAccountLinkServiceTests
             userQuery.Object,
             linkQuery.Object,
             merge.Object,
+            Mock.Of<ITelegramUserService>(),
+            Mock.Of<ITelegramAdminAlertService>(),
             config.Object,
             Mock.Of<ILogger<TelegramAccountLinkService>>());
 
@@ -368,7 +386,9 @@ public class TelegramAccountLinkServiceTests
             ]);
 
         var sut = new TelegramAccountLinkService(
-            cache, userQuery.Object, linkQuery.Object, Mock.Of<IUserMergeService>(), config.Object,
+            cache, userQuery.Object, linkQuery.Object, Mock.Of<IUserMergeService>(),
+            Mock.Of<ITelegramUserService>(), Mock.Of<ITelegramAdminAlertService>(),
+            config.Object,
             Mock.Of<ILogger<TelegramAccountLinkService>>());
 
         var result = await sut.CompleteLinkByCodeAsync("STALECOD", DefaultTelegramId, CancellationToken.None);
@@ -391,7 +411,9 @@ public class TelegramAccountLinkServiceTests
             .ReturnsAsync((UserIdentityLink?)null);
 
         var sut = new TelegramAccountLinkService(
-            cache, userQuery.Object, linkQuery.Object, Mock.Of<IUserMergeService>(), config.Object,
+            cache, userQuery.Object, linkQuery.Object, Mock.Of<IUserMergeService>(),
+            Mock.Of<ITelegramUserService>(), Mock.Of<ITelegramAdminAlertService>(),
+            config.Object,
             Mock.Of<ILogger<TelegramAccountLinkService>>());
 
         var result = await sut.CompleteLinkByCodeAsync("NOSUCHCD", DefaultTelegramId, CancellationToken.None);
@@ -430,7 +452,9 @@ public class TelegramAccountLinkServiceTests
             ]);
 
         var sut = new TelegramAccountLinkService(
-            cache, userQuery.Object, linkQuery.Object, Mock.Of<IUserMergeService>(), config.Object,
+            cache, userQuery.Object, linkQuery.Object, Mock.Of<IUserMergeService>(),
+            Mock.Of<ITelegramUserService>(), Mock.Of<ITelegramAdminAlertService>(),
+            config.Object,
             Mock.Of<ILogger<TelegramAccountLinkService>>());
 
         var issued = await sut.RequestLinkCodeAsync(dashboardUserId, null, CancellationToken.None);
@@ -448,7 +472,8 @@ public class TelegramAccountLinkServiceTests
         IReadOnlyList<UserIdentityLink>? survivorLinks = null,
         User? survivorUser = null,
         IMemoryCache? cache = null,
-        IUserMergeService? merge = null)
+        IUserMergeService? merge = null,
+        Mock<ITelegramAdminAlertService>? adminAlert = null)
     {
         cache ??= new MemoryCache(new MemoryCacheOptions());
         var userQuery = new Mock<IUserQueryService>();
@@ -457,6 +482,16 @@ public class TelegramAccountLinkServiceTests
         var mergeService = merge ?? mergeMock!.Object;
         var config = new Mock<IConfiguration>();
         config.Setup(c => c.GetSection(It.IsAny<string>())).Returns(Mock.Of<IConfigurationSection>());
+
+        adminAlert ??= new Mock<ITelegramAdminAlertService>();
+        adminAlert
+            .Setup(a => a.NotifyAccountsLinkedAsync(It.IsAny<TelegramAccountsLinkedAlert>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var telegramUsers = new Mock<ITelegramUserService>();
+        telegramUsers
+            .Setup(s => s.GetUserByTelegramIdAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TelegramBotUser?)null);
 
         var resolvedTelegramUserId = telegramUserId > 0 ? telegramUserId : userId;
         var resolvedSurvivorLinks = survivorLinks ??
@@ -470,7 +505,14 @@ public class TelegramAccountLinkServiceTests
         ];
 
         userQuery.Setup(q => q.GetById(userId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new User { Id = userId, IsBlocked = false });
+            .ReturnsAsync(new User
+            {
+                Id = userId,
+                IsBlocked = false,
+                DisplayName = $"user-{userId}",
+                Email = $"user{userId}@example.com",
+                AvatarUrl = "https://example.com/avatar.jpg",
+            });
         if (resolvedTelegramUserId != userId)
         {
             userQuery.Setup(q => q.GetById(resolvedTelegramUserId, It.IsAny<CancellationToken>()))
@@ -506,6 +548,8 @@ public class TelegramAccountLinkServiceTests
             userQuery.Object,
             linkQuery.Object,
             mergeService,
+            telegramUsers.Object,
+            adminAlert.Object,
             config.Object,
             Mock.Of<ILogger<TelegramAccountLinkService>>());
     }

--- a/DataGateMonitor.Tests/Services/Users/UserPasswordHistoryServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/UserPasswordHistoryServiceTests.cs
@@ -1,0 +1,62 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.UserCredentialTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.DataBase.UnitOfWork;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Others.Notifications;
+using DataGateMonitor.Services.Users;
+using DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.Users;
+
+public class UserPasswordHistoryServiceTests
+{
+    private static UserPasswordHistoryService CreateSut(
+        Mock<IUserCredentialQueryService>? credentials = null)
+    {
+        return new UserPasswordHistoryService(
+            Mock.Of<IUnitOfWork>(),
+            (credentials ?? new Mock<IUserCredentialQueryService>()).Object,
+            Mock.Of<IUserQueryService>(),
+            Mock.Of<ICommandService<UserCredential, int>>(),
+            Mock.Of<ICommandService<UserPasswordHistory, int>>(),
+            Mock.Of<IPasswordHasher<User>>(),
+            Mock.Of<IAppNotificationFacade>(),
+            NullLogger<UserPasswordHistoryService>.Instance);
+    }
+
+    [Fact]
+    public async Task AdminSetPasswordAsync_WhenPasswordTooShort_Fails()
+    {
+        var sut = CreateSut();
+        var result = await sut.AdminSetPasswordAsync(
+            1,
+            2,
+            new AdminSetUserPasswordRequest { NewPassword = "short" },
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("8 characters", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AdminSetPasswordAsync_WhenNoCredential_Fails()
+    {
+        var credentials = new Mock<IUserCredentialQueryService>();
+        credentials.Setup(c => c.GetByUserId(9, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserCredential?)null);
+
+        var sut = CreateSut(credentials);
+        var result = await sut.AdminSetPasswordAsync(
+            9,
+            2,
+            new AdminSetUserPasswordRequest { NewPassword = "longenough" },
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Contains("no password credential", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DataGateMonitor.Tests/Services/Users/UserServiceTests.cs
+++ b/DataGateMonitor.Tests/Services/Users/UserServiceTests.cs
@@ -128,8 +128,11 @@ public class UserServiceTests
             Items = users
         };
         _userQuery.Setup(q => q.GetPage(It.Is<GetAllUsersRequest>(r => r.Page == 1 && r.PageSize == 20), It.IsAny<CancellationToken>())).ReturnsAsync(paged);
-        _userIdentityLinkQuery.Setup(q => q.GetByUserId(1, It.IsAny<CancellationToken>())).ReturnsAsync((UserIdentityLink?)null);
-        _userIdentityLinkQuery.Setup(q => q.GetByUserId(2, It.IsAny<CancellationToken>())).ReturnsAsync((UserIdentityLink?)null);
+        _userIdentityLinkQuery
+            .Setup(q => q.GetFirstByUserIds(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.SequenceEqual(new[] { 1, 2 })),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, UserIdentityLink>());
 
         var result = await _sut.GetUsersPage(new GetAllUsersRequest { Page = 1, PageSize = 20 }, CancellationToken.None);
 
@@ -140,10 +143,64 @@ public class UserServiceTests
         result.Users.Should().HaveCount(2);
         result.Users![0].Id.Should().Be(1);
         result.Users[0].DisplayName.Should().Be("U1");
+        result.Users[0].Provider.Should().BeEmpty();
+        result.Users[0].ExternalId.Should().BeEmpty();
+        result.Users[0].ProviderRowId.Should().BeNull();
         result.Users[1].Id.Should().Be(2);
         result.Users[1].DisplayName.Should().Be("U2");
         _userQuery.VerifyAll();
-        _userIdentityLinkQuery.Verify(q => q.GetByUserId(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _userIdentityLinkQuery.Verify(
+            q => q.GetFirstByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _userIdentityLinkQuery.Verify(
+            q => q.GetByUserId(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetUsersPage_EnrichesDtosFromBatchedIdentityLinks()
+    {
+        var users = new List<User>
+        {
+            new() { Id = 1, DisplayName = "U1", CreateDate = DateTimeOffset.UtcNow, LastUpdate = DateTimeOffset.UtcNow },
+            new() { Id = 2, DisplayName = "U2", CreateDate = DateTimeOffset.UtcNow, LastUpdate = DateTimeOffset.UtcNow }
+        };
+        var paged = new PagedResponse<User>
+        {
+            Page = 1,
+            PageSize = 20,
+            TotalCount = 2,
+            Items = users
+        };
+        var links = new Dictionary<int, UserIdentityLink>
+        {
+            [1] = new()
+            {
+                Id = 10,
+                UserId = 1,
+                Provider = "google",
+                ExternalId = "g-1",
+                ProviderRowId = 55,
+                CreateDate = DateTimeOffset.UtcNow,
+                LastUpdate = DateTimeOffset.UtcNow
+            }
+        };
+        _userQuery.Setup(q => q.GetPage(It.IsAny<GetAllUsersRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(paged);
+        _userIdentityLinkQuery
+            .Setup(q => q.GetFirstByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(links);
+
+        var result = await _sut.GetUsersPage(new GetAllUsersRequest { Page = 1, PageSize = 20 }, CancellationToken.None);
+
+        result.Users![0].Provider.Should().Be("google");
+        result.Users[0].ExternalId.Should().Be("g-1");
+        result.Users[0].ProviderRowId.Should().Be(55);
+        result.Users[1].Provider.Should().BeEmpty();
+        result.Users[1].ExternalId.Should().BeEmpty();
+        result.Users[1].ProviderRowId.Should().BeNull();
+        _userIdentityLinkQuery.Verify(
+            q => q.GetFirstByUserIds(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -349,6 +406,11 @@ public class UserServiceTests
             Items = [],
         };
         _userQuery.Setup(q => q.GetPage(It.Is<GetAllUsersRequest>(r => r.Page == 1 && r.PageSize == 500), It.IsAny<CancellationToken>())).ReturnsAsync(paged);
+        _userIdentityLinkQuery
+            .Setup(q => q.GetFirstByUserIds(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 0),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, UserIdentityLink>());
 
         var result = await _sut.GetUsersPage(new GetAllUsersRequest { Page = 0, PageSize = 9999 }, CancellationToken.None);
 

--- a/DataGateMonitor.Tests/Services/VpnAccess/VpnServerQuotaPlanAccessGuardTests.cs
+++ b/DataGateMonitor.Tests/Services/VpnAccess/VpnServerQuotaPlanAccessGuardTests.cs
@@ -1,0 +1,83 @@
+using DataGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
+using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.VpnAccess;
+using FluentAssertions;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.VpnAccess;
+
+public sealed class VpnServerQuotaPlanAccessGuardTests
+{
+    [Fact]
+    public async Task Ensure_WhenUserIsAdmin_SkipsAllowlist()
+    {
+        const string externalId = "admin-ext";
+        const int userId = 7;
+        const int vpnServerId = 99;
+
+        var identity = new Mock<IUserIdentityLinkQueryService>(MockBehavior.Strict);
+        identity.Setup(q => q.GetByExternalId(externalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserIdentityLink { UserId = userId, ExternalId = externalId });
+
+        var users = new Mock<IUserQueryService>(MockBehavior.Strict);
+        users.Setup(q => q.GetById(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = userId, IsAdmin = true });
+
+        var plans = new Mock<IUserQuotaPlanQueryService>(MockBehavior.Strict);
+        var allowlist = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+
+        var sut = new VpnServerQuotaPlanAccessGuard(
+            identity.Object,
+            plans.Object,
+            allowlist.Object,
+            users.Object);
+
+        await sut.Invoking(s => s.EnsureTargetUserMayUseServerAsync(externalId, vpnServerId, CancellationToken.None))
+            .Should().NotThrowAsync();
+
+        plans.Verify(
+            q => q.GetActiveByUserId(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        allowlist.Verify(
+            q => q.GetByQuotaPlanIdAndServerId(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Ensure_WhenNonAdminPlanDeniesServer_Throws()
+    {
+        const string externalId = "user-ext";
+        const int userId = 8;
+        const int planId = 3;
+        const int vpnServerId = 55;
+
+        var identity = new Mock<IUserIdentityLinkQueryService>(MockBehavior.Strict);
+        identity.Setup(q => q.GetByExternalId(externalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserIdentityLink { UserId = userId, ExternalId = externalId });
+
+        var users = new Mock<IUserQueryService>(MockBehavior.Strict);
+        users.Setup(q => q.GetById(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = userId, IsAdmin = false });
+
+        var plans = new Mock<IUserQuotaPlanQueryService>(MockBehavior.Strict);
+        plans.Setup(q => q.GetActiveByUserId(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserQuotaPlan { UserId = userId, QuotaPlanId = planId });
+
+        var allowlist = new Mock<IQuotaPlanAllowedServerQueryService>(MockBehavior.Strict);
+        allowlist.Setup(q => q.GetByQuotaPlanIdAndServerId(planId, vpnServerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((QuotaPlanAllowedServer?)null);
+
+        var sut = new VpnServerQuotaPlanAccessGuard(
+            identity.Object,
+            plans.Object,
+            allowlist.Object,
+            users.Object);
+
+        await sut.Invoking(s => s.EnsureTargetUserMayUseServerAsync(externalId, vpnServerId, CancellationToken.None))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(VpnServerAccessErrorKeys.NotAllowedByQuotaPlan);
+    }
+}

--- a/DataGateMonitor.Tests/Services/XrayNode/XrayVpnServerStatusLogServicePublicIpTests.cs
+++ b/DataGateMonitor.Tests/Services/XrayNode/XrayVpnServerStatusLogServicePublicIpTests.cs
@@ -139,4 +139,35 @@ public class XrayVpnServerStatusLogServicePublicIpTests
         Assert.Equal("198.51.100.1", existing.ServerRemoteIp);
         _statusCmd.Verify(c => c.Update(existing, true, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task TryAppendOrUpdateAsync_WhenAllSourcesUnusable_UsesDash()
+    {
+        _statusQuery
+            .Setup(q => q.GetBySessionIdAndVpnServerId(It.IsAny<Guid>(), 11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerStatusLog?)null);
+        _config.Setup(c => c.GetByVpnServerIdId(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServerOvpnFileConfig { VpnServerId = 11, VpnServerIp = "127.0.0.1" });
+        _publicIp.Setup(p => p.GetAsync(11, VpnServerType.Xray, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("0.0.0.0");
+
+        VpnServerStatusLog? saved = null;
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<VpnServerStatusLog, bool, CancellationToken>((e, _, _) => saved = e)
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+
+        await CreateSut().TryAppendOrUpdateAsync(
+            new VpnServer
+            {
+                Id = 11,
+                ServerName = "Xray-1",
+                ApiUrl = "not-a-url",
+                ServerType = VpnServerType.Xray
+            },
+            Payload(),
+            CancellationToken.None);
+
+        Assert.Equal("-", saved!.ServerRemoteIp);
+    }
 }

--- a/DataGateMonitor.Tests/Services/XrayNode/XrayVpnServerStatusLogServicePublicIpTests.cs
+++ b/DataGateMonitor.Tests/Services/XrayNode/XrayVpnServerStatusLogServicePublicIpTests.cs
@@ -1,0 +1,142 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerStatusLogTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Models.XrayNode;
+using DataGateMonitor.Services.Helpers;
+using DataGateMonitor.Services.XrayNode;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace DataGateMonitor.Tests.Services.XrayNode;
+
+public class XrayVpnServerStatusLogServicePublicIpTests
+{
+    private readonly Mock<ILogger<XrayVpnServerStatusLogService>> _logger = new();
+    private readonly Mock<IVpnServerOvpnFileConfigQueryService> _config = new();
+    private readonly Mock<IVpnNodePublicIpLookup> _publicIp = new();
+    private readonly Mock<IVpnServerStatusLogQueryService> _statusQuery = new();
+    private readonly Mock<ICommandService<VpnServerStatusLog, int>> _statusCmd = new();
+
+    private XrayVpnServerStatusLogService CreateSut() => new(
+        _logger.Object,
+        _config.Object,
+        _publicIp.Object,
+        _statusQuery.Object,
+        _statusCmd.Object);
+
+    private static VpnServer Server() => new()
+    {
+        Id = 11,
+        ServerName = "Xray-1",
+        ApiUrl = "https://x1.datagateapp.com/",
+        ServerType = VpnServerType.Xray
+    };
+
+    private static XrayNodeClientsResponse Payload() => new()
+    {
+        Clients = [],
+        Server = new XrayNodeServerSnapshotDto
+        {
+            UpSince = DateTimeOffset.UtcNow.AddHours(-2),
+            Version = "1.8.0",
+            ServerLocalIp = "10.0.0.1",
+            BytesIn = 1,
+            BytesOut = 2
+        }
+    };
+
+    [Fact]
+    public async Task TryAppendOrUpdateAsync_UsesNodePublicIp()
+    {
+        _statusQuery
+            .Setup(q => q.GetBySessionIdAndVpnServerId(It.IsAny<Guid>(), 11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerStatusLog?)null);
+        _config.Setup(c => c.GetByVpnServerIdId(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServerOvpnFileConfig { VpnServerId = 11, VpnServerIp = "1.2.3.4" });
+        _publicIp.Setup(p => p.GetAsync(11, VpnServerType.Xray, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("203.0.113.77");
+
+        VpnServerStatusLog? saved = null;
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<VpnServerStatusLog, bool, CancellationToken>((e, _, _) => saved = e)
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+
+        await CreateSut().TryAppendOrUpdateAsync(Server(), Payload(), CancellationToken.None);
+
+        Assert.Equal("203.0.113.77", saved!.ServerRemoteIp);
+        Assert.Equal("10.0.0.1", saved.ServerLocalIp);
+    }
+
+    [Fact]
+    public async Task TryAppendOrUpdateAsync_WhenLookupReturnsNull_FallsBackToConfigIp()
+    {
+        _statusQuery
+            .Setup(q => q.GetBySessionIdAndVpnServerId(It.IsAny<Guid>(), 11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerStatusLog?)null);
+        _config.Setup(c => c.GetByVpnServerIdId(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new VpnServerOvpnFileConfig { VpnServerId = 11, VpnServerIp = "9.9.9.9" });
+        _publicIp.Setup(p => p.GetAsync(11, VpnServerType.Xray, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        VpnServerStatusLog? saved = null;
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<VpnServerStatusLog, bool, CancellationToken>((e, _, _) => saved = e)
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+
+        await CreateSut().TryAppendOrUpdateAsync(Server(), Payload(), CancellationToken.None);
+
+        Assert.Equal("9.9.9.9", saved!.ServerRemoteIp);
+    }
+
+    [Fact]
+    public async Task TryAppendOrUpdateAsync_WhenNoPublicIpOrConfig_FallsBackToApiUrlHost()
+    {
+        _statusQuery
+            .Setup(q => q.GetBySessionIdAndVpnServerId(It.IsAny<Guid>(), 11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerStatusLog?)null);
+        _config.Setup(c => c.GetByVpnServerIdId(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerOvpnFileConfig?)null);
+        _publicIp.Setup(p => p.GetAsync(11, VpnServerType.Xray, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        VpnServerStatusLog? saved = null;
+        _statusCmd
+            .Setup(c => c.Add(It.IsAny<VpnServerStatusLog>(), true, It.IsAny<CancellationToken>()))
+            .Callback<VpnServerStatusLog, bool, CancellationToken>((e, _, _) => saved = e)
+            .ReturnsAsync((VpnServerStatusLog e, bool _, CancellationToken _) => e);
+
+        await CreateSut().TryAppendOrUpdateAsync(Server(), Payload(), CancellationToken.None);
+
+        Assert.Equal("x1.datagateapp.com", saved!.ServerRemoteIp);
+    }
+
+    [Fact]
+    public async Task TryAppendOrUpdateAsync_UpdatesExistingRow()
+    {
+        var existing = new VpnServerStatusLog
+        {
+            Id = 5,
+            VpnServerId = 11,
+            ServerRemoteIp = "old"
+        };
+        _statusQuery
+            .Setup(q => q.GetBySessionIdAndVpnServerId(It.IsAny<Guid>(), 11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        _config.Setup(c => c.GetByVpnServerIdId(11, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((VpnServerOvpnFileConfig?)null);
+        _publicIp.Setup(p => p.GetAsync(11, VpnServerType.Xray, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("198.51.100.1");
+        _statusCmd
+            .Setup(c => c.Update(existing, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        await CreateSut().TryAppendOrUpdateAsync(Server(), Payload(), CancellationToken.None);
+
+        Assert.Equal("198.51.100.1", existing.ServerRemoteIp);
+        _statusCmd.Verify(c => c.Update(existing, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
@@ -14,6 +14,7 @@ using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.TelegramLogin;
 using DataGateMonitor.Services.Api.Auth.Totp;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
 using DataGateMonitor.Services.Api.Auth.Registers;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Users;
@@ -57,6 +58,7 @@ public static class AuthServiceConfiguration
         services.AddScoped<IAdminForgotPasswordService, AdminForgotPasswordService>();
         services.AddScoped<IEmailConfirmationService, EmailConfirmationService>();
         services.AddScoped<ITelegramLoginCodeService, TelegramLoginCodeService>();
+        services.AddScoped<ITvLoginSessionService, TvLoginSessionService>();
         services.AddScoped<IAdminTotpService, AdminTotpService>();
 
         services.AddAuthorization(options =>

--- a/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
@@ -42,6 +42,8 @@ public static class AuthServiceConfiguration
         #region example google env
         // GoogleAuth:ClientId → ENV: GOOGLEAUTH__CLIENTID
         // GoogleAuth:ClientSecret → ENV: GOOGLEAUTH__CLIENTSECRET
+        // Auth:PublicWebBaseUrl → ENV: Auth__PublicWebBaseUrl  (compose / .env — public origin for TV QR /tv/link)
+        // Auth:TvLoginSessionMinutes → ENV: Auth__TvLoginSessionMinutes
         #endregion
         services.Configure<GoogleAuthSettings>(configuration.GetSection("GoogleAuth"));
         

--- a/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
@@ -62,6 +62,7 @@ public static class AuthServiceConfiguration
         services.AddScoped<IEmailConfirmationService, EmailConfirmationService>();
         services.AddScoped<ITelegramLoginCodeService, TelegramLoginCodeService>();
         services.AddScoped<ITvLoginSessionService, TvLoginSessionService>();
+        services.AddScoped<ITvLoginAdminService, TvLoginAdminService>();
         services.AddSingleton<ITvLoginHubNotifier, TvLoginHubNotifier>();
         services.AddScoped<IAdminTotpService, AdminTotpService>();
 

--- a/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/AuthServiceConfiguration.cs
@@ -15,6 +15,7 @@ using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.TelegramLogin;
 using DataGateMonitor.Services.Api.Auth.Totp;
 using DataGateMonitor.Services.Api.Auth.TvLogin;
+using DataGateMonitor.Hubs;
 using DataGateMonitor.Services.Api.Auth.Registers;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Users;
@@ -59,6 +60,7 @@ public static class AuthServiceConfiguration
         services.AddScoped<IEmailConfirmationService, EmailConfirmationService>();
         services.AddScoped<ITelegramLoginCodeService, TelegramLoginCodeService>();
         services.AddScoped<ITvLoginSessionService, TvLoginSessionService>();
+        services.AddSingleton<ITvLoginHubNotifier, TvLoginHubNotifier>();
         services.AddScoped<IAdminTotpService, AdminTotpService>();
 
         services.AddAuthorization(options =>

--- a/DataGateMonitor/Configurations/DataBaseConfigurations.cs
+++ b/DataGateMonitor/Configurations/DataBaseConfigurations.cs
@@ -3,6 +3,7 @@ using DataGateMonitor.DataBase.Repositories;
 using DataGateMonitor.DataBase.Repositories.Interfaces;
 using DataGateMonitor.DataBase.Repositories.Queries;
 using DataGateMonitor.DataBase.UnitOfWork;
+using DataGateMonitor.Data.Interceptors;
 using DataGateMonitor.Models.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -20,10 +21,18 @@ public static class DataBaseConfigurations
         {
             logger.Information("Using EF Core in-memory database for integration tests: {DatabaseName}", inMemoryDatabaseName);
             services.AddDbContext<ApplicationDbContext>(
-                options => options.UseInMemoryDatabase(inMemoryDatabaseName),
+                (sp, options) =>
+                {
+                    options.UseInMemoryDatabase(inMemoryDatabaseName);
+                    ApplyEfDiagnostics(options, sp);
+                },
                 ServiceLifetime.Scoped);
             services.AddDbContextFactory<ApplicationDbContext>(
-                options => options.UseInMemoryDatabase(inMemoryDatabaseName),
+                (sp, options) =>
+                {
+                    options.UseInMemoryDatabase(inMemoryDatabaseName);
+                    ApplyEfDiagnostics(options, sp);
+                },
                 ServiceLifetime.Scoped);
             services.AddScoped<IRepositoryFactory, RepositoryFactory>();
             services.AddScoped<IQueryFactory, QueryFactory>();
@@ -73,7 +82,7 @@ public static class DataBaseConfigurations
         };
 
         // Scoped ApplicationDbContext
-        services.AddDbContext<ApplicationDbContext>((options) =>
+        services.AddDbContext<ApplicationDbContext>((sp, options) =>
         {
             options.UseNpgsql(
                 connectionString,
@@ -83,11 +92,11 @@ public static class DataBaseConfigurations
                 )
             );
 
-            ApplyEfDiagnostics(options);
+            ApplyEfDiagnostics(options, sp);
         }, ServiceLifetime.Scoped);
 
         // Scoped DbContextFactory
-        services.AddDbContextFactory<ApplicationDbContext>((options) =>
+        services.AddDbContextFactory<ApplicationDbContext>((sp, options) =>
         {
             options.UseNpgsql(
                 connectionString,
@@ -97,7 +106,7 @@ public static class DataBaseConfigurations
                 )
             );
 
-            ApplyEfDiagnostics(options);
+            ApplyEfDiagnostics(options, sp);
         }, ServiceLifetime.Scoped);
         
         services.AddScoped<IRepositoryFactory, RepositoryFactory>();
@@ -114,12 +123,17 @@ public static class DataBaseConfigurations
 
     /// <summary>
     /// EF query-shape advisory (e.g. First without OrderBy in projections) — Debug only to avoid Wazuh WRN noise.
+    /// Registers slow-command interceptor when available from DI.
     /// </summary>
-    private static void ApplyEfDiagnostics(DbContextOptionsBuilder options)
+    private static void ApplyEfDiagnostics(DbContextOptionsBuilder options, IServiceProvider sp)
     {
         options.ConfigureWarnings(w =>
             w.Log((CoreEventId.FirstWithoutOrderByAndFilterWarning, LogLevel.Debug)));
         options.LogTo(_ => { }, LogLevel.Warning);
+
+        var interceptor = sp.GetService<SlowDbCommandInterceptor>();
+        if (interceptor is not null)
+            options.AddInterceptors(interceptor);
     }
 }
 

--- a/DataGateMonitor/Configurations/MiddlewareConfiguration.cs
+++ b/DataGateMonitor/Configurations/MiddlewareConfiguration.cs
@@ -7,5 +7,6 @@ public static class MiddlewareConfiguration
     public static void ConfigureMiddleware(this WebApplication app)
     {
         app.UseMiddleware<GlobalExceptionMiddleware>();
+        app.UseMiddleware<RequestTimingMiddleware>();
     }
 }

--- a/DataGateMonitor/Configurations/PipelineConfiguration.cs
+++ b/DataGateMonitor/Configurations/PipelineConfiguration.cs
@@ -102,6 +102,7 @@ public static class PipelineConfiguration
         app.MapHub<OpenVpnFrontendHub>("/api/hubs/frontend");
         app.MapHub<AdminNotificationHub>("/api/hubs/admin-notify");
         app.MapHub<OpenVpnProxyTrafficFlowHub>("/api/hubs/proxy-traffic-flow");
+        app.MapHub<TvLoginHub>("/api/hubs/tv-login");
         app.MapHub<OpenVpnStatusHub>("/api/hubs/status-stream", options =>
         {
             // Default: WebSockets only — publisher sends ~every 700ms; long polling is heavy at scale.

--- a/DataGateMonitor/Configurations/QueryCommandConfiguration.cs
+++ b/DataGateMonitor/Configurations/QueryCommandConfiguration.cs
@@ -33,6 +33,7 @@ using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
 using DataGateMonitor.DataBase.Services.Query.UserRefreshTokenTable;
 using DataGateMonitor.DataBase.Services.Query.UserRoleTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
 
 namespace DataGateMonitor.Configurations;
 
@@ -88,6 +89,7 @@ public static class QueryCommandConfiguration
         services.AddScoped<IUserRefreshTokenQueryService, UserRefreshTokenQueryService>();
         
         services.AddScoped<IDeviceQueryService, DeviceQueryService>();
+        services.AddScoped<ITvLoginSessionQueryService, TvLoginSessionQueryService>();
 
 
         // Feature: overview queries

--- a/DataGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/ServiceConfiguration.cs
@@ -19,6 +19,7 @@ using DataGateMonitor.Services.UserRoles;
 using DataGateMonitor.Services.Users;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.Services.DataGateXRayManager.ClientLinks;
+using DataGateMonitor.Services.VpnAccess;
 using DataGateMonitor.Services.Api.MobileCrashIngest;
 using DataGateMonitor.Services.Api.WindowsCrashIngest;
 using DataGateMonitor.Services.Cache;
@@ -154,6 +155,7 @@ public static class ServiceConfiguration
         services.AddHttpClient();
         services.AddScoped<ICertApiClient, CertApiClient>();
         services.AddScoped<IOvpnFileApiClient, OvpnFileApiClient>();
+        services.AddScoped<IVpnServerQuotaPlanAccessGuard, VpnServerQuotaPlanAccessGuard>();
         services.AddScoped<IOvpnFileApiService, OvpnFileApiService>();
         services.AddScoped<IXrayClientLinkMicroserviceClient, XrayClientLinkMicroserviceClient>();
         services.AddScoped<IXrayClientLinkService, XrayClientLinkService>();

--- a/DataGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/ServiceConfiguration.cs
@@ -126,7 +126,12 @@ public static class ServiceConfiguration
         services.AddScoped<IVpnServerPiHoleConfigService, VpnServerPiHoleConfigService>();
         services.AddScoped<ISettingsService, SettingsService>();
         
-        services.AddScoped<IExternalIpAddressService, ExternalIpAddressService>();
+        services.AddHttpClient<IExternalIpAddressService, ExternalIpAddressService>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+        });
+        services.AddScoped<IVpnNodePublicIpLookup, VpnNodePublicIpLookup>();
+        services.AddScoped<IVpnServerClientPresenceService, VpnServerClientPresenceService>();
 
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<IUserPasswordHistoryService, UserPasswordHistoryService>();

--- a/DataGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/ServiceConfiguration.cs
@@ -79,6 +79,8 @@ public static class ServiceConfiguration
         services.AddMemoryCache();
         services.AddSingleton<IApiMemoryCacheService, ApiMemoryCacheService>();
         services.AddSingleton<IStatusCacheGenerationService, StatusCacheGenerationService>();
+        services.AddSingleton<IRedisMultiplexerConnector, StackExchangeRedisMultiplexerConnector>();
+        services.AddSingleton<IRedisDatabaseProvider, ConfigurationRedisDatabaseProvider>();
         services.AddSingleton<IConnectedClientsCounterStore, RedisConnectedClientsCounterStore>();
         services.AddSingleton<IStatusStreamLogStore, StatusStreamLogStore>();
         

--- a/DataGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/ServiceConfiguration.cs
@@ -24,6 +24,8 @@ using DataGateMonitor.Services.Api.MobileCrashIngest;
 using DataGateMonitor.Services.Api.WindowsCrashIngest;
 using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.StatusStreamLogs;
+using DataGateMonitor.Services.Performance;
+using DataGateMonitor.Data.Interceptors;
 using DataGateMonitor.Services.XrayNode;
 using System.Net;
 using System.Net.Http;
@@ -83,6 +85,9 @@ public static class ServiceConfiguration
         services.AddSingleton<IRedisDatabaseProvider, ConfigurationRedisDatabaseProvider>();
         services.AddSingleton<IConnectedClientsCounterStore, RedisConnectedClientsCounterStore>();
         services.AddSingleton<IStatusStreamLogStore, StatusStreamLogStore>();
+        services.Configure<PerformanceMonitoringOptions>(configuration.GetSection(PerformanceMonitoringOptions.SectionName));
+        services.AddSingleton<IPerformanceSampleStore, PerformanceSampleStore>();
+        services.AddSingleton<SlowDbCommandInterceptor>();
         
         services.AddScoped<IOpenVpnClientService, OpenVpnClientService>();
         services.AddScoped<IOpenVpnStateService, OpenVpnStateService>();

--- a/DataGateMonitor/Configurations/ServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/ServiceConfiguration.cs
@@ -123,6 +123,7 @@ public static class ServiceConfiguration
             services.AddHostedService<OpenVpnProxyTrafficFlowBackgroundService>();
             services.AddHostedService<TrafficDailyRollupBackgroundService>();
             services.AddHostedService<FreeTierOpenVpnSessionEnforcementBackgroundService>();
+            services.AddHostedService<FreeTierUnsubscribedVpnUsersDailyDigestBackgroundService>();
         }
 
         services.AddScoped<IVpnEventLogService, VpnEventLogService>();
@@ -149,6 +150,8 @@ public static class ServiceConfiguration
         services.AddScoped<IOpenVpnDisconnectExecutor, OpenVpnDisconnectExecutor>();
         services.AddScoped<IFreeTierEnforcementOverviewService, FreeTierEnforcementOverviewService>();
         services.AddScoped<IFreeTierGraceDisconnectNotifier, FreeTierGraceDisconnectNotifier>();
+        services.AddScoped<IFreeTierUnsubscribedUserReminderService, FreeTierUnsubscribedUserReminderService>();
+        services.AddScoped<IFreeTierUnsubscribedVpnUsersDailyDigestService, FreeTierUnsubscribedVpnUsersDailyDigestService>();
         
         services.AddScoped<IQuotaPlanService, QuotaPlanService>();
         services.AddScoped<IUserRoleManagementService, UserRoleManagementService>();

--- a/DataGateMonitor/Configurations/TelegramServiceConfiguration.cs
+++ b/DataGateMonitor/Configurations/TelegramServiceConfiguration.cs
@@ -12,6 +12,7 @@ public static class TelegramServiceConfiguration
         services.PostConfigure<TelegramChannelSettings>(TelegramChannelSettings.ApplyEnvOverrides);
         services.AddScoped<ITelegramChannelMembershipChecker, TelegramChannelMembershipChecker>();
         services.AddScoped<ITelegramDirectMessageSender, TelegramDirectMessageSender>();
+        services.AddScoped<ITelegramAdminAlertService, TelegramAdminAlertService>();
 
         services.AddScoped<ITelegramBotUserProfilePhotoService, TelegramBotUserProfilePhotoService>();
         services.AddScoped<ITelegramUserService, TelegramUserService>();

--- a/DataGateMonitor/Controllers/AuthController.cs
+++ b/DataGateMonitor/Controllers/AuthController.cs
@@ -10,6 +10,7 @@ using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
 using DataGateMonitor.Services.Api.Auth.TelegramLogin;
 using DataGateMonitor.Services.Api.Auth.Totp;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
 using DataGateMonitor.Services.Api.CurrentUser.Interfaces;
 using DataGateMonitor.Services.Api.Auth.Registers.Interfaces;
 using DataGateMonitor.Services.Users.Interfaces;
@@ -37,6 +38,7 @@ public class AuthController(
     ITokenService tokenService,
     IAdminForgotPasswordService adminForgotPasswordService,
     ITelegramLoginCodeService telegramLoginCodeService,
+    ITvLoginSessionService tvLoginSessionService,
     IAdminTotpService adminTotpService,
     ICurrentUserService currentUserService,
     IAdminIdleSessionTracker adminIdleSessionTracker,
@@ -348,6 +350,108 @@ public class AuthController(
     {
         var result = await telegramLoginCodeService.LoginWithCodeAsync(request, ct);
         return Ok(ApiResponse<LoginResponse>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// TV / device linking: create a short-lived session (QR + user code). Public.
+    /// </summary>
+    [AllowAnonymous]
+    [HttpPost("tv/session")]
+    [ProducesResponseType(typeof(ApiResponse<CreateTvLoginSessionResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<CreateTvLoginSessionResponse>>> CreateTvLoginSession(
+        [FromBody] CreateTvLoginSessionRequest? request,
+        CancellationToken ct)
+    {
+        var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var result = await tvLoginSessionService.CreateSessionAsync(
+            request ?? new CreateTvLoginSessionRequest(),
+            clientIp,
+            ct);
+        return Ok(ApiResponse<CreateTvLoginSessionResponse>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// TV polls until approved/denied/expired. On first approved poll, returns login tokens once.
+    /// </summary>
+    [AllowAnonymous]
+    [HttpGet("tv/session/{sessionId:guid}")]
+    [ProducesResponseType(typeof(ApiResponse<TvLoginSessionPollResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<TvLoginSessionPollResponse>>> PollTvLoginSession(
+        [FromRoute] Guid sessionId,
+        CancellationToken ct)
+    {
+        var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var result = await tvLoginSessionService.PollSessionAsync(sessionId, clientIp, ct);
+        return Ok(ApiResponse<TvLoginSessionPollResponse>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// Authenticated phone/web preview of a pending TV session by user code.
+    /// </summary>
+    [Authorize]
+    [HttpGet("tv/session/by-code/{userCode}")]
+    [ProducesResponseType(typeof(ApiResponse<TvLoginSessionPreviewResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status410Gone)]
+    public async Task<ActionResult<ApiResponse<TvLoginSessionPreviewResponse>>> GetTvLoginSessionByCode(
+        [FromRoute] string userCode,
+        CancellationToken ct)
+    {
+        try
+        {
+            var result = await tvLoginSessionService.GetByUserCodeAsync(userCode, ct);
+            return Ok(ApiResponse<TvLoginSessionPreviewResponse>.SuccessResponse(result));
+        }
+        catch (InvalidOperationException ex) when (
+            ex.Message == TvLoginSessionService.SessionExpiredMessage)
+        {
+            return StatusCode(
+                StatusCodes.Status410Gone,
+                ApiResponse<TvLoginSessionPreviewResponse>.ErrorResponse(ex.Message));
+        }
+        catch (InvalidOperationException ex) when (
+            ex.Message == TvLoginSessionService.SessionNotFoundMessage)
+        {
+            return NotFound(ApiResponse<TvLoginSessionPreviewResponse>.ErrorResponse(ex.Message));
+        }
+    }
+
+    /// <summary>
+    /// Authenticated phone/web approves a pending TV session. TOTP must already be satisfied on this Bearer.
+    /// </summary>
+    [Authorize]
+    [HttpPost("tv/session/approve")]
+    [ProducesResponseType(typeof(ApiResponse<TvLoginSessionActionResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<TvLoginSessionActionResponse>>> ApproveTvLoginSession(
+        [FromBody] ApproveTvLoginSessionRequest request,
+        CancellationToken ct)
+    {
+        var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var result = await tvLoginSessionService.ApproveAsync(
+            request,
+            currentUserService.UserId,
+            clientIp,
+            ct);
+        return Ok(ApiResponse<TvLoginSessionActionResponse>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// Authenticated phone/web denies a pending TV session.
+    /// </summary>
+    [Authorize]
+    [HttpPost("tv/session/deny")]
+    [ProducesResponseType(typeof(ApiResponse<TvLoginSessionActionResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<TvLoginSessionActionResponse>>> DenyTvLoginSession(
+        [FromBody] DenyTvLoginSessionRequest request,
+        CancellationToken ct)
+    {
+        var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        var result = await tvLoginSessionService.DenyAsync(
+            request,
+            currentUserService.UserId,
+            clientIp,
+            ct);
+        return Ok(ApiResponse<TvLoginSessionActionResponse>.SuccessResponse(result));
     }
 
     [AllowAnonymous]

--- a/DataGateMonitor/Controllers/AuthController.cs
+++ b/DataGateMonitor/Controllers/AuthController.cs
@@ -353,7 +353,8 @@ public class AuthController(
     }
 
     /// <summary>
-    /// TV / device linking: create a short-lived session (QR + user code). Public.
+    /// TV / device linking: create a short-lived session (QR payload + 6-digit user code). Public.
+    /// Prefer SignalR <c>/api/hubs/tv-login</c> (<c>WatchSession</c>); fall back to polling GET tv/session/{id}.
     /// </summary>
     [AllowAnonymous]
     [HttpPost("tv/session")]
@@ -371,7 +372,8 @@ public class AuthController(
     }
 
     /// <summary>
-    /// TV polls until approved/denied/expired. On first approved poll, returns login tokens once.
+    /// TV status check / poll fallback. Same DB status as SignalR.
+    /// Status: pending → viewed (phone opened code) → approved (tokens once) | denied | expired | consumed.
     /// </summary>
     [AllowAnonymous]
     [HttpGet("tv/session/{sessionId:guid}")]

--- a/DataGateMonitor/Controllers/AuthController.cs
+++ b/DataGateMonitor/Controllers/AuthController.cs
@@ -399,13 +399,27 @@ public class AuthController(
         [FromRoute] string userCode,
         CancellationToken ct)
     {
+        var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
         try
         {
-            var result = await tvLoginSessionService.GetByUserCodeAsync(userCode, ct);
+            var result = await tvLoginSessionService.GetByUserCodeAsync(
+                userCode,
+                currentUserService.UserId,
+                clientIp,
+                ct);
             return Ok(ApiResponse<TvLoginSessionPreviewResponse>.SuccessResponse(result));
         }
         catch (InvalidOperationException ex) when (
-            ex.Message == TvLoginSessionService.SessionExpiredMessage)
+            ex.Message == TvLoginSessionService.RateLimitMessage)
+        {
+            return StatusCode(
+                StatusCodes.Status429TooManyRequests,
+                ApiResponse<TvLoginSessionPreviewResponse>.ErrorResponse(ex.Message));
+        }
+        catch (InvalidOperationException ex) when (
+            ex.Message is TvLoginSessionService.SessionExpiredMessage
+                or TvLoginSessionService.SessionDeniedMessage
+                or TvLoginSessionService.SessionAlreadyCompletedMessage)
         {
             return StatusCode(
                 StatusCodes.Status410Gone,

--- a/DataGateMonitor/Controllers/AuthController.cs
+++ b/DataGateMonitor/Controllers/AuthController.cs
@@ -219,7 +219,7 @@ public class AuthController(
     }
 
     /// <summary>
-    /// Client apps: read-only Free/Default access status (channel subscription or merged Telegram account).
+    /// Client apps: read-only Free/Default access status (requires Telegram channel subscription).
     /// Does not notify admins or start a grace period.
     /// </summary>
     [Authorize]

--- a/DataGateMonitor/Controllers/FreeTierEnforcementController.cs
+++ b/DataGateMonitor/Controllers/FreeTierEnforcementController.cs
@@ -16,12 +16,13 @@ namespace DataGateMonitor.Controllers;
 [Authorize]
 [Authorize(Roles = "Admin,App")]
 public class FreeTierEnforcementController(
-    IFreeTierEnforcementOverviewService overviewService) : BaseController
+    IFreeTierEnforcementOverviewService overviewService,
+    IFreeTierUnsubscribedVpnUsersDailyDigestService unsubscribedVpnDigestService) : BaseController
 {
     /// <summary>
-    /// Every non-compliant Free/Default user (not merged, not channel-subscribed) — i.e. everyone the
-    /// enforcement job would disconnect on its next run. Refresh manually; this evaluates Telegram
-    /// channel membership per candidate and should not be polled automatically.
+    /// Every non-compliant Free/Default user (not channel-subscribed) — i.e. everyone the
+    /// enforcement job would disconnect on its next run (subject to grace). Refresh manually; this
+    /// evaluates Telegram channel membership per candidate and should not be polled automatically.
     /// </summary>
     [HttpGet("candidates")]
     public async Task<ActionResult<ApiResponse<GetFreeTierEnforcementCandidatesResponse>>> GetCandidates(
@@ -29,6 +30,17 @@ public class FreeTierEnforcementController(
     {
         var result = await overviewService.GetCandidatesAsync(ct);
         return Ok(ApiResponse<GetFreeTierEnforcementCandidatesResponse>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// On-demand digest text of Free/Default users currently online without channel subscription
+    /// (same payload as the daily admin Telegram digest).
+    /// </summary>
+    [HttpGet("unsubscribed-vpn-digest")]
+    public async Task<ActionResult<ApiResponse<string>>> GetUnsubscribedVpnDigest(CancellationToken ct)
+    {
+        var text = await unsubscribedVpnDigestService.BuildDigestTextAsync(ct);
+        return Ok(ApiResponse<string>.SuccessResponse(text));
     }
 
     [HttpGet("disconnect-log")]

--- a/DataGateMonitor/Controllers/FreeTierEnforcementController.cs
+++ b/DataGateMonitor/Controllers/FreeTierEnforcementController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using DataGateMonitor.Services.Users.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using DataGateMonitor.SharedModels.Responses;
@@ -17,7 +18,8 @@ namespace DataGateMonitor.Controllers;
 [Authorize(Roles = "Admin,App")]
 public class FreeTierEnforcementController(
     IFreeTierEnforcementOverviewService overviewService,
-    IFreeTierUnsubscribedVpnUsersDailyDigestService unsubscribedVpnDigestService) : BaseController
+    IFreeTierUnsubscribedVpnUsersDailyDigestService unsubscribedVpnDigestService,
+    IFreeTierUnsubscribedUserReminderService unsubscribedUserReminderService) : BaseController
 {
     /// <summary>
     /// Every non-compliant Free/Default user (not channel-subscribed) — i.e. everyone the
@@ -33,14 +35,33 @@ public class FreeTierEnforcementController(
     }
 
     /// <summary>
-    /// On-demand digest text of Free/Default users currently online without channel subscription
-    /// (same payload as the daily admin Telegram digest).
+    /// On-demand digest of Free/Default users currently online without channel subscription
+    /// (text for Telegram + structured candidates for admin buttons).
     /// </summary>
     [HttpGet("unsubscribed-vpn-digest")]
-    public async Task<ActionResult<ApiResponse<string>>> GetUnsubscribedVpnDigest(CancellationToken ct)
+    public async Task<ActionResult<ApiResponse<FreeTierUnsubscribedVpnDigestResponse>>> GetUnsubscribedVpnDigest(
+        CancellationToken ct)
     {
-        var text = await unsubscribedVpnDigestService.BuildDigestTextAsync(ct);
-        return Ok(ApiResponse<string>.SuccessResponse(text));
+        var result = await unsubscribedVpnDigestService.BuildDigestAsync(ct);
+        return Ok(ApiResponse<FreeTierUnsubscribedVpnDigestResponse>.SuccessResponse(result));
+    }
+
+    /// <summary>
+    /// Force-send a channel-subscribe reminder via Telegram DM or email
+    /// (<paramref name="target"/> = dashboard user id or Telegram id for Telegram;
+    /// dashboard user id for email).
+    /// </summary>
+    [HttpPost("remind-channel-subscribe/{target}")]
+    public async Task<ActionResult<ApiResponse<FreeTierChannelSubscribeRemindResponse>>> RemindChannelSubscribe(
+        string target,
+        [FromQuery] FreeTierChannelSubscribeRemindChannel channel = FreeTierChannelSubscribeRemindChannel.Telegram,
+        CancellationToken ct = default)
+    {
+        var result = await unsubscribedUserReminderService.ForceRemindAsync(target, channel, ct);
+        if (!result.Success)
+            return BadRequest(ApiResponse<FreeTierChannelSubscribeRemindResponse>.ErrorResponse(result.Message));
+
+        return Ok(ApiResponse<FreeTierChannelSubscribeRemindResponse>.SuccessResponse(result));
     }
 
     [HttpGet("disconnect-log")]

--- a/DataGateMonitor/Controllers/FreeTierEnforcementController.cs
+++ b/DataGateMonitor/Controllers/FreeTierEnforcementController.cs
@@ -43,6 +43,9 @@ public class FreeTierEnforcementController(
         CancellationToken ct)
     {
         var result = await unsubscribedVpnDigestService.BuildDigestAsync(ct);
+        // Live /unsubscribed_vpn_users fetch counts as today's digest so the hourly job
+        // does not re-DM the same list right after a deploy (IMemoryCache was empty).
+        unsubscribedVpnDigestService.MarkDailyDigestSatisfiedForToday();
         return Ok(ApiResponse<FreeTierUnsubscribedVpnDigestResponse>.SuccessResponse(result));
     }
 

--- a/DataGateMonitor/Controllers/PerformanceController.cs
+++ b/DataGateMonitor/Controllers/PerformanceController.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.Services.Performance;
+using DataGateMonitor.SharedModels.DataGateMonitor.Performance;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateMonitor.Controllers;
+
+[ApiController]
+[Route("api/performance")]
+[Authorize(Roles = "Admin")]
+public sealed class PerformanceController(IPerformanceSampleStore sampleStore) : BaseController
+{
+    [HttpGet("http-requests")]
+    [ProducesResponseType(typeof(ApiResponse<PerformanceHttpRequestsResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<PerformanceHttpRequestsResponse>>> GetHttpRequests(
+        [FromQuery] int limit = 200,
+        CancellationToken ct = default)
+    {
+        var items = await sampleStore.GetHttpLatestAsync(limit, ct);
+        var response = new PerformanceHttpRequestsResponse
+        {
+            Items = items.Select(MapHttp).ToList()
+        };
+        return Ok(ApiResponse<PerformanceHttpRequestsResponse>.SuccessResponse(response));
+    }
+
+    [HttpGet("db-queries")]
+    [ProducesResponseType(typeof(ApiResponse<PerformanceDbQueriesResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<PerformanceDbQueriesResponse>>> GetDbQueries(
+        [FromQuery] int limit = 200,
+        CancellationToken ct = default)
+    {
+        var items = await sampleStore.GetDbLatestAsync(limit, ct);
+        var response = new PerformanceDbQueriesResponse
+        {
+            Items = items.Select(MapDb).ToList()
+        };
+        return Ok(ApiResponse<PerformanceDbQueriesResponse>.SuccessResponse(response));
+    }
+
+    [HttpDelete]
+    [ProducesResponseType(typeof(ApiResponse<string>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<string>>> ClearAll(CancellationToken ct = default)
+    {
+        await sampleStore.ClearAllAsync(ct);
+        return Ok(ApiResponse<string>.SuccessResponse("Performance samples cleared."));
+    }
+
+    [HttpDelete("http-requests")]
+    [ProducesResponseType(typeof(ApiResponse<string>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<string>>> ClearHttp(CancellationToken ct = default)
+    {
+        await sampleStore.ClearHttpAsync(ct);
+        return Ok(ApiResponse<string>.SuccessResponse("HTTP performance samples cleared."));
+    }
+
+    [HttpDelete("db-queries")]
+    [ProducesResponseType(typeof(ApiResponse<string>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<string>>> ClearDb(CancellationToken ct = default)
+    {
+        await sampleStore.ClearDbAsync(ct);
+        return Ok(ApiResponse<string>.SuccessResponse("DB performance samples cleared."));
+    }
+
+    private static PerformanceHttpRequestEntryDto MapHttp(PerformanceHttpSample s) =>
+        new()
+        {
+            TimestampUtc = s.TimestampUtc,
+            RequestId = s.RequestId,
+            Method = s.Method,
+            Path = s.Path,
+            StatusCode = s.StatusCode,
+            DurationMs = s.DurationMs,
+            UserName = s.UserName,
+            TraceId = s.TraceId
+        };
+
+    private static PerformanceDbQueryEntryDto MapDb(PerformanceDbSample s) =>
+        new()
+        {
+            TimestampUtc = s.TimestampUtc,
+            RequestId = s.RequestId,
+            DurationMs = s.DurationMs,
+            CommandType = s.CommandType,
+            Sql = s.Sql,
+            Succeeded = s.Succeeded,
+            ExceptionMessage = s.ExceptionMessage
+        };
+}

--- a/DataGateMonitor/Controllers/TvLoginSessionsAdminController.cs
+++ b/DataGateMonitor/Controllers/TvLoginSessionsAdminController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using DataGateMonitor.Services.Api.Auth.TvLogin;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+using DataGateMonitor.SharedModels.Responses;
+
+namespace DataGateMonitor.Controllers;
+
+[ApiController]
+[Route("api/admin/tv-login-sessions")]
+[Authorize(Roles = "Admin")]
+public sealed class TvLoginSessionsAdminController(ITvLoginAdminService adminService) : BaseController
+{
+    /// <summary>List TV device-linking sessions (newest first). Optional filters: approvedUserId, status.</summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<GetAdminTvLoginSessionsResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<GetAdminTvLoginSessionsResponse>>> List(
+        [FromQuery] int? approvedUserId,
+        [FromQuery] string? status,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 50,
+        CancellationToken ct = default)
+    {
+        var result = await adminService.ListAsync(approvedUserId, status, skip, take, ct);
+        return Ok(ApiResponse<GetAdminTvLoginSessionsResponse>.SuccessResponse(result));
+    }
+
+    /// <summary>Per-user TV login usage summary for the user detail card.</summary>
+    [HttpGet("by-user/{userId:int}/summary")]
+    [ProducesResponseType(typeof(ApiResponse<UserTvLoginSummaryResponse>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<ApiResponse<UserTvLoginSummaryResponse>>> GetUserSummary(
+        [FromRoute] int userId,
+        CancellationToken ct)
+    {
+        var result = await adminService.GetUserSummaryAsync(userId, ct);
+        return Ok(ApiResponse<UserTvLoginSummaryResponse>.SuccessResponse(result));
+    }
+}

--- a/DataGateMonitor/Controllers/VpnServerAuthorizationHelper.cs
+++ b/DataGateMonitor/Controllers/VpnServerAuthorizationHelper.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using DataGateMonitor.Services.Api;
 using DataGateMonitor.Services.Api.Auth.Handlers.Interfaces;
+using DataGateMonitor.Services.VpnAccess;
 using DataGateMonitor.SharedModels.Responses;
 
 namespace DataGateMonitor.Controllers;
@@ -23,7 +24,7 @@ public static class VpnServerAuthorizationHelper
                 ApiResponse<string>.ErrorResponse("User id missing from token.")));
         if (!await access.UserHasAccessAsync(userId, vpnServerId, ct))
             return new ActionResult<ApiResponse<T>>(new ObjectResult(ApiResponse<string>.ErrorResponse(
-                    "Access to this VPN server is denied for your quota plan."))
+                    VpnServerAccessErrorKeys.NotAllowedByQuotaPlan))
                 { StatusCode = StatusCodes.Status403Forbidden });
         return null;
     }

--- a/DataGateMonitor/Controllers/VpnServersController.cs
+++ b/DataGateMonitor/Controllers/VpnServersController.cs
@@ -36,7 +36,8 @@ public class VpnServersController(IVpnDataService vpnDataService,
     IApiMemoryCacheService apiMemoryCacheService,
     IStatusCacheGenerationService statusCacheGenerationService,
     IStatusStreamLogStore statusStreamLogStore,
-    IVpnServerPostSetupService vpnServerPostSetupService) : BaseController
+    IVpnServerPostSetupService vpnServerPostSetupService,
+    IConnectedClientsCounterStore connectedClientsCounterStore) : BaseController
 {
     private static readonly TimeSpan ServersListCacheTtl = TimeSpan.FromHours(1);
 
@@ -72,6 +73,7 @@ public class VpnServersController(IVpnDataService vpnDataService,
         {
             var result = await openVpnServerOverviewQuery.GetAllVpnServersWithStatusAsync(
                 includeDeleted, requireQuotaPlanAssignment: false, restrictToQuotaPlanId, token);
+            await VpnServerConnectedCountOverlay.ApplyAsync(result, connectedClientsCounterStore, token);
 
             var baseResponse = new VpnServerWithStatusesResponse
             {

--- a/DataGateMonitor/Controllers/VpnServersV2Controller.cs
+++ b/DataGateMonitor/Controllers/VpnServersV2Controller.cs
@@ -28,7 +28,8 @@ public class VpnServersV2Controller(
     IUserQuotaPlanQueryService userQuotaPlanQueryService,
     IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService,
     IApiMemoryCacheService apiMemoryCacheService,
-    IStatusCacheGenerationService statusCacheGenerationService) : BaseController
+    IStatusCacheGenerationService statusCacheGenerationService,
+    IConnectedClientsCounterStore connectedClientsCounterStore) : BaseController
 {
     private static readonly TimeSpan ServersListCacheTtl = TimeSpan.FromHours(1);
 
@@ -124,6 +125,7 @@ public class VpnServersV2Controller(
                 requireQuotaPlanAssignment: false,
                 restrictToQuotaPlanId,
                 token);
+            await VpnServerConnectedCountOverlay.ApplyAsync(result, connectedClientsCounterStore, token);
             var response = new VpnServerWithStatusesV2Response();
             if (result.Count == 0)
                 return ApiResponse<VpnServerWithStatusesV2Response>.SuccessResponse(response);
@@ -172,6 +174,9 @@ public class VpnServersV2Controller(
                 ServersListCacheTtl,
                 ct);
         }
+
+        if (cached.Data?.VpnServerWithStatuses is { Count: > 0 } statuses)
+            await VpnServerConnectedCountOverlay.ApplyAsync(statuses, connectedClientsCounterStore, ct);
 
         return Ok(cached);
     }

--- a/DataGateMonitor/Controllers/VpnServersV3Controller.cs
+++ b/DataGateMonitor/Controllers/VpnServersV3Controller.cs
@@ -31,7 +31,8 @@ public class VpnServersV3Controller(
     IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService,
     IQuotaPlanQueryService quotaPlanQueryService,
     IApiMemoryCacheService apiMemoryCacheService,
-    IStatusCacheGenerationService statusCacheGenerationService) : BaseController
+    IStatusCacheGenerationService statusCacheGenerationService,
+    IConnectedClientsCounterStore connectedClientsCounterStore) : BaseController
 {
     private static readonly TimeSpan ServersListCacheTtl = TimeSpan.FromHours(1);
 
@@ -113,6 +114,7 @@ public class VpnServersV3Controller(
                 requireQuotaPlanAssignment: false,
                 restrictToQuotaPlanId: null,
                 token);
+            await VpnServerConnectedCountOverlay.ApplyAsync(result, connectedClientsCounterStore, token);
             var response = new VpnServerWithStatusesV3Response { UserQuotaPlan = access.Context };
             if (result.Count == 0)
                 return ApiResponse<VpnServerWithStatusesV3Response>.SuccessResponse(response);
@@ -146,7 +148,10 @@ public class VpnServersV3Controller(
             return ApiResponse<VpnServerWithStatusesV3Response>.SuccessResponse(response);
         }
 
-        return Ok(await GetOrCreateCachedAsync(cacheKey, stampKey, BuildResponse, withoutCache, ct));
+        var cached = await GetOrCreateCachedAsync(cacheKey, stampKey, BuildResponse, withoutCache, ct);
+        if (cached.Data?.VpnServerWithStatuses is { Count: > 0 } statuses)
+            await VpnServerConnectedCountOverlay.ApplyAsync(statuses, connectedClientsCounterStore, ct);
+        return Ok(cached);
     }
 
     private async Task<ApiResponse<T>> GetOrCreateCachedAsync<T>(

--- a/DataGateMonitor/Data/Interceptors/SlowDbCommandInterceptor.cs
+++ b/DataGateMonitor/Data/Interceptors/SlowDbCommandInterceptor.cs
@@ -1,0 +1,129 @@
+using System.Data.Common;
+using DataGateMonitor.Services.Performance;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Options;
+
+namespace DataGateMonitor.Data.Interceptors;
+
+public sealed class SlowDbCommandInterceptor(
+    IPerformanceSampleStore sampleStore,
+    IOptions<PerformanceMonitoringOptions> options,
+    ILogger<SlowDbCommandInterceptor> logger) : DbCommandInterceptor
+{
+    public override DbDataReader ReaderExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        DbDataReader result)
+    {
+        Record(command, eventData.Duration, succeeded: true, exception: null);
+        return base.ReaderExecuted(command, eventData, result);
+    }
+
+    public override ValueTask<DbDataReader> ReaderExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        DbDataReader result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: true, exception: null);
+        return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override int NonQueryExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result)
+    {
+        Record(command, eventData.Duration, succeeded: true, exception: null);
+        return base.NonQueryExecuted(command, eventData, result);
+    }
+
+    public override ValueTask<int> NonQueryExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: true, exception: null);
+        return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override object? ScalarExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result)
+    {
+        Record(command, eventData.Duration, succeeded: true, exception: null);
+        return base.ScalarExecuted(command, eventData, result);
+    }
+
+    public override ValueTask<object?> ScalarExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: true, exception: null);
+        return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override void CommandFailed(DbCommand command, CommandErrorEventData eventData)
+    {
+        Record(command, eventData.Duration, succeeded: false, exception: eventData.Exception);
+        base.CommandFailed(command, eventData);
+    }
+
+    public override Task CommandFailedAsync(
+        DbCommand command,
+        CommandErrorEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        Record(command, eventData.Duration, succeeded: false, exception: eventData.Exception);
+        return base.CommandFailedAsync(command, eventData, cancellationToken);
+    }
+
+    /// <summary>Visible for unit tests.</summary>
+    internal void Record(
+        DbCommand command,
+        TimeSpan duration,
+        bool succeeded,
+        Exception? exception)
+    {
+        try
+        {
+            var durationMs = (long)duration.TotalMilliseconds;
+            var threshold = Math.Max(0, options.Value.DbSlowMs);
+            if (succeeded && durationMs < threshold)
+                return;
+
+            var sqlMax = Math.Clamp(options.Value.SqlMaxLength, 64, 16_000);
+            var sql = Truncate(command.CommandText, sqlMax);
+
+            // Fire-and-forget; interceptor must not block the EF pipeline on Redis.
+            _ = sampleStore.AppendDbAsync(
+                new PerformanceDbSample
+                {
+                    TimestampUtc = DateTimeOffset.UtcNow,
+                    RequestId = PerformanceRequestContext.RequestId,
+                    DurationMs = durationMs,
+                    CommandType = command.CommandType.ToString(),
+                    Sql = sql,
+                    Succeeded = succeeded,
+                    ExceptionMessage = Truncate(exception?.Message, 500)
+                },
+                CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to record DB performance sample.");
+        }
+    }
+
+    internal static string Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+
+        return value.Length <= max ? value : value[..max] + "…";
+    }
+}

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.44" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.64</Version>
-        <AssemblyVersion>1.0.3.64</AssemblyVersion>
-        <FileVersion>1.0.3.64</FileVersion>
+        <Version>1.0.3.65</Version>
+        <AssemblyVersion>1.0.3.65</AssemblyVersion>
+        <FileVersion>1.0.3.65</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.63</Version>
-        <AssemblyVersion>1.0.3.63</AssemblyVersion>
-        <FileVersion>1.0.3.63</FileVersion>
+        <Version>1.0.3.64</Version>
+        <AssemblyVersion>1.0.3.64</AssemblyVersion>
+        <FileVersion>1.0.3.64</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.45" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.46" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.77</Version>
-        <AssemblyVersion>1.0.3.77</AssemblyVersion>
-        <FileVersion>1.0.3.77</FileVersion>
+        <Version>1.0.3.78</Version>
+        <AssemblyVersion>1.0.3.78</AssemblyVersion>
+        <FileVersion>1.0.3.78</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.72</Version>
-        <AssemblyVersion>1.0.3.72</AssemblyVersion>
-        <FileVersion>1.0.3.72</FileVersion>
+        <Version>1.0.3.73</Version>
+        <AssemblyVersion>1.0.3.73</AssemblyVersion>
+        <FileVersion>1.0.3.73</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.92</Version>
-        <AssemblyVersion>1.0.3.92</AssemblyVersion>
-        <FileVersion>1.0.3.92</FileVersion>
+        <Version>1.0.3.93</Version>
+        <AssemblyVersion>1.0.3.93</AssemblyVersion>
+        <FileVersion>1.0.3.93</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.78</Version>
-        <AssemblyVersion>1.0.3.78</AssemblyVersion>
-        <FileVersion>1.0.3.78</FileVersion>
+        <Version>1.0.3.79</Version>
+        <AssemblyVersion>1.0.3.79</AssemblyVersion>
+        <FileVersion>1.0.3.79</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.73</Version>
-        <AssemblyVersion>1.0.3.73</AssemblyVersion>
-        <FileVersion>1.0.3.73</FileVersion>
+        <Version>1.0.3.74</Version>
+        <AssemblyVersion>1.0.3.74</AssemblyVersion>
+        <FileVersion>1.0.3.74</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.76</Version>
-        <AssemblyVersion>1.0.3.76</AssemblyVersion>
-        <FileVersion>1.0.3.76</FileVersion>
+        <Version>1.0.3.77</Version>
+        <AssemblyVersion>1.0.3.77</AssemblyVersion>
+        <FileVersion>1.0.3.77</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.89</Version>
-        <AssemblyVersion>1.0.3.89</AssemblyVersion>
-        <FileVersion>1.0.3.89</FileVersion>
+        <Version>1.0.3.92</Version>
+        <AssemblyVersion>1.0.3.92</AssemblyVersion>
+        <FileVersion>1.0.3.92</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.50" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.82</Version>
-        <AssemblyVersion>1.0.3.82</AssemblyVersion>
-        <FileVersion>1.0.3.82</FileVersion>
+        <Version>1.0.3.83</Version>
+        <AssemblyVersion>1.0.3.83</AssemblyVersion>
+        <FileVersion>1.0.3.83</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.70</Version>
-        <AssemblyVersion>1.0.3.70</AssemblyVersion>
-        <FileVersion>1.0.3.70</FileVersion>
+        <Version>1.0.3.71</Version>
+        <AssemblyVersion>1.0.3.71</AssemblyVersion>
+        <FileVersion>1.0.3.71</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.79</Version>
-        <AssemblyVersion>1.0.3.79</AssemblyVersion>
-        <FileVersion>1.0.3.79</FileVersion>
+        <Version>1.0.3.80</Version>
+        <AssemblyVersion>1.0.3.80</AssemblyVersion>
+        <FileVersion>1.0.3.80</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.87</Version>
-        <AssemblyVersion>1.0.3.87</AssemblyVersion>
-        <FileVersion>1.0.3.87</FileVersion>
+        <Version>1.0.3.89</Version>
+        <AssemblyVersion>1.0.3.89</AssemblyVersion>
+        <FileVersion>1.0.3.89</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.80</Version>
-        <AssemblyVersion>1.0.3.80</AssemblyVersion>
-        <FileVersion>1.0.3.80</FileVersion>
+        <Version>1.0.3.81</Version>
+        <AssemblyVersion>1.0.3.81</AssemblyVersion>
+        <FileVersion>1.0.3.81</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.75</Version>
-        <AssemblyVersion>1.0.3.75</AssemblyVersion>
-        <FileVersion>1.0.3.75</FileVersion>
+        <Version>1.0.3.76</Version>
+        <AssemblyVersion>1.0.3.76</AssemblyVersion>
+        <FileVersion>1.0.3.76</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.74</Version>
-        <AssemblyVersion>1.0.3.74</AssemblyVersion>
-        <FileVersion>1.0.3.74</FileVersion>
+        <Version>1.0.3.75</Version>
+        <AssemblyVersion>1.0.3.75</AssemblyVersion>
+        <FileVersion>1.0.3.75</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.84</Version>
-        <AssemblyVersion>1.0.3.84</AssemblyVersion>
-        <FileVersion>1.0.3.84</FileVersion>
+        <Version>1.0.3.85</Version>
+        <AssemblyVersion>1.0.3.85</AssemblyVersion>
+        <FileVersion>1.0.3.85</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.83</Version>
-        <AssemblyVersion>1.0.3.83</AssemblyVersion>
-        <FileVersion>1.0.3.83</FileVersion>
+        <Version>1.0.3.84</Version>
+        <AssemblyVersion>1.0.3.84</AssemblyVersion>
+        <FileVersion>1.0.3.84</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.85</Version>
-        <AssemblyVersion>1.0.3.85</AssemblyVersion>
-        <FileVersion>1.0.3.85</FileVersion>
+        <Version>1.0.3.86</Version>
+        <AssemblyVersion>1.0.3.86</AssemblyVersion>
+        <FileVersion>1.0.3.86</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.65</Version>
-        <AssemblyVersion>1.0.3.65</AssemblyVersion>
-        <FileVersion>1.0.3.65</FileVersion>
+        <Version>1.0.3.69</Version>
+        <AssemblyVersion>1.0.3.69</AssemblyVersion>
+        <FileVersion>1.0.3.69</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.47" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.81</Version>
-        <AssemblyVersion>1.0.3.81</AssemblyVersion>
-        <FileVersion>1.0.3.81</FileVersion>
+        <Version>1.0.3.82</Version>
+        <AssemblyVersion>1.0.3.82</AssemblyVersion>
+        <FileVersion>1.0.3.82</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.86</Version>
-        <AssemblyVersion>1.0.3.86</AssemblyVersion>
-        <FileVersion>1.0.3.86</FileVersion>
+        <Version>1.0.3.87</Version>
+        <AssemblyVersion>1.0.3.87</AssemblyVersion>
+        <FileVersion>1.0.3.87</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.69</Version>
-        <AssemblyVersion>1.0.3.69</AssemblyVersion>
-        <FileVersion>1.0.3.69</FileVersion>
+        <Version>1.0.3.70</Version>
+        <AssemblyVersion>1.0.3.70</AssemblyVersion>
+        <FileVersion>1.0.3.70</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.71</Version>
-        <AssemblyVersion>1.0.3.71</AssemblyVersion>
-        <FileVersion>1.0.3.71</FileVersion>
+        <Version>1.0.3.72</Version>
+        <AssemblyVersion>1.0.3.72</AssemblyVersion>
+        <FileVersion>1.0.3.72</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
@@ -37,7 +37,7 @@
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <!-- SharedModels: NuGet only. Latest on nuget.org: https://www.nuget.org/packages/DataGateMonitor.SharedModels -->
-        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.48" />
+        <PackageReference Include="DataGateMonitor.SharedModels" Version="1.0.49" />
         <PackageReference Include="Otp.NET" Version="1.4.1" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
         <PackageReference Include="Serilog" Version="4.3.1" />

--- a/DataGateMonitor/DataGateMonitor.csproj
+++ b/DataGateMonitor/DataGateMonitor.csproj
@@ -6,9 +6,9 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <Product>DataGateMonitor</Product>
         <AssemblyTitle>DataGateMonitor</AssemblyTitle>
-        <Version>1.0.3.93</Version>
-        <AssemblyVersion>1.0.3.93</AssemblyVersion>
-        <FileVersion>1.0.3.93</FileVersion>
+        <Version>1.0.3.94</Version>
+        <AssemblyVersion>1.0.3.94</AssemblyVersion>
+        <FileVersion>1.0.3.94</FileVersion>
         <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 

--- a/DataGateMonitor/Hubs/TvLoginHub.cs
+++ b/DataGateMonitor/Hubs/TvLoginHub.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+namespace DataGateMonitor.Hubs;
+
+/// <summary>
+/// Anonymous hub for Android TV (and similar) to watch a device-linking session in real time.
+/// Join with <see cref="WatchSession"/>; listen for <c>TvLoginSessionStatusChanged</c>.
+/// When status becomes <c>approved</c>, call GET /api/auth/tv/session/{sessionId} once to receive tokens.
+/// </summary>
+[AllowAnonymous]
+public sealed class TvLoginHub(ITvLoginSessionQueryService sessionQuery) : Hub
+{
+    public const string StatusChangedEvent = "TvLoginSessionStatusChanged";
+    public const string HubPath = "/api/hubs/tv-login";
+
+    public static string GroupName(Guid sessionId) => $"tv-login:{sessionId:D}";
+
+    /// <summary>Subscribe to status updates for a TV login session created via POST /api/auth/tv/session.</summary>
+    public async Task WatchSession(Guid sessionId)
+    {
+        var session = await sessionQuery.GetById(sessionId, Context.ConnectionAborted);
+        if (session is null)
+            throw new HubException("TV login session not found.");
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName(sessionId));
+
+        // Immediate snapshot so the TV UI can render without an extra HTTP round-trip.
+        var status = MapStatus(session);
+        await Clients.Caller.SendAsync(
+            StatusChangedEvent,
+            new TvLoginSessionStatusEvent
+            {
+                SessionId = session.Id,
+                Status = status,
+                ExpiresAt = session.ExpiresAt,
+            },
+            Context.ConnectionAborted);
+    }
+
+    public Task UnwatchSession(Guid sessionId)
+        => Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName(sessionId));
+
+    private static string MapStatus(TvLoginSession session)
+    {
+        if (session.Status == TvLoginSessionStatus.Pending
+            && session.ExpiresAt <= DateTimeOffset.UtcNow)
+            return "expired";
+
+        return session.Status switch
+        {
+            TvLoginSessionStatus.Pending => "pending",
+            TvLoginSessionStatus.Viewed => "viewed",
+            TvLoginSessionStatus.Approved => "approved",
+            TvLoginSessionStatus.Denied => "denied",
+            TvLoginSessionStatus.Expired => "expired",
+            TvLoginSessionStatus.Consumed => "consumed",
+            _ => "expired",
+        };
+    }
+}

--- a/DataGateMonitor/Hubs/TvLoginHub.cs
+++ b/DataGateMonitor/Hubs/TvLoginHub.cs
@@ -46,7 +46,7 @@ public sealed class TvLoginHub(ITvLoginSessionQueryService sessionQuery) : Hub
 
     private static string MapStatus(TvLoginSession session)
     {
-        if (session.Status == TvLoginSessionStatus.Pending
+        if (session.Status is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed
             && session.ExpiresAt <= DateTimeOffset.UtcNow)
             return "expired";
 

--- a/DataGateMonitor/Hubs/TvLoginHubNotifier.cs
+++ b/DataGateMonitor/Hubs/TvLoginHubNotifier.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.SignalR;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+namespace DataGateMonitor.Hubs;
+
+public interface ITvLoginHubNotifier
+{
+    Task NotifyStatusAsync(
+        Guid sessionId,
+        string status,
+        DateTimeOffset expiresAt,
+        CancellationToken ct = default);
+}
+
+public sealed class TvLoginHubNotifier(
+    IHubContext<TvLoginHub> hubContext,
+    ILogger<TvLoginHubNotifier> logger) : ITvLoginHubNotifier
+{
+    public async Task NotifyStatusAsync(
+        Guid sessionId,
+        string status,
+        DateTimeOffset expiresAt,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await hubContext.Clients
+                .Group(TvLoginHub.GroupName(sessionId))
+                .SendAsync(
+                    TvLoginHub.StatusChangedEvent,
+                    new TvLoginSessionStatusEvent
+                    {
+                        SessionId = sessionId,
+                        Status = status,
+                        ExpiresAt = expiresAt,
+                    },
+                    ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to push TV login status {Status} for session {SessionId}", status, sessionId);
+        }
+    }
+}

--- a/DataGateMonitor/Middlewares/GlobalExceptionMiddleware.cs
+++ b/DataGateMonitor/Middlewares/GlobalExceptionMiddleware.cs
@@ -141,6 +141,8 @@ public class GlobalExceptionMiddleware(
         {
             UnauthorizedAccessException => ((int)HttpStatusCode.Unauthorized, exception.Message),
             ArgumentException => ((int)HttpStatusCode.BadRequest, exception.Message),
+            InvalidOperationException ioe when IsRateLimitMessage(ioe.Message)
+                => ((int)HttpStatusCode.TooManyRequests, ioe.Message),
             InvalidOperationException ioe when IsDuplicateOrConflictMessage(ioe.Message)
                 => ((int)HttpStatusCode.Conflict, ioe.Message),
             InvalidOperationException ioe when IsClientFacingInvalidOperation(ioe.Message)
@@ -166,6 +168,9 @@ public class GlobalExceptionMiddleware(
         await context.Response.WriteAsync(json);
     }
 
+    private static bool IsRateLimitMessage(string message) =>
+        message.Contains("Too many requests", StringComparison.OrdinalIgnoreCase);
+
     private static bool IsDuplicateOrConflictMessage(string message) =>
         message.Contains("already exists", StringComparison.OrdinalIgnoreCase)
         || message.Contains("already in use", StringComparison.OrdinalIgnoreCase)
@@ -176,8 +181,10 @@ public class GlobalExceptionMiddleware(
         || message.Contains("is missing", StringComparison.OrdinalIgnoreCase)
         || message.Contains("not found", StringComparison.OrdinalIgnoreCase)
         || message.Contains("has expired", StringComparison.OrdinalIgnoreCase)
-        || message.Contains("no longer pending", StringComparison.OrdinalIgnoreCase)
-        || message.Contains("Too many requests", StringComparison.OrdinalIgnoreCase);
+        || message.Contains("was denied", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("already completed", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("do not match", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("no longer pending", StringComparison.OrdinalIgnoreCase);
 
     private static string GetExceptionDetails(Exception ex)
     {

--- a/DataGateMonitor/Middlewares/GlobalExceptionMiddleware.cs
+++ b/DataGateMonitor/Middlewares/GlobalExceptionMiddleware.cs
@@ -174,7 +174,10 @@ public class GlobalExceptionMiddleware(
     private static bool IsClientFacingInvalidOperation(string message) =>
         message.Contains("only supported for", StringComparison.OrdinalIgnoreCase)
         || message.Contains("is missing", StringComparison.OrdinalIgnoreCase)
-        || message.Contains("not found", StringComparison.OrdinalIgnoreCase);
+        || message.Contains("not found", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("has expired", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("no longer pending", StringComparison.OrdinalIgnoreCase)
+        || message.Contains("Too many requests", StringComparison.OrdinalIgnoreCase);
 
     private static string GetExceptionDetails(Exception ex)
     {

--- a/DataGateMonitor/Middlewares/RequestTimingMiddleware.cs
+++ b/DataGateMonitor/Middlewares/RequestTimingMiddleware.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using System.Security.Claims;
+using DataGateMonitor.Services.Performance;
+using Microsoft.Extensions.Options;
+
+namespace DataGateMonitor.Middlewares;
+
+public sealed class RequestTimingMiddleware(
+    RequestDelegate next,
+    IPerformanceSampleStore sampleStore,
+    IOptions<PerformanceMonitoringOptions> options,
+    ILogger<RequestTimingMiddleware> logger)
+{
+    private static readonly PathString[] SkipPrefixes =
+    [
+        new("/api/performance"),
+        new("/health"),
+        new("/swagger"),
+        new("/api/hubs"),
+        new("/hubs")
+    ];
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (ShouldSkip(context.Request))
+        {
+            await next(context);
+            return;
+        }
+
+        var requestId = Guid.NewGuid().ToString("N");
+        PerformanceRequestContext.RequestId = requestId;
+        context.Items["PerformanceRequestId"] = requestId;
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            sw.Stop();
+            try
+            {
+                await MaybeRecordAsync(context, requestId, sw.ElapsedMilliseconds);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex, "Failed to record HTTP performance sample.");
+            }
+            finally
+            {
+                PerformanceRequestContext.RequestId = null;
+            }
+        }
+    }
+
+    private async Task MaybeRecordAsync(HttpContext context, string requestId, long durationMs)
+    {
+        var statusCode = context.Response.StatusCode;
+        var threshold = Math.Max(0, options.Value.HttpSlowMs);
+        if (durationMs < threshold && statusCode < 500)
+            return;
+
+        var userName =
+            context.User?.Identity?.IsAuthenticated == true
+                ? context.User.Identity.Name
+                  ?? context.User.FindFirstValue(ClaimTypes.Name)
+                  ?? context.User.FindFirstValue(ClaimTypes.Email)
+                : null;
+
+        var path = context.Request.Path.HasValue
+            ? context.Request.Path.Value!
+            : "/";
+        if (context.Request.QueryString.HasValue)
+            path += context.Request.QueryString.Value;
+
+        await sampleStore.AppendHttpAsync(
+            new PerformanceHttpSample
+            {
+                TimestampUtc = DateTimeOffset.UtcNow,
+                RequestId = requestId,
+                Method = context.Request.Method,
+                Path = path,
+                StatusCode = statusCode,
+                DurationMs = durationMs,
+                UserName = userName,
+                TraceId = context.TraceIdentifier
+            },
+            context.RequestAborted);
+    }
+
+    private static bool ShouldSkip(HttpRequest request)
+    {
+        if (HttpMethods.IsOptions(request.Method))
+            return true;
+
+        var path = request.Path;
+        if (!path.HasValue)
+            return true;
+
+        // Skip non-API static / root assets; still time /api/* (except exclusions).
+        if (!path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase)
+            && !path.StartsWithSegments("/health", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        foreach (var prefix in SkipPrefixes)
+        {
+            if (path.StartsWithSegments(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/ITvLoginAdminService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/ITvLoginAdminService.cs
@@ -1,0 +1,15 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+namespace DataGateMonitor.Services.Api.Auth.TvLogin;
+
+public interface ITvLoginAdminService
+{
+    Task<GetAdminTvLoginSessionsResponse> ListAsync(
+        int? approvedUserId,
+        string? status,
+        int skip,
+        int take,
+        CancellationToken ct);
+
+    Task<UserTvLoginSummaryResponse> GetUserSummaryAsync(int userId, CancellationToken ct);
+}

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/ITvLoginSessionService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/ITvLoginSessionService.cs
@@ -1,0 +1,28 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+namespace DataGateMonitor.Services.Api.Auth.TvLogin;
+
+public interface ITvLoginSessionService
+{
+    Task<CreateTvLoginSessionResponse> CreateSessionAsync(
+        CreateTvLoginSessionRequest request,
+        string? clientIp,
+        CancellationToken ct);
+
+    Task<TvLoginSessionPollResponse> PollSessionAsync(Guid sessionId, string? clientIp, CancellationToken ct);
+
+    Task<TvLoginSessionPreviewResponse> GetByUserCodeAsync(string userCode, CancellationToken ct);
+
+    Task<TvLoginSessionActionResponse> ApproveAsync(
+        ApproveTvLoginSessionRequest request,
+        int approvingUserId,
+        string? clientIp,
+        CancellationToken ct);
+
+    Task<TvLoginSessionActionResponse> DenyAsync(
+        DenyTvLoginSessionRequest request,
+        int denyingUserId,
+        string? clientIp,
+        CancellationToken ct);
+}

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/ITvLoginSessionService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/ITvLoginSessionService.cs
@@ -12,7 +12,11 @@ public interface ITvLoginSessionService
 
     Task<TvLoginSessionPollResponse> PollSessionAsync(Guid sessionId, string? clientIp, CancellationToken ct);
 
-    Task<TvLoginSessionPreviewResponse> GetByUserCodeAsync(string userCode, CancellationToken ct);
+    Task<TvLoginSessionPreviewResponse> GetByUserCodeAsync(
+        string userCode,
+        int requestingUserId,
+        string? clientIp,
+        CancellationToken ct);
 
     Task<TvLoginSessionActionResponse> ApproveAsync(
         ApproveTvLoginSessionRequest request,

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginAdminService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginAdminService.cs
@@ -1,0 +1,136 @@
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+namespace DataGateMonitor.Services.Api.Auth.TvLogin;
+
+public sealed class TvLoginAdminService(
+    ITvLoginSessionQueryService sessions,
+    IUserQueryService users) : ITvLoginAdminService
+{
+    public async Task<GetAdminTvLoginSessionsResponse> ListAsync(
+        int? approvedUserId,
+        string? status,
+        int skip,
+        int take,
+        CancellationToken ct)
+    {
+        TvLoginSessionStatus? statusFilter = null;
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            if (!TryParseStatus(status, out var parsed))
+                throw new InvalidOperationException($"Unknown TV login status '{status}'.");
+            statusFilter = parsed;
+        }
+
+        var (items, total) = await sessions.ListAsync(approvedUserId, statusFilter, skip, take, ct);
+
+        var userIds = items
+            .Where(x => x.ApprovedUserId is int)
+            .Select(x => x.ApprovedUserId!.Value)
+            .Distinct()
+            .ToList();
+
+        var userMap = new Dictionary<int, User>();
+        foreach (var id in userIds)
+        {
+            var user = await users.GetById(id, ct);
+            if (user != null)
+                userMap[id] = user;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var dtos = items.Select(s =>
+        {
+            userMap.TryGetValue(s.ApprovedUserId ?? -1, out var user);
+            return new AdminTvLoginSessionDto
+            {
+                SessionId = s.Id,
+                UserCode = s.UserCode,
+                Status = MapStatus(s, now),
+                DeviceName = s.DeviceName,
+                Client = s.Client,
+                DeviceId = s.DeviceId,
+                UserAgent = s.UserAgent,
+                ApprovedUserId = s.ApprovedUserId,
+                ApprovedUserEmail = user?.Email,
+                ApprovedUserDisplayName = user?.DisplayName,
+                CreateDate = s.CreateDate,
+                ExpiresAt = s.ExpiresAt,
+                CompletedAt = s.CompletedAt,
+            };
+        }).ToList();
+
+        return new GetAdminTvLoginSessionsResponse
+        {
+            Sessions = dtos,
+            TotalCount = total,
+        };
+    }
+
+    public async Task<UserTvLoginSummaryResponse> GetUserSummaryAsync(int userId, CancellationToken ct)
+    {
+        var count = await sessions.CountApprovedOrConsumedForUserAsync(userId, ct);
+        var latest = count > 0
+            ? await sessions.GetLatestApprovedOrConsumedForUserAsync(userId, ct)
+            : null;
+
+        return new UserTvLoginSummaryResponse
+        {
+            HasUsedTvLogin = count > 0,
+            ApprovedOrConsumedCount = count,
+            LastUsedAt = latest?.CompletedAt ?? latest?.CreateDate,
+            LastDeviceName = latest?.DeviceName,
+            LastClient = latest?.Client,
+        };
+    }
+
+    internal static string MapStatus(TvLoginSession session, DateTimeOffset now)
+    {
+        if ((session.Status == TvLoginSessionStatus.Pending || session.Status == TvLoginSessionStatus.Viewed)
+            && session.ExpiresAt <= now)
+        {
+            return "expired";
+        }
+
+        return session.Status switch
+        {
+            TvLoginSessionStatus.Pending => "pending",
+            TvLoginSessionStatus.Viewed => "viewed",
+            TvLoginSessionStatus.Approved => "approved",
+            TvLoginSessionStatus.Denied => "denied",
+            TvLoginSessionStatus.Expired => "expired",
+            TvLoginSessionStatus.Consumed => "consumed",
+            _ => "expired",
+        };
+    }
+
+    private static bool TryParseStatus(string status, out TvLoginSessionStatus parsed)
+    {
+        switch (status.Trim().ToLowerInvariant())
+        {
+            case "pending":
+                parsed = TvLoginSessionStatus.Pending;
+                return true;
+            case "viewed":
+                parsed = TvLoginSessionStatus.Viewed;
+                return true;
+            case "approved":
+                parsed = TvLoginSessionStatus.Approved;
+                return true;
+            case "denied":
+                parsed = TvLoginSessionStatus.Denied;
+                return true;
+            case "expired":
+                parsed = TvLoginSessionStatus.Expired;
+                return true;
+            case "consumed":
+                parsed = TvLoginSessionStatus.Consumed;
+                return true;
+            default:
+                parsed = default;
+                return false;
+        }
+    }
+}

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Hubs;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Login;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
@@ -18,6 +19,7 @@ public sealed class TvLoginSessionService(
     ICommandService<TvLoginSession, Guid> sessionCommand,
     IUserQueryService userQueryService,
     ITokenService tokenService,
+    ITvLoginHubNotifier hubNotifier,
     IMemoryCache cache,
     IConfiguration configuration,
     IHttpContextAccessor httpContextAccessor,
@@ -30,7 +32,7 @@ public sealed class TvLoginSessionService(
 
     private const int DefaultTtlMinutes = 5;
     private const int PollIntervalSeconds = 2;
-    private const int UserCodeLength = 8;
+    private const int UserCodeLength = 6;
     private const int CreateRateLimitMax = 10;
     private const int CreateRateLimitWindowMinutes = 10;
     private const int PollRateLimitMax = 200;
@@ -88,6 +90,7 @@ public sealed class TvLoginSessionService(
             QrPayload = qrPayload,
             ExpiresAt = session.ExpiresAt,
             PollIntervalSeconds = PollIntervalSeconds,
+            SignalRHubPath = TvLoginHub.HubPath,
         };
     }
 
@@ -101,11 +104,12 @@ public sealed class TvLoginSessionService(
         var session = await sessionQuery.GetById(sessionId, ct)
                       ?? throw new InvalidOperationException(SessionNotFoundMessage);
 
-        session = await EnsureNotStalePendingAsync(session, ct);
+        session = await EnsureNotStaleOpenAsync(session, ct);
 
         return session.Status switch
         {
             TvLoginSessionStatus.Pending => StatusOnly(session, "pending"),
+            TvLoginSessionStatus.Viewed => StatusOnly(session, "viewed"),
             TvLoginSessionStatus.Denied => StatusOnly(session, "denied"),
             TvLoginSessionStatus.Expired => StatusOnly(session, "expired"),
             TvLoginSessionStatus.Consumed => StatusOnly(session, "consumed"),
@@ -121,23 +125,44 @@ public sealed class TvLoginSessionService(
             throw new InvalidOperationException(SessionNotFoundMessage);
 
         var session = await sessionQuery.GetActiveByUserCode(normalized, ct);
-        if (session is not null)
+        if (session is null)
         {
-            return new TvLoginSessionPreviewResponse
-            {
-                SessionId = session.Id,
-                UserCode = FormatUserCode(session.UserCode),
-                DeviceName = session.DeviceName,
-                ExpiresAt = session.ExpiresAt,
-                Status = "pending",
-            };
+            var latest = await sessionQuery.GetLatestByUserCode(normalized, ct);
+            if (latest is null)
+                throw new InvalidOperationException(SessionNotFoundMessage);
+            throw new InvalidOperationException(SessionExpiredMessage);
         }
 
-        var latest = await sessionQuery.GetLatestByUserCode(normalized, ct);
-        if (latest is null)
-            throw new InvalidOperationException(SessionNotFoundMessage);
+        session = await EnsureNotStaleOpenAsync(session, ct);
+        if (session.Status is not (TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
+            throw new InvalidOperationException(SessionExpiredMessage);
 
-        throw new InvalidOperationException(SessionExpiredMessage);
+        // Phone opened the link / entered the code — mark viewed so TV (hub or poll) can show "continue on phone".
+        if (session.Status == TvLoginSessionStatus.Pending)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var affected = await sessionCommand.UpdateWhere(
+                s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Pending && s.ExpiresAt > now,
+                set => set
+                    .SetProperty(x => x.Status, TvLoginSessionStatus.Viewed)
+                    .SetProperty(x => x.LastUpdate, now),
+                ct);
+            if (affected == 1)
+            {
+                session.Status = TvLoginSessionStatus.Viewed;
+                await hubNotifier.NotifyStatusAsync(session.Id, "viewed", session.ExpiresAt, ct);
+            }
+        }
+
+        return new TvLoginSessionPreviewResponse
+        {
+            SessionId = session.Id,
+            UserCode = FormatUserCode(session.UserCode),
+            DeviceName = session.DeviceName,
+            ExpiresAt = session.ExpiresAt,
+            // Phone approve UI always treats an open session as pending confirmation.
+            Status = "pending",
+        };
     }
 
     public async Task<TvLoginSessionActionResponse> ApproveAsync(
@@ -151,18 +176,18 @@ public sealed class TvLoginSessionService(
             ApproveRateLimitMax,
             ApproveRateLimitWindowMinutes);
 
-        var session = await ResolvePendingSessionAsync(request.SessionId, request.UserCode, ct);
+        var session = await ResolveOpenSessionAsync(request.SessionId, request.UserCode, ct);
         var user = await userQueryService.GetById(approvingUserId, ct)
                    ?? throw new UnauthorizedAccessException("User not found.");
 
         if (user.IsBlocked)
             throw new UnauthorizedAccessException("User account is blocked.");
 
-        // Phone Bearer already passed JWT auth (and TOTP at login when required). Issue TV tokens only after approve;
-        // TV poll receives final tokens — no second TOTP challenge on the TV.
         var now = DateTimeOffset.UtcNow;
         var affected = await sessionCommand.UpdateWhere(
-            s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Pending && s.ExpiresAt > now,
+            s => s.Id == session.Id
+                 && (s.Status == TvLoginSessionStatus.Pending || s.Status == TvLoginSessionStatus.Viewed)
+                 && s.ExpiresAt > now,
             set => set
                 .SetProperty(x => x.Status, TvLoginSessionStatus.Approved)
                 .SetProperty(x => x.ApprovedUserId, approvingUserId)
@@ -178,6 +203,8 @@ public sealed class TvLoginSessionService(
             session.Id,
             approvingUserId);
 
+        await hubNotifier.NotifyStatusAsync(session.Id, "approved", session.ExpiresAt, ct);
+
         return new TvLoginSessionActionResponse { Status = "approved" };
     }
 
@@ -192,10 +219,12 @@ public sealed class TvLoginSessionService(
             ApproveRateLimitMax,
             ApproveRateLimitWindowMinutes);
 
-        var session = await ResolvePendingSessionAsync(request.SessionId, request.UserCode, ct);
+        var session = await ResolveOpenSessionAsync(request.SessionId, request.UserCode, ct);
         var now = DateTimeOffset.UtcNow;
         var affected = await sessionCommand.UpdateWhere(
-            s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Pending && s.ExpiresAt > now,
+            s => s.Id == session.Id
+                 && (s.Status == TvLoginSessionStatus.Pending || s.Status == TvLoginSessionStatus.Viewed)
+                 && s.ExpiresAt > now,
             set => set
                 .SetProperty(x => x.Status, TvLoginSessionStatus.Denied)
                 .SetProperty(x => x.CompletedAt, now)
@@ -209,6 +238,8 @@ public sealed class TvLoginSessionService(
             "TV login session {SessionId} denied by user {UserId}",
             session.Id,
             denyingUserId);
+
+        await hubNotifier.NotifyStatusAsync(session.Id, "denied", session.ExpiresAt, ct);
 
         return new TvLoginSessionActionResponse { Status = "denied" };
     }
@@ -227,10 +258,10 @@ public sealed class TvLoginSessionService(
         if (user is null || user.IsBlocked)
         {
             await MarkConsumedAsync(session.Id, ct);
+            await hubNotifier.NotifyStatusAsync(session.Id, "consumed", session.ExpiresAt, ct);
             return StatusOnly(session, "expired");
         }
 
-        // Claim one-time delivery before issuing tokens to avoid replay.
         var now = DateTimeOffset.UtcNow;
         var claimed = await sessionCommand.UpdateWhere(
             s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Approved,
@@ -253,6 +284,8 @@ public sealed class TvLoginSessionService(
             "TV login session {SessionId} tokens issued for user {UserId} (consumed)",
             session.Id,
             user.Id);
+
+        await hubNotifier.NotifyStatusAsync(session.Id, "consumed", session.ExpiresAt, ct);
 
         return new TvLoginSessionPollResponse
         {
@@ -282,7 +315,7 @@ public sealed class TvLoginSessionService(
             ct);
     }
 
-    private async Task<TvLoginSession> ResolvePendingSessionAsync(
+    private async Task<TvLoginSession> ResolveOpenSessionAsync(
         Guid? sessionId,
         string? userCode,
         CancellationToken ct)
@@ -303,31 +336,36 @@ public sealed class TvLoginSessionService(
         if (session is null)
             throw new InvalidOperationException(SessionNotFoundMessage);
 
-        session = await EnsureNotStalePendingAsync(session, ct);
+        session = await EnsureNotStaleOpenAsync(session, ct);
 
-        if (session.Status != TvLoginSessionStatus.Pending)
+        if (session.Status is not (TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
             throw new InvalidOperationException(SessionNotPendingMessage);
 
         return session;
     }
 
-    private async Task<TvLoginSession> EnsureNotStalePendingAsync(TvLoginSession session, CancellationToken ct)
+    private async Task<TvLoginSession> EnsureNotStaleOpenAsync(TvLoginSession session, CancellationToken ct)
     {
-        if (session.Status != TvLoginSessionStatus.Pending)
+        if (session.Status is not (TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
             return session;
 
         if (session.ExpiresAt > DateTimeOffset.UtcNow)
             return session;
 
         var now = DateTimeOffset.UtcNow;
+        var previous = session.Status;
         await sessionCommand.UpdateWhere(
-            s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Pending,
+            s => s.Id == session.Id
+                 && (s.Status == TvLoginSessionStatus.Pending || s.Status == TvLoginSessionStatus.Viewed),
             set => set
                 .SetProperty(x => x.Status, TvLoginSessionStatus.Expired)
                 .SetProperty(x => x.LastUpdate, now),
             ct);
 
         session.Status = TvLoginSessionStatus.Expired;
+        if (previous is TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed)
+            await hubNotifier.NotifyStatusAsync(session.Id, "expired", session.ExpiresAt, ct);
+
         return session;
     }
 
@@ -345,13 +383,9 @@ public sealed class TvLoginSessionService(
 
     private static string GenerateRawUserCode()
     {
-        const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-        var bytes = new byte[UserCodeLength];
-        RandomNumberGenerator.Fill(bytes);
-        var result = new char[UserCodeLength];
-        for (var i = 0; i < UserCodeLength; i++)
-            result[i] = chars[bytes[i] % chars.Length];
-        return new string(result);
+        // Cryptographically random 6-digit code, including leading zeros (stored as string).
+        var value = RandomNumberGenerator.GetInt32(0, 1_000_000);
+        return value.ToString("D6");
     }
 
     internal static string NormalizeUserCode(string? userCode)
@@ -364,18 +398,14 @@ public sealed class TvLoginSessionService(
         {
             if (ch is '-' or ' ' or '\t')
                 continue;
-            sb.Append(char.ToUpperInvariant(ch));
+            if (ch is >= '0' and <= '9')
+                sb.Append(ch);
         }
 
         return sb.ToString();
     }
 
-    internal static string FormatUserCode(string normalized)
-    {
-        if (normalized.Length != UserCodeLength)
-            return normalized;
-        return $"{normalized[..4]}-{normalized[4..]}";
-    }
+    internal static string FormatUserCode(string normalized) => normalized;
 
     private string GetPublicWebBaseUrl()
     {

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
@@ -410,8 +410,13 @@ public sealed class TvLoginSessionService(
     private string GetPublicWebBaseUrl()
     {
         var configured = configuration["Auth:PublicWebBaseUrl"]
-                         ?? configuration["Frontend:BaseUrl"]
-                         ?? "https://dash.datagateapp.com";
+                         ?? configuration["Frontend:BaseUrl"];
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            throw new InvalidOperationException(
+                "Auth:PublicWebBaseUrl is not configured. Set Auth__PublicWebBaseUrl (or Frontend__BaseUrl) to the public web origin used in TV QR links, e.g. https://dash.example.com");
+        }
+
         return configured.TrimEnd('/');
     }
 

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
@@ -1,0 +1,463 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Api.Auth.Login;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Requests;
+using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
+
+namespace DataGateMonitor.Services.Api.Auth.TvLogin;
+
+public sealed class TvLoginSessionService(
+    ITvLoginSessionQueryService sessionQuery,
+    ICommandService<TvLoginSession, Guid> sessionCommand,
+    IUserQueryService userQueryService,
+    ITokenService tokenService,
+    IMemoryCache cache,
+    IConfiguration configuration,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<TvLoginSessionService> logger) : ITvLoginSessionService
+{
+    public const string RateLimitMessage = "Too many requests. Try again later.";
+    public const string SessionNotFoundMessage = "TV login session not found.";
+    public const string SessionExpiredMessage = "TV login session has expired.";
+    public const string SessionNotPendingMessage = "TV login session is no longer pending.";
+
+    private const int DefaultTtlMinutes = 5;
+    private const int PollIntervalSeconds = 2;
+    private const int UserCodeLength = 8;
+    private const int CreateRateLimitMax = 10;
+    private const int CreateRateLimitWindowMinutes = 10;
+    private const int PollRateLimitMax = 200;
+    private const int PollRateLimitWindowMinutes = 10;
+    private const int ApproveRateLimitMax = 30;
+    private const int ApproveRateLimitWindowMinutes = 10;
+
+    private static readonly ConcurrentDictionary<string, object> RateLimitLocks = new();
+
+    public async Task<CreateTvLoginSessionResponse> CreateSessionAsync(
+        CreateTvLoginSessionRequest request,
+        string? clientIp,
+        CancellationToken ct)
+    {
+        EnsureNotRateLimited($"tvlogin:rl:create:{IpKey(clientIp)}", CreateRateLimitMax, CreateRateLimitWindowMinutes);
+
+        var ttlMinutes = configuration.GetValue<int?>("Auth:TvLoginSessionMinutes") ?? DefaultTtlMinutes;
+        if (ttlMinutes <= 0)
+            ttlMinutes = DefaultTtlMinutes;
+
+        var (deviceId, userAgent) = GetClientInfo();
+        var userCode = await GenerateUniqueUserCodeAsync(ct);
+        var now = DateTimeOffset.UtcNow;
+        var session = new TvLoginSession
+        {
+            Id = Guid.NewGuid(),
+            UserCode = userCode,
+            Status = TvLoginSessionStatus.Pending,
+            DeviceName = Truncate(request.DeviceName?.Trim(), 128),
+            Client = Truncate(request.Client?.Trim(), 64),
+            ExpiresAt = now.AddMinutes(ttlMinutes),
+            DeviceId = Truncate(deviceId, 128),
+            UserAgent = Truncate(userAgent, 512),
+        };
+
+        await sessionCommand.Add(session, ct: ct);
+
+        var formattedCode = FormatUserCode(userCode);
+        var baseUrl = GetPublicWebBaseUrl();
+        var verificationUrl = $"{baseUrl}/tv/link";
+        var qrPayload = $"{verificationUrl}?code={Uri.EscapeDataString(formattedCode)}";
+
+        logger.LogInformation(
+            "Created TV login session {SessionId} (device={DeviceName}, client={Client}, expires={ExpiresAt})",
+            session.Id,
+            session.DeviceName,
+            session.Client,
+            session.ExpiresAt);
+
+        return new CreateTvLoginSessionResponse
+        {
+            SessionId = session.Id,
+            UserCode = formattedCode,
+            VerificationUrl = verificationUrl,
+            QrPayload = qrPayload,
+            ExpiresAt = session.ExpiresAt,
+            PollIntervalSeconds = PollIntervalSeconds,
+        };
+    }
+
+    public async Task<TvLoginSessionPollResponse> PollSessionAsync(
+        Guid sessionId,
+        string? clientIp,
+        CancellationToken ct)
+    {
+        EnsureNotRateLimited($"tvlogin:rl:poll:{IpKey(clientIp)}", PollRateLimitMax, PollRateLimitWindowMinutes);
+
+        var session = await sessionQuery.GetById(sessionId, ct)
+                      ?? throw new InvalidOperationException(SessionNotFoundMessage);
+
+        session = await EnsureNotStalePendingAsync(session, ct);
+
+        return session.Status switch
+        {
+            TvLoginSessionStatus.Pending => StatusOnly(session, "pending"),
+            TvLoginSessionStatus.Denied => StatusOnly(session, "denied"),
+            TvLoginSessionStatus.Expired => StatusOnly(session, "expired"),
+            TvLoginSessionStatus.Consumed => StatusOnly(session, "consumed"),
+            TvLoginSessionStatus.Approved => await DeliverTokensOnceAsync(session, ct),
+            _ => StatusOnly(session, "expired"),
+        };
+    }
+
+    public async Task<TvLoginSessionPreviewResponse> GetByUserCodeAsync(string userCode, CancellationToken ct)
+    {
+        var normalized = NormalizeUserCode(userCode);
+        if (normalized.Length != UserCodeLength)
+            throw new InvalidOperationException(SessionNotFoundMessage);
+
+        var session = await sessionQuery.GetActiveByUserCode(normalized, ct);
+        if (session is not null)
+        {
+            return new TvLoginSessionPreviewResponse
+            {
+                SessionId = session.Id,
+                UserCode = FormatUserCode(session.UserCode),
+                DeviceName = session.DeviceName,
+                ExpiresAt = session.ExpiresAt,
+                Status = "pending",
+            };
+        }
+
+        var latest = await sessionQuery.GetLatestByUserCode(normalized, ct);
+        if (latest is null)
+            throw new InvalidOperationException(SessionNotFoundMessage);
+
+        throw new InvalidOperationException(SessionExpiredMessage);
+    }
+
+    public async Task<TvLoginSessionActionResponse> ApproveAsync(
+        ApproveTvLoginSessionRequest request,
+        int approvingUserId,
+        string? clientIp,
+        CancellationToken ct)
+    {
+        EnsureNotRateLimited(
+            $"tvlogin:rl:approve:{approvingUserId}:{IpKey(clientIp)}",
+            ApproveRateLimitMax,
+            ApproveRateLimitWindowMinutes);
+
+        var session = await ResolvePendingSessionAsync(request.SessionId, request.UserCode, ct);
+        var user = await userQueryService.GetById(approvingUserId, ct)
+                   ?? throw new UnauthorizedAccessException("User not found.");
+
+        if (user.IsBlocked)
+            throw new UnauthorizedAccessException("User account is blocked.");
+
+        // Phone Bearer already passed JWT auth (and TOTP at login when required). Issue TV tokens only after approve;
+        // TV poll receives final tokens — no second TOTP challenge on the TV.
+        var now = DateTimeOffset.UtcNow;
+        var affected = await sessionCommand.UpdateWhere(
+            s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Pending && s.ExpiresAt > now,
+            set => set
+                .SetProperty(x => x.Status, TvLoginSessionStatus.Approved)
+                .SetProperty(x => x.ApprovedUserId, approvingUserId)
+                .SetProperty(x => x.CompletedAt, now)
+                .SetProperty(x => x.LastUpdate, now),
+            ct);
+
+        if (affected != 1)
+            throw new InvalidOperationException(SessionNotPendingMessage);
+
+        logger.LogInformation(
+            "TV login session {SessionId} approved by user {UserId}",
+            session.Id,
+            approvingUserId);
+
+        return new TvLoginSessionActionResponse { Status = "approved" };
+    }
+
+    public async Task<TvLoginSessionActionResponse> DenyAsync(
+        DenyTvLoginSessionRequest request,
+        int denyingUserId,
+        string? clientIp,
+        CancellationToken ct)
+    {
+        EnsureNotRateLimited(
+            $"tvlogin:rl:deny:{denyingUserId}:{IpKey(clientIp)}",
+            ApproveRateLimitMax,
+            ApproveRateLimitWindowMinutes);
+
+        var session = await ResolvePendingSessionAsync(request.SessionId, request.UserCode, ct);
+        var now = DateTimeOffset.UtcNow;
+        var affected = await sessionCommand.UpdateWhere(
+            s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Pending && s.ExpiresAt > now,
+            set => set
+                .SetProperty(x => x.Status, TvLoginSessionStatus.Denied)
+                .SetProperty(x => x.CompletedAt, now)
+                .SetProperty(x => x.LastUpdate, now),
+            ct);
+
+        if (affected != 1)
+            throw new InvalidOperationException(SessionNotPendingMessage);
+
+        logger.LogInformation(
+            "TV login session {SessionId} denied by user {UserId}",
+            session.Id,
+            denyingUserId);
+
+        return new TvLoginSessionActionResponse { Status = "denied" };
+    }
+
+    private async Task<TvLoginSessionPollResponse> DeliverTokensOnceAsync(
+        TvLoginSession session,
+        CancellationToken ct)
+    {
+        if (session.ApprovedUserId is null)
+        {
+            logger.LogWarning("TV login session {SessionId} is approved but has no ApprovedUserId", session.Id);
+            return StatusOnly(session, "expired");
+        }
+
+        var user = await userQueryService.GetById(session.ApprovedUserId.Value, ct);
+        if (user is null || user.IsBlocked)
+        {
+            await MarkConsumedAsync(session.Id, ct);
+            return StatusOnly(session, "expired");
+        }
+
+        // Claim one-time delivery before issuing tokens to avoid replay.
+        var now = DateTimeOffset.UtcNow;
+        var claimed = await sessionCommand.UpdateWhere(
+            s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Approved,
+            set => set
+                .SetProperty(x => x.Status, TvLoginSessionStatus.Consumed)
+                .SetProperty(x => x.LastUpdate, now),
+            ct);
+
+        if (claimed != 1)
+            return StatusOnly(session, "consumed");
+
+        var tokenPair = await tokenService.IssueAsync(
+            userId: user.Id,
+            externalId: null,
+            deviceId: session.DeviceId,
+            userAgent: session.UserAgent ?? session.Client ?? "android-tv",
+            ct: ct);
+
+        logger.LogInformation(
+            "TV login session {SessionId} tokens issued for user {UserId} (consumed)",
+            session.Id,
+            user.Id);
+
+        return new TvLoginSessionPollResponse
+        {
+            Status = "approved",
+            ExpiresAt = session.ExpiresAt,
+            UserId = user.Id,
+            DisplayName = user.DisplayName,
+            Email = user.Email,
+            Token = tokenPair.AccessToken,
+            Expiration = tokenPair.AccessExpiresAt,
+            RefreshToken = tokenPair.RefreshToken,
+            RefreshExpiration = tokenPair.RefreshExpiresAt,
+            RequiresTotp = false,
+            LoginChallengeId = null,
+            RequiresTotpSetup = false,
+        };
+    }
+
+    private async Task MarkConsumedAsync(Guid sessionId, CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        await sessionCommand.UpdateWhere(
+            s => s.Id == sessionId && s.Status == TvLoginSessionStatus.Approved,
+            set => set
+                .SetProperty(x => x.Status, TvLoginSessionStatus.Consumed)
+                .SetProperty(x => x.LastUpdate, now),
+            ct);
+    }
+
+    private async Task<TvLoginSession> ResolvePendingSessionAsync(
+        Guid? sessionId,
+        string? userCode,
+        CancellationToken ct)
+    {
+        TvLoginSession? session = null;
+
+        if (sessionId is { } id && id != Guid.Empty)
+            session = await sessionQuery.GetById(id, ct);
+
+        if (session is null && !string.IsNullOrWhiteSpace(userCode))
+        {
+            var normalized = NormalizeUserCode(userCode);
+            if (normalized.Length == UserCodeLength)
+                session = await sessionQuery.GetActiveByUserCode(normalized, ct)
+                          ?? await sessionQuery.GetLatestByUserCode(normalized, ct);
+        }
+
+        if (session is null)
+            throw new InvalidOperationException(SessionNotFoundMessage);
+
+        session = await EnsureNotStalePendingAsync(session, ct);
+
+        if (session.Status != TvLoginSessionStatus.Pending)
+            throw new InvalidOperationException(SessionNotPendingMessage);
+
+        return session;
+    }
+
+    private async Task<TvLoginSession> EnsureNotStalePendingAsync(TvLoginSession session, CancellationToken ct)
+    {
+        if (session.Status != TvLoginSessionStatus.Pending)
+            return session;
+
+        if (session.ExpiresAt > DateTimeOffset.UtcNow)
+            return session;
+
+        var now = DateTimeOffset.UtcNow;
+        await sessionCommand.UpdateWhere(
+            s => s.Id == session.Id && s.Status == TvLoginSessionStatus.Pending,
+            set => set
+                .SetProperty(x => x.Status, TvLoginSessionStatus.Expired)
+                .SetProperty(x => x.LastUpdate, now),
+            ct);
+
+        session.Status = TvLoginSessionStatus.Expired;
+        return session;
+    }
+
+    private async Task<string> GenerateUniqueUserCodeAsync(CancellationToken ct)
+    {
+        for (var attempt = 0; attempt < 32; attempt++)
+        {
+            var code = GenerateRawUserCode();
+            if (!await sessionQuery.AnyActiveByUserCode(code, ct))
+                return code;
+        }
+
+        throw new InvalidOperationException("Unable to allocate a unique TV login code. Try again.");
+    }
+
+    private static string GenerateRawUserCode()
+    {
+        const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        var bytes = new byte[UserCodeLength];
+        RandomNumberGenerator.Fill(bytes);
+        var result = new char[UserCodeLength];
+        for (var i = 0; i < UserCodeLength; i++)
+            result[i] = chars[bytes[i] % chars.Length];
+        return new string(result);
+    }
+
+    internal static string NormalizeUserCode(string? userCode)
+    {
+        if (string.IsNullOrWhiteSpace(userCode))
+            return string.Empty;
+
+        var sb = new StringBuilder(UserCodeLength);
+        foreach (var ch in userCode)
+        {
+            if (ch is '-' or ' ' or '\t')
+                continue;
+            sb.Append(char.ToUpperInvariant(ch));
+        }
+
+        return sb.ToString();
+    }
+
+    internal static string FormatUserCode(string normalized)
+    {
+        if (normalized.Length != UserCodeLength)
+            return normalized;
+        return $"{normalized[..4]}-{normalized[4..]}";
+    }
+
+    private string GetPublicWebBaseUrl()
+    {
+        var configured = configuration["Auth:PublicWebBaseUrl"]
+                         ?? configuration["Frontend:BaseUrl"]
+                         ?? "https://dash.datagateapp.com";
+        return configured.TrimEnd('/');
+    }
+
+    private static TvLoginSessionPollResponse StatusOnly(TvLoginSession session, string status) => new()
+    {
+        Status = status,
+        ExpiresAt = session.ExpiresAt,
+    };
+
+    private void EnsureNotRateLimited(string cacheKey, int maxRequests, int windowMinutes)
+    {
+        if (IsRateLimited(cacheKey, maxRequests, windowMinutes))
+            throw new InvalidOperationException(RateLimitMessage);
+        RecordRateLimit(cacheKey, windowMinutes);
+    }
+
+    private bool IsRateLimited(string cacheKey, int maxRequests, int windowMinutes)
+    {
+        var gate = RateLimitLocks.GetOrAdd(cacheKey, static _ => new object());
+        lock (gate)
+        {
+            if (!cache.TryGetValue(cacheKey, out RateLimitEntry? entry) || entry is null)
+                return false;
+            return entry.Count >= maxRequests;
+        }
+    }
+
+    private void RecordRateLimit(string cacheKey, int windowMinutes)
+    {
+        var gate = RateLimitLocks.GetOrAdd(cacheKey, static _ => new object());
+        lock (gate)
+        {
+            if (!cache.TryGetValue(cacheKey, out RateLimitEntry? entry) || entry is null)
+            {
+                entry = new RateLimitEntry { Count = 1 };
+                cache.Set(cacheKey, entry, new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(windowMinutes),
+                });
+                return;
+            }
+
+            entry.Count++;
+            cache.Set(cacheKey, entry, new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(windowMinutes),
+            });
+        }
+    }
+
+    private static string IpKey(string? clientIp) =>
+        string.IsNullOrWhiteSpace(clientIp) ? "unknown" : clientIp.Trim();
+
+    private (string? deviceId, string? userAgent) GetClientInfo()
+    {
+        var ctx = httpContextAccessor.HttpContext;
+        if (ctx is null)
+            return (null, null);
+        var userAgent = ctx.Request.Headers.UserAgent.ToString();
+        var deviceId = ctx.Request.Headers["X-Device-Id"].ToString();
+        if (string.IsNullOrWhiteSpace(deviceId))
+            deviceId = null;
+        if (string.IsNullOrWhiteSpace(userAgent))
+            userAgent = null;
+        return (deviceId, userAgent);
+    }
+
+    private static string? Truncate(string? value, int max)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+        return value.Length <= max ? value : value[..max];
+    }
+
+    private sealed class RateLimitEntry
+    {
+        public int Count { get; set; }
+    }
+}

--- a/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
+++ b/DataGateMonitor/Services/Api/Auth/TvLogin/TvLoginSessionService.cs
@@ -1,8 +1,10 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.TvLoginSessionTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
@@ -28,7 +30,10 @@ public sealed class TvLoginSessionService(
     public const string RateLimitMessage = "Too many requests. Try again later.";
     public const string SessionNotFoundMessage = "TV login session not found.";
     public const string SessionExpiredMessage = "TV login session has expired.";
+    public const string SessionDeniedMessage = "TV login session was denied.";
+    public const string SessionAlreadyCompletedMessage = "TV login session was already completed.";
     public const string SessionNotPendingMessage = "TV login session is no longer pending.";
+    public const string SessionCodeMismatchMessage = "TV login session id and user code do not match.";
 
     private const int DefaultTtlMinutes = 5;
     private const int PollIntervalSeconds = 2;
@@ -39,6 +44,9 @@ public sealed class TvLoginSessionService(
     private const int PollRateLimitWindowMinutes = 10;
     private const int ApproveRateLimitMax = 30;
     private const int ApproveRateLimitWindowMinutes = 10;
+    private const int PreviewRateLimitMax = 60;
+    private const int PreviewRateLimitWindowMinutes = 10;
+    private const int CreateInsertRetryMax = 8;
 
     private static readonly ConcurrentDictionary<string, object> RateLimitLocks = new();
 
@@ -49,29 +57,51 @@ public sealed class TvLoginSessionService(
     {
         EnsureNotRateLimited($"tvlogin:rl:create:{IpKey(clientIp)}", CreateRateLimitMax, CreateRateLimitWindowMinutes);
 
+        // Resolve public URL before any DB write so misconfiguration cannot orphan Pending rows.
+        var baseUrl = GetPublicWebBaseUrl();
+
         var ttlMinutes = configuration.GetValue<int?>("Auth:TvLoginSessionMinutes") ?? DefaultTtlMinutes;
         if (ttlMinutes <= 0)
             ttlMinutes = DefaultTtlMinutes;
 
         var (deviceId, userAgent) = GetClientInfo();
-        var userCode = await GenerateUniqueUserCodeAsync(ct);
         var now = DateTimeOffset.UtcNow;
-        var session = new TvLoginSession
+        TvLoginSession? session = null;
+
+        for (var attempt = 0; attempt < CreateInsertRetryMax; attempt++)
         {
-            Id = Guid.NewGuid(),
-            UserCode = userCode,
-            Status = TvLoginSessionStatus.Pending,
-            DeviceName = Truncate(request.DeviceName?.Trim(), 128),
-            Client = Truncate(request.Client?.Trim(), 64),
-            ExpiresAt = now.AddMinutes(ttlMinutes),
-            DeviceId = Truncate(deviceId, 128),
-            UserAgent = Truncate(userAgent, 512),
-        };
+            var userCode = await GenerateUniqueUserCodeAsync(ct);
+            session = new TvLoginSession
+            {
+                Id = Guid.NewGuid(),
+                UserCode = userCode,
+                Status = TvLoginSessionStatus.Pending,
+                DeviceName = Truncate(request.DeviceName?.Trim(), 128),
+                Client = Truncate(request.Client?.Trim(), 64),
+                ExpiresAt = now.AddMinutes(ttlMinutes),
+                DeviceId = Truncate(deviceId, 128),
+                UserAgent = Truncate(userAgent, 512),
+            };
 
-        await sessionCommand.Add(session, ct: ct);
+            try
+            {
+                await sessionCommand.Add(session, ct: ct);
+                break;
+            }
+            catch (Exception ex) when (IsUniqueUserCodeViolation(ex) && attempt < CreateInsertRetryMax - 1)
+            {
+                logger.LogWarning(
+                    ex,
+                    "TV login user code collision on insert (attempt {Attempt}); retrying allocation",
+                    attempt + 1);
+                session = null;
+            }
+        }
 
-        var formattedCode = FormatUserCode(userCode);
-        var baseUrl = GetPublicWebBaseUrl();
+        if (session is null)
+            throw new InvalidOperationException("Unable to allocate a unique TV login code. Try again.");
+
+        var formattedCode = FormatUserCode(session.UserCode);
         var verificationUrl = $"{baseUrl}/tv/link";
         var qrPayload = $"{verificationUrl}?code={Uri.EscapeDataString(formattedCode)}";
 
@@ -118,8 +148,17 @@ public sealed class TvLoginSessionService(
         };
     }
 
-    public async Task<TvLoginSessionPreviewResponse> GetByUserCodeAsync(string userCode, CancellationToken ct)
+    public async Task<TvLoginSessionPreviewResponse> GetByUserCodeAsync(
+        string userCode,
+        int requestingUserId,
+        string? clientIp,
+        CancellationToken ct)
     {
+        EnsureNotRateLimited(
+            $"tvlogin:rl:preview:{requestingUserId}:{IpKey(clientIp)}",
+            PreviewRateLimitMax,
+            PreviewRateLimitWindowMinutes);
+
         var normalized = NormalizeUserCode(userCode);
         if (normalized.Length != UserCodeLength)
             throw new InvalidOperationException(SessionNotFoundMessage);
@@ -130,12 +169,12 @@ public sealed class TvLoginSessionService(
             var latest = await sessionQuery.GetLatestByUserCode(normalized, ct);
             if (latest is null)
                 throw new InvalidOperationException(SessionNotFoundMessage);
-            throw new InvalidOperationException(SessionExpiredMessage);
+            throw new InvalidOperationException(MessageForClosedSession(latest.Status));
         }
 
         session = await EnsureNotStaleOpenAsync(session, ct);
         if (session.Status is not (TvLoginSessionStatus.Pending or TvLoginSessionStatus.Viewed))
-            throw new InvalidOperationException(SessionExpiredMessage);
+            throw new InvalidOperationException(MessageForClosedSession(session.Status));
 
         // Phone opened the link / entered the code — mark viewed so TV (hub or poll) can show "continue on phone".
         if (session.Status == TvLoginSessionStatus.Pending)
@@ -321,16 +360,28 @@ public sealed class TvLoginSessionService(
         CancellationToken ct)
     {
         TvLoginSession? session = null;
+        string? normalizedCode = null;
+        if (!string.IsNullOrWhiteSpace(userCode))
+        {
+            normalizedCode = NormalizeUserCode(userCode);
+            if (normalizedCode.Length != UserCodeLength)
+                normalizedCode = null;
+        }
 
         if (sessionId is { } id && id != Guid.Empty)
-            session = await sessionQuery.GetById(id, ct);
-
-        if (session is null && !string.IsNullOrWhiteSpace(userCode))
         {
-            var normalized = NormalizeUserCode(userCode);
-            if (normalized.Length == UserCodeLength)
-                session = await sessionQuery.GetActiveByUserCode(normalized, ct)
-                          ?? await sessionQuery.GetLatestByUserCode(normalized, ct);
+            session = await sessionQuery.GetById(id, ct);
+            if (session is not null && normalizedCode is not null
+                && !string.Equals(session.UserCode, normalizedCode, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(SessionCodeMismatchMessage);
+            }
+        }
+
+        if (session is null && normalizedCode is not null)
+        {
+            session = await sessionQuery.GetActiveByUserCode(normalizedCode, ct)
+                      ?? await sessionQuery.GetLatestByUserCode(normalizedCode, ct);
         }
 
         if (session is null)
@@ -407,6 +458,13 @@ public sealed class TvLoginSessionService(
 
     internal static string FormatUserCode(string normalized) => normalized;
 
+    internal static string MessageForClosedSession(TvLoginSessionStatus status) => status switch
+    {
+        TvLoginSessionStatus.Denied => SessionDeniedMessage,
+        TvLoginSessionStatus.Approved or TvLoginSessionStatus.Consumed => SessionAlreadyCompletedMessage,
+        _ => SessionExpiredMessage,
+    };
+
     private string GetPublicWebBaseUrl()
     {
         var configured = configuration["Auth:PublicWebBaseUrl"]
@@ -469,6 +527,19 @@ public sealed class TvLoginSessionService(
 
     private static string IpKey(string? clientIp) =>
         string.IsNullOrWhiteSpace(clientIp) ? "unknown" : clientIp.Trim();
+
+    private static bool IsUniqueUserCodeViolation(Exception ex)
+    {
+        for (var cur = ex; cur is not null; cur = cur.InnerException)
+        {
+            if (cur is PostgresException { SqlState: "23505" })
+                return true;
+            if (cur is DbUpdateException db && db.InnerException is PostgresException { SqlState: "23505" })
+                return true;
+        }
+
+        return false;
+    }
 
     private (string? deviceId, string? userAgent) GetClientInfo()
     {

--- a/DataGateMonitor/Services/Api/VpnDataService.cs
+++ b/DataGateMonitor/Services/Api/VpnDataService.cs
@@ -8,7 +8,6 @@ using DataGateMonitor.SharedModels.Enums;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Events;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.OpenVpnProxy;
-using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.Api.PostSetup;
@@ -18,7 +17,6 @@ namespace DataGateMonitor.Services.Api;
 
 public class VpnDataService(
     ILogger<IVpnDataService> logger,
-    IExternalIpAddressService externalIpAddressService,
     IQuotaPlanQueryService quotaPlanQueryService,
     IVpnServerQueryService openVpnServerQueryService,
     IVpnServerOvpnFileConfigQueryService openVpnServerOvpnFileConfigQueryService,
@@ -35,7 +33,7 @@ public class VpnDataService(
     IVpnNodePublicIpLookup vpnNodePublicIpLookup,
     IVpnServerClientPresenceService vpnServerClientPresenceService) : IVpnDataService
 {
-    private static readonly TimeSpan ExternalIpResolveTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan MicroserviceInfoResolveTimeout = TimeSpan.FromSeconds(5);
 
     public async Task<VpnServer> AddVpnServer(VpnServer server, List<int> quotaPlanIds, List<int> tagIds, CancellationToken ct)
     {
@@ -224,10 +222,11 @@ public class VpnDataService(
         if (await openVpnServerOvpnFileConfigQueryService.AnyByVpnServerId(server.Id, ct))
             return false;
 
+        // Empty IP until node /api/info PublicIp is applied — never dashboard WAN IP.
         var config = new VpnServerOvpnFileConfig
         {
             VpnServerId = server.Id,
-            VpnServerIp = await GetExternalIpSafelyAsync(ct),
+            VpnServerIp = string.Empty,
             ConfigTemplate = DefaultOpenVpnClientConfigTemplate,
         };
 
@@ -241,11 +240,11 @@ public class VpnDataService(
         if (await openVpnServerOvpnFileConfigQueryService.AnyByVpnServerId(server.Id, ct))
             return false;
 
-        var ip = await GetExternalIpSafelyAsync(ct);
+        var ip = await TryGetNodePublicIpAsync(server.Id, VpnServerType.Xray, ct) ?? string.Empty;
         await openVpnServerOvpnFileConfigCommandService.Add(new VpnServerOvpnFileConfig
         {
             VpnServerId = server.Id,
-            VpnServerIp = string.IsNullOrWhiteSpace(ip) ? "127.0.0.1" : ip,
+            VpnServerIp = ip,
             VpnServerPort = 443,
             ConfigTemplate = DefaultXrayClientLinkTemplate,
         }, true, ct);
@@ -309,15 +308,20 @@ public class VpnDataService(
             microserviceInfoService,
             logger,
             "Failed to auto-detect default OpenVPN export config for VpnServerId={VpnServerId}.",
-            ct);
+            ct,
+            MicroserviceInfoResolveTimeout);
 
-    private async Task<string> GetExternalIpSafelyAsync(CancellationToken ct)
+    private async Task<string?> TryGetNodePublicIpAsync(int vpnServerId, VpnServerType serverType, CancellationToken ct)
     {
         try
         {
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeoutCts.CancelAfter(ExternalIpResolveTimeout);
-            return await externalIpAddressService.GetRemoteIpAddress(timeoutCts.Token);
+            timeoutCts.CancelAfter(MicroserviceInfoResolveTimeout);
+            var diagnostics = await microserviceInfoService.GetInfoAsync(vpnServerId, timeoutCts.Token);
+            var ip = serverType == VpnServerType.Xray
+                ? diagnostics.Xray?.PublicIp
+                : diagnostics.OpenVpn?.PublicIp;
+            return string.IsNullOrWhiteSpace(ip) ? null : ip.Trim();
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -325,8 +329,8 @@ public class VpnDataService(
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to resolve external IP quickly; fallback to loopback value.");
-            return "127.0.0.1";
+            logger.LogDebug(ex, "VpnServerId: {Id}. Could not load node PublicIp for default export config.", vpnServerId);
+            return null;
         }
     }
 }

--- a/DataGateMonitor/Services/Api/VpnDataService.cs
+++ b/DataGateMonitor/Services/Api/VpnDataService.cs
@@ -341,8 +341,14 @@ public class VpnDataService(
         var root = JObject.FromObject(openVpnInfo, Newtonsoft.Json.JsonSerializer.Create(ProjectJson.WebSettings));
         if (TryGetPropertyIgnoreCase(root, "config", out var cfgToken) && cfgToken is JObject cfg)
         {
-            if (TryGetPropertyIgnoreCase(cfg, "port", out var portToken) && portToken is { Type: JTokenType.Integer })
-                port = portToken.Value<int>();
+            if (TryGetPropertyIgnoreCase(cfg, "port", out var portToken))
+            {
+                if (portToken is { Type: JTokenType.Integer })
+                    port = portToken.Value<int>();
+                else if (portToken is { Type: JTokenType.String } &&
+                         int.TryParse(portToken.Value<string>(), out var parsedPort))
+                    port = parsedPort;
+            }
 
             if (TryGetPropertyIgnoreCase(cfg, "proto", out var protoToken) && protoToken is { Type: JTokenType.String })
             {

--- a/DataGateMonitor/Services/Api/VpnDataService.cs
+++ b/DataGateMonitor/Services/Api/VpnDataService.cs
@@ -12,9 +12,7 @@ using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.Api.PostSetup;
-using DataGateMonitor.Serialization;
-using Newtonsoft.Json.Linq;
-using System.Text.RegularExpressions;
+using DataGateMonitor.Services.Helpers;
 
 namespace DataGateMonitor.Services.Api;
 
@@ -36,7 +34,6 @@ public class VpnDataService(
     IOpenVpnEventClientFactory eventClientFactory) : IVpnDataService
 {
     private static readonly TimeSpan ExternalIpResolveTimeout = TimeSpan.FromSeconds(5);
-    private static readonly TimeSpan OpenVpnAutoDetectTimeout = TimeSpan.FromSeconds(5);
 
     public async Task<VpnServer> AddVpnServer(VpnServer server, List<int> quotaPlanIds, List<int> tagIds, CancellationToken ct)
     {
@@ -291,32 +288,14 @@ public class VpnDataService(
         await openVpnServerTagCommandService.AddRange(links, saveChanges: true, ct);
     }
 
-    private async Task TryApplyDetectedOpenVpnSettingsAsync(int vpnServerId, VpnServerOvpnFileConfig config, CancellationToken ct)
-    {
-        try
-        {
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeoutCts.CancelAfter(OpenVpnAutoDetectTimeout);
-            var diagnostics = await microserviceInfoService.GetInfoAsync(vpnServerId, timeoutCts.Token);
-            if (diagnostics is null || diagnostics.ServerType != VpnServerType.OpenVpn || diagnostics.OpenVpn is null)
-                return;
-
-            if (!TryExtractPortProto(diagnostics.OpenVpn, out var port, out var proto))
-                return;
-
-            if (port is > 0 and <= 65535)
-                config.VpnServerPort = port.Value;
-
-            if (!string.IsNullOrWhiteSpace(proto))
-                config.ConfigTemplate = ReplaceProtoDirective(config.ConfigTemplate, proto);
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(ex,
-                "Failed to auto-detect default OpenVPN export config for VpnServerId={VpnServerId}.",
-                vpnServerId);
-        }
-    }
+    private Task TryApplyDetectedOpenVpnSettingsAsync(int vpnServerId, VpnServerOvpnFileConfig config, CancellationToken ct) =>
+        OpenVpnDetectedSettingsHelper.TryApplyAsync(
+            vpnServerId,
+            config,
+            microserviceInfoService,
+            logger,
+            "Failed to auto-detect default OpenVPN export config for VpnServerId={VpnServerId}.",
+            ct);
 
     private async Task<string> GetExternalIpSafelyAsync(CancellationToken ct)
     {
@@ -326,64 +305,14 @@ public class VpnDataService(
             timeoutCts.CancelAfter(ExternalIpResolveTimeout);
             return await externalIpAddressService.GetRemoteIpAddress(timeoutCts.Token);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to resolve external IP quickly; fallback to loopback value.");
             return "127.0.0.1";
         }
-    }
-
-    private static bool TryExtractPortProto(object openVpnInfo, out int? port, out string? proto)
-    {
-        port = null;
-        proto = null;
-
-        var root = JObject.FromObject(openVpnInfo, Newtonsoft.Json.JsonSerializer.Create(ProjectJson.WebSettings));
-        if (TryGetPropertyIgnoreCase(root, "config", out var cfgToken) && cfgToken is JObject cfg)
-        {
-            if (TryGetPropertyIgnoreCase(cfg, "port", out var portToken))
-            {
-                if (portToken is { Type: JTokenType.Integer })
-                    port = portToken.Value<int>();
-                else if (portToken is { Type: JTokenType.String } &&
-                         int.TryParse(portToken.Value<string>(), out var parsedPort))
-                    port = parsedPort;
-            }
-
-            if (TryGetPropertyIgnoreCase(cfg, "proto", out var protoToken) && protoToken is { Type: JTokenType.String })
-            {
-                var p = protoToken.Value<string>()?.Trim().ToLowerInvariant();
-                if (p is "tcp" or "udp")
-                    proto = p;
-            }
-        }
-
-        return port.HasValue || !string.IsNullOrWhiteSpace(proto);
-    }
-
-    private static bool TryGetPropertyIgnoreCase(JObject obj, string propertyName, out JToken? value)
-    {
-        foreach (var prop in obj.Properties())
-        {
-            if (string.Equals(prop.Name, propertyName, StringComparison.OrdinalIgnoreCase))
-            {
-                value = prop.Value;
-                return true;
-            }
-        }
-
-        value = null;
-        return false;
-    }
-
-    private static string ReplaceProtoDirective(string template, string proto)
-    {
-        if (string.IsNullOrWhiteSpace(template))
-            return template;
-
-        if (Regex.IsMatch(template, @"^\s*proto\s+\S+", RegexOptions.IgnoreCase | RegexOptions.Multiline))
-            return Regex.Replace(template, @"^\s*proto\s+\S+", $"proto {proto}", RegexOptions.IgnoreCase | RegexOptions.Multiline);
-
-        return $"proto {proto}\n{template}";
     }
 }

--- a/DataGateMonitor/Services/Api/VpnDataService.cs
+++ b/DataGateMonitor/Services/Api/VpnDataService.cs
@@ -31,7 +31,9 @@ public class VpnDataService(
     IStatusCacheGenerationService statusCacheGenerationService,
     IMicroserviceInfoService microserviceInfoService,
     IOpenVpnMicroserviceClientFactory microserviceClientFactory,
-    IOpenVpnEventClientFactory eventClientFactory) : IVpnDataService
+    IOpenVpnEventClientFactory eventClientFactory,
+    IVpnNodePublicIpLookup vpnNodePublicIpLookup,
+    IVpnServerClientPresenceService vpnServerClientPresenceService) : IVpnDataService
 {
     private static readonly TimeSpan ExternalIpResolveTimeout = TimeSpan.FromSeconds(5);
 
@@ -84,6 +86,12 @@ public class VpnDataService(
 
     public async Task<VpnServer> UpdateVpnServer(VpnServer server, List<int> quotaPlanIds, List<int> tagIds, CancellationToken ct)
     {
+        var previous = await openVpnServerQueryService.GetById(server.Id, ct)
+                       ?? throw new InvalidOperationException("OpenVPN server not found");
+        var becameDisabled = server.IsDisable && !previous.IsDisable;
+        var apiUrlChanged = !string.Equals(
+            previous.ApiUrl?.Trim(), server.ApiUrl?.Trim(), StringComparison.OrdinalIgnoreCase);
+
         var result = await transactionRunner.RunAsync(async _ =>
         {
             var now = DateTimeOffset.UtcNow;
@@ -123,6 +131,10 @@ public class VpnDataService(
         statusCacheGenerationService.Bump();
         microserviceClientFactory.Invalidate(result.Id);
         eventClientFactory.Remove(result.Id);
+        if (apiUrlChanged)
+            vpnNodePublicIpLookup.Invalidate(result.Id);
+        if (becameDisabled)
+            await vpnServerClientPresenceService.MarkAllDisconnectedAsync(result.Id, ct);
         return result;
     }
 
@@ -136,10 +148,12 @@ public class VpnDataService(
             x => x.Id == vpnServerId,
             u => u.SetProperty(x => x.IsDeleted, true).SetProperty(x => x.LastUpdate, now),
             ct);
+        await vpnServerClientPresenceService.MarkAllDisconnectedAsync(vpnServerId, ct);
         await serverOpenVpnNotificationService.NotifyDeleted(openVpnServer.Id, openVpnServer.ServerName, ct);
         statusCacheGenerationService.Bump();
         microserviceClientFactory.Invalidate(openVpnServer.Id);
         eventClientFactory.Remove(openVpnServer.Id);
+        vpnNodePublicIpLookup.Invalidate(openVpnServer.Id);
         return true;
     }
 

--- a/DataGateMonitor/Services/Api/VpnServerOvpnFileConfigService.cs
+++ b/DataGateMonitor/Services/Api/VpnServerOvpnFileConfigService.cs
@@ -17,6 +17,7 @@ public class VpnServerOvpnFileConfigService(
     IMicroserviceInfoService microserviceInfoService)
     : IVpnServerOvpnFileConfigService
 {
+    private static readonly TimeSpan OpenVpnAutoDetectTimeout = TimeSpan.FromSeconds(5);
     private readonly ILogger<VpnServerOvpnFileConfigService> _logger = logger;
 
 
@@ -63,7 +64,9 @@ public class VpnServerOvpnFileConfigService(
     {
         try
         {
-            var diagnostics = await microserviceInfoService.GetInfoAsync(config.VpnServerId, ct);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(OpenVpnAutoDetectTimeout);
+            var diagnostics = await microserviceInfoService.GetInfoAsync(config.VpnServerId, timeoutCts.Token);
             if (diagnostics is null || diagnostics.ServerType != VpnServerType.OpenVpn || diagnostics.OpenVpn is null)
                 return;
 
@@ -92,8 +95,14 @@ public class VpnServerOvpnFileConfigService(
         var root = JObject.FromObject(openVpnInfo, Newtonsoft.Json.JsonSerializer.Create(ProjectJson.WebSettings));
         if (TryGetPropertyIgnoreCase(root, "config", out var cfgToken) && cfgToken is JObject cfg)
         {
-            if (TryGetPropertyIgnoreCase(cfg, "port", out var portToken) && portToken is { Type: JTokenType.Integer })
-                port = portToken.Value<int>();
+            if (TryGetPropertyIgnoreCase(cfg, "port", out var portToken))
+            {
+                if (portToken is { Type: JTokenType.Integer })
+                    port = portToken.Value<int>();
+                else if (portToken is { Type: JTokenType.String } &&
+                         int.TryParse(portToken.Value<string>(), out var parsedPort))
+                    port = parsedPort;
+            }
 
             if (TryGetPropertyIgnoreCase(cfg, "proto", out var protoToken) && protoToken is { Type: JTokenType.String })
             {

--- a/DataGateMonitor/Services/Api/VpnServerOvpnFileConfigService.cs
+++ b/DataGateMonitor/Services/Api/VpnServerOvpnFileConfigService.cs
@@ -3,36 +3,41 @@ using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
-using DataGateMonitor.SharedModels.Enums;
-using DataGateMonitor.Serialization;
-using Newtonsoft.Json.Linq;
-using System.Text.RegularExpressions;
+using DataGateMonitor.Services.Helpers;
 
 namespace DataGateMonitor.Services.Api;
 
 public class VpnServerOvpnFileConfigService(
-    ILogger<VpnServerOvpnFileConfigService> logger, 
-    IVpnServerOvpnFileConfigQueryService  openVpnServerOvpnFileConfigQueryService,
+    ILogger<VpnServerOvpnFileConfigService> logger,
+    IVpnServerOvpnFileConfigQueryService openVpnServerOvpnFileConfigQueryService,
     ICommandService<VpnServerOvpnFileConfig, int> openVpnServerOvpnFileConfigCommandService,
-    IMicroserviceInfoService microserviceInfoService)
+    IMicroserviceInfoService microserviceInfoService,
+    TimeSpan? openVpnAutoDetectTimeout = null)
     : IVpnServerOvpnFileConfigService
 {
-    private static readonly TimeSpan OpenVpnAutoDetectTimeout = TimeSpan.FromSeconds(5);
     private readonly ILogger<VpnServerOvpnFileConfigService> _logger = logger;
+    private readonly TimeSpan _openVpnAutoDetectTimeout =
+        openVpnAutoDetectTimeout ?? OpenVpnDetectedSettingsHelper.DefaultAutoDetectTimeout;
 
-
-    public async Task<VpnServerOvpnFileConfig> GetVpnServerOvpnFileConfigByServerId(int vpnServerId, 
+    public async Task<VpnServerOvpnFileConfig> GetVpnServerOvpnFileConfigByServerId(int vpnServerId,
         CancellationToken ct)
     {
         return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(vpnServerId, ct)
                ?? throw new InvalidOperationException("OvpnFileConfig not found");
     }
-    
+
     public async Task<VpnServerOvpnFileConfig> AddOrUpdateVpnServerOvpnFileConfigByServerId(
         VpnServerOvpnFileConfig openVpnServerOvpnFileConfig, bool autoDetectServerSettings, CancellationToken ct)
     {
         if (autoDetectServerSettings)
-            await TryApplyDetectedOpenVpnSettingsAsync(openVpnServerOvpnFileConfig, ct);
+            await OpenVpnDetectedSettingsHelper.TryApplyAsync(
+                openVpnServerOvpnFileConfig.VpnServerId,
+                openVpnServerOvpnFileConfig,
+                microserviceInfoService,
+                _logger,
+                "Failed to auto-detect OpenVPN port/proto for VpnServerId={VpnServerId}. Keeping provided values.",
+                ct,
+                _openVpnAutoDetectTimeout);
 
         var existingConfig = await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(
             openVpnServerOvpnFileConfig.VpnServerId, ct);
@@ -50,94 +55,13 @@ public class VpnServerOvpnFileConfigService(
         {
             openVpnServerOvpnFileConfig.CreateDate = DateTimeOffset.UtcNow;
             openVpnServerOvpnFileConfig.LastUpdate = DateTimeOffset.UtcNow;
-            
+
             await openVpnServerOvpnFileConfigCommandService.Add(openVpnServerOvpnFileConfig, true, ct);
         }
-        
+
         return await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(
                    openVpnServerOvpnFileConfig.VpnServerId, ct)
                ?? throw new InvalidOperationException($"OpenVPN server OVPN file configuration not found for " +
                                                       $"server ID {openVpnServerOvpnFileConfig.VpnServerId}.");
-    }
-
-    private async Task TryApplyDetectedOpenVpnSettingsAsync(VpnServerOvpnFileConfig config, CancellationToken ct)
-    {
-        try
-        {
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            timeoutCts.CancelAfter(OpenVpnAutoDetectTimeout);
-            var diagnostics = await microserviceInfoService.GetInfoAsync(config.VpnServerId, timeoutCts.Token);
-            if (diagnostics is null || diagnostics.ServerType != VpnServerType.OpenVpn || diagnostics.OpenVpn is null)
-                return;
-
-            if (!TryExtractPortProto(diagnostics.OpenVpn, out var port, out var proto))
-                return;
-
-            if (port is > 0 and <= 65535)
-                config.VpnServerPort = port.Value;
-
-            if (!string.IsNullOrWhiteSpace(proto))
-                config.ConfigTemplate = ReplaceProtoDirective(config.ConfigTemplate, proto);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex,
-                "Failed to auto-detect OpenVPN port/proto for VpnServerId={VpnServerId}. Keeping provided values.",
-                config.VpnServerId);
-        }
-    }
-
-    private static bool TryExtractPortProto(object openVpnInfo, out int? port, out string? proto)
-    {
-        port = null;
-        proto = null;
-
-        var root = JObject.FromObject(openVpnInfo, Newtonsoft.Json.JsonSerializer.Create(ProjectJson.WebSettings));
-        if (TryGetPropertyIgnoreCase(root, "config", out var cfgToken) && cfgToken is JObject cfg)
-        {
-            if (TryGetPropertyIgnoreCase(cfg, "port", out var portToken))
-            {
-                if (portToken is { Type: JTokenType.Integer })
-                    port = portToken.Value<int>();
-                else if (portToken is { Type: JTokenType.String } &&
-                         int.TryParse(portToken.Value<string>(), out var parsedPort))
-                    port = parsedPort;
-            }
-
-            if (TryGetPropertyIgnoreCase(cfg, "proto", out var protoToken) && protoToken is { Type: JTokenType.String })
-            {
-                var p = protoToken.Value<string>()?.Trim().ToLowerInvariant();
-                if (p is "tcp" or "udp")
-                    proto = p;
-            }
-        }
-
-        return port.HasValue || !string.IsNullOrWhiteSpace(proto);
-    }
-
-    private static bool TryGetPropertyIgnoreCase(JObject obj, string propertyName, out JToken? value)
-    {
-        foreach (var prop in obj.Properties())
-        {
-            if (string.Equals(prop.Name, propertyName, StringComparison.OrdinalIgnoreCase))
-            {
-                value = prop.Value;
-                return true;
-            }
-        }
-
-        value = null;
-        return false;
-    }
-
-    private static string ReplaceProtoDirective(string template, string proto)
-    {
-        if (string.IsNullOrWhiteSpace(template))
-            return template;
-
-        if (Regex.IsMatch(template, @"^\s*proto\s+\S+", RegexOptions.IgnoreCase | RegexOptions.Multiline))
-            return Regex.Replace(template, @"^\s*proto\s+\S+", $"proto {proto}", RegexOptions.IgnoreCase | RegexOptions.Multiline);
-
-        return $"proto {proto}\n{template}";
     }
 }

--- a/DataGateMonitor/Services/BackgroundServices/FreeTierUnsubscribedVpnUsersDailyDigestBackgroundService.cs
+++ b/DataGateMonitor/Services/BackgroundServices/FreeTierUnsubscribedVpnUsersDailyDigestBackgroundService.cs
@@ -1,0 +1,46 @@
+using DataGateMonitor.Services.Users.Interfaces;
+
+namespace DataGateMonitor.Services.BackgroundServices;
+
+/// <summary>
+/// Hourly tick that may send the once-per-UTC-day admin digest of Free/Default VPN users
+/// who are online without a required Telegram channel subscription.
+/// </summary>
+public sealed class FreeTierUnsubscribedVpnUsersDailyDigestBackgroundService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<FreeTierUnsubscribedVpnUsersDailyDigestBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Let the app finish warming up, then check roughly once an hour.
+        await Task.Delay(TimeSpan.FromMinutes(2), stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var digest = scope.ServiceProvider
+                    .GetRequiredService<IFreeTierUnsubscribedVpnUsersDailyDigestService>();
+                await digest.TrySendDailyDigestAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Unsubscribed VPN-users daily digest iteration failed.");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/DataGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
+++ b/DataGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
@@ -6,6 +6,7 @@ using Npgsql;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Services.BackgroundServices.Interfaces;
 using DataGateMonitor.Services.Cache;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.Others.Notifications.ServerOpenVpnApiClient;
 using DataGateMonitor.Services.StatusStreamLogs;
@@ -109,8 +110,13 @@ public class OpenVpnBackgroundService : BackgroundService, IOpenVpnBackgroundSer
 
             // Disabled rows are never polled — still publish Idle so the status stream is not empty and
             // clients do not treat "missing server" as Pending for the whole fleet.
+            // Also clear hanging IsConnected sessions (disable may have been set outside UpdateVpnServer).
+            var presence = scope.ServiceProvider.GetRequiredService<IVpnServerClientPresenceService>();
             foreach (var skipped in openVpnServers.Where(s => s.IsDisable))
+            {
                 _statusManager.UpdateStatus(skipped.Id, ServiceStatus.Idle, nextRunSeconds);
+                await presence.MarkAllDisconnectedAsync(skipped.Id, cancellationToken);
+            }
 
             var serversToPoll = openVpnServers.Where(x => x.IsDisable != true).ToList();
             _logger.LogInformation(

--- a/DataGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
+++ b/DataGateMonitor/Services/BackgroundServices/OpenVpnBackgroundService.cs
@@ -32,6 +32,8 @@ public class OpenVpnBackgroundService : BackgroundService, IOpenVpnBackgroundSer
     private readonly int _maxPollingDegreeOfParallelism;
     private CancellationTokenSource _delayTokenSource = new();
     private readonly ConcurrentDictionary<int, ServiceStatus> _previousStatusByServer = new();
+    private DateTimeOffset _lastStatusCacheBumpUtc = DateTimeOffset.MinValue;
+    private static readonly TimeSpan StatusCacheBumpMaxInterval = TimeSpan.FromMinutes(2);
     public OpenVpnBackgroundService(
         ILogger<OpenVpnBackgroundService> logger,
         IServiceProvider serviceProvider,
@@ -269,11 +271,32 @@ public class OpenVpnBackgroundService : BackgroundService, IOpenVpnBackgroundSer
                 }
             });
 
+            var statusChanged = false;
             foreach (var (serverId, dto) in _statusManager.GetAllStatuses())
             {
-                _previousStatusByServer.AddOrUpdate(serverId, dto.Status, (_, _) => dto.Status);
+                _previousStatusByServer.AddOrUpdate(
+                    serverId,
+                    _ =>
+                    {
+                        statusChanged = true;
+                        return dto.Status;
+                    },
+                    (_, previous) =>
+                    {
+                        if (previous != dto.Status)
+                            statusChanged = true;
+                        return dto.Status;
+                    });
             }
-            _statusCacheGenerationService.Bump();
+
+            // Avoid invalidating get-all-with-status on every poll; refresh at least every 2 minutes
+            // so CountSessions stays reasonably fresh while Redis overlays keep connected counts live.
+            var nowUtc = DateTimeOffset.UtcNow;
+            if (statusChanged || nowUtc - _lastStatusCacheBumpUtc >= StatusCacheBumpMaxInterval)
+            {
+                _statusCacheGenerationService.Bump();
+                _lastStatusCacheBumpUtc = nowUtc;
+            }
 
             _logger.LogInformation(
                 "VPN polling cycle completed in {ElapsedMs} ms. Processed={Processed}, Success={Success}, Timeouts={Timeouts}, Failed={Failed}, Disabled={Disabled}.",

--- a/DataGateMonitor/Services/BackgroundServices/OpenVpnServerProcessor.cs
+++ b/DataGateMonitor/Services/BackgroundServices/OpenVpnServerProcessor.cs
@@ -2,6 +2,7 @@ using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.BackgroundServices.Interfaces;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.Services.Helpers;
 
 namespace DataGateMonitor.Services.BackgroundServices;
 
@@ -18,6 +19,7 @@ public class OpenVpnServerProcessor(
         using var scope = serviceProvider.CreateScope();
         var openVpnServerService = scope.ServiceProvider.GetRequiredService<IVpnServerService>();
         var serverCmd = scope.ServiceProvider.GetRequiredService<ICommandService<VpnServer, int>>();
+        var presence = scope.ServiceProvider.GetRequiredService<IVpnServerClientPresenceService>();
 
         try
         {
@@ -44,13 +46,14 @@ public class OpenVpnServerProcessor(
         }
         catch (Exception ex)
         {
-            // Mark server offline on failure
+            // Mark server offline and clear hanging "online" sessions — we can no longer observe the node.
             var now = DateTimeOffset.UtcNow;
             await serverCmd.UpdateWhere(
                 s => s.Id == openVpnServer.Id,
                 u => u.SetProperty(x => x.IsOnline, false)
                     .SetProperty(x => x.LastUpdate, now),
                 ct);
+            await presence.MarkAllDisconnectedAsync(openVpnServer.Id, ct);
 
             logger.LogError(ex,
                 "OpenVpnServerProcessor error. VpnServerId: {Id}. Name: {Name}. Url: {Url}",

--- a/DataGateMonitor/Services/BackgroundServices/VpnServerService.cs
+++ b/DataGateMonitor/Services/BackgroundServices/VpnServerService.cs
@@ -2,17 +2,18 @@ using DataGateMonitor.DataBase.Services.Command;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Command.VpnServerClientTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
+using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerStatusLogTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.Models.Helpers.Services;
 using DataGateMonitor.Services.BackgroundServices.Interfaces;
 using DataGateMonitor.Services.Helpers;
-using DataGateMonitor.Services.Helpers.Interfaces;
 using DataGateMonitor.Services.Cache;
 using DataGateMonitor.Services.DataGateOpenVpnManager;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces;
 using DataGateMonitor.Services.OpenVpnManagementInterfaces.Interfaces;
+using DataGateMonitor.SharedModels.Enums;
 
 namespace DataGateMonitor.Services.BackgroundServices;
 
@@ -24,7 +25,8 @@ public class VpnServerService(
     IOpenVpnStateService openVpnStateService,
     IIssuedOvpnFileQueryService openVpnFileQueryService,
     IVpnServerStatusLogQueryService openVpnServerStatusLogQueryService,
-    IExternalIpAddressService externalIpAddressService,
+    IVpnServerOvpnFileConfigQueryService openVpnServerOvpnFileConfigQueryService,
+    IVpnNodePublicIpLookup vpnNodePublicIpLookup,
     ITransactionRunner transactionRunner,
     IUserQueryService userQueryService,
     ICommandService<VpnServer, int> openVpnServerCommandService,
@@ -166,10 +168,17 @@ public class VpnServerService(
                     $"Check the OpenVPN management 'state' payload format or server configuration.");
             }
 
-            serverInfo.OpenVpnState.ServerRemoteIp = await externalIpAddressService.GetRemoteIpAddress(ct);
-
             if (serverInfo.OpenVpnState != null)
             {
+                var ovpnConfig = await openVpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(
+                    openVpnServer.Id, ct);
+                var nodePublicIp = await vpnNodePublicIpLookup.GetAsync(
+                    openVpnServer.Id, VpnServerType.OpenVpn, ct);
+                serverInfo.OpenVpnState.ServerRemoteIp = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+                    nodePublicIp,
+                    ovpnConfig?.VpnServerIp,
+                    openVpnServer.ApiUrl);
+
                 serverInfo.Version = await openVpnVersionService.GetVersionAsync(openVpnServer, ct);
             }
 
@@ -241,5 +250,4 @@ public class VpnServerService(
         logger.LogInformation($"VpnServerId: {openVpnServer.Id}. " +
                               $"SaveVpnServerStatusLogAsync completed successfully.");
     }
-
 }

--- a/DataGateMonitor/Services/BackgroundServices/XrayServerProcessor.cs
+++ b/DataGateMonitor/Services/BackgroundServices/XrayServerProcessor.cs
@@ -1,6 +1,7 @@
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.BackgroundServices.Interfaces;
+using DataGateMonitor.Services.Helpers;
 using DataGateMonitor.Services.XrayNode;
 
 namespace DataGateMonitor.Services.BackgroundServices;
@@ -24,6 +25,7 @@ public sealed class XrayServerProcessor(
         var xrayApi = scope.ServiceProvider.GetRequiredService<IXrayNodeApiClient>();
         var sync = scope.ServiceProvider.GetRequiredService<IXrayVpnClientSyncService>();
         var serverCmd = scope.ServiceProvider.GetRequiredService<ICommandService<VpnServer, int>>();
+        var presence = scope.ServiceProvider.GetRequiredService<IVpnServerClientPresenceService>();
 
         var now = DateTimeOffset.UtcNow;
         try
@@ -66,6 +68,7 @@ public sealed class XrayServerProcessor(
                     .SetProperty(x => x.XrayClientsPolledAt, now)
                     .SetProperty(x => x.XrayClientsPollError, err),
                 ct);
+            await presence.MarkAllDisconnectedAsync(server.Id, ct);
 
             logger.LogError(ex,
                 "XrayServerProcessor error. VpnServerId: {Id}. Name: {Name}. Url: {Url}",

--- a/DataGateMonitor/Services/Cache/IRedisDatabaseProvider.cs
+++ b/DataGateMonitor/Services/Cache/IRedisDatabaseProvider.cs
@@ -1,0 +1,80 @@
+using StackExchange.Redis;
+
+namespace DataGateMonitor.Services.Cache;
+
+/// <summary>
+/// Optional Redis access for cache counters. Returns null when Redis is not configured or unavailable.
+/// </summary>
+public interface IRedisDatabaseProvider
+{
+    Task<IDatabase?> GetDatabaseAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Creates a StackExchange.Redis multiplexer from a connection string.
+/// </summary>
+public interface IRedisMultiplexerConnector
+{
+    Task<IConnectionMultiplexer> ConnectAsync(string connectionString, CancellationToken cancellationToken = default);
+}
+
+public sealed class StackExchangeRedisMultiplexerConnector : IRedisMultiplexerConnector
+{
+    public async Task<IConnectionMultiplexer> ConnectAsync(string connectionString, CancellationToken cancellationToken = default)
+        => await ConnectionMultiplexer.ConnectAsync(connectionString);
+}
+
+/// <summary>
+/// Lazily connects using Redis connection string from configuration.
+/// A failed connect is remembered so callers fall back to DB without retry storms.
+/// </summary>
+public sealed class ConfigurationRedisDatabaseProvider(
+    IConfiguration configuration,
+    ILogger<ConfigurationRedisDatabaseProvider> logger,
+    IRedisMultiplexerConnector multiplexerConnector) : IRedisDatabaseProvider
+{
+    private readonly string? _connectionString =
+        configuration.GetConnectionString("Redis")
+        ?? configuration["Redis:ConnectionString"]
+        ?? configuration["REDIS_CONNECTION_STRING"];
+    private readonly SemaphoreSlim _connectLock = new(1, 1);
+    private IConnectionMultiplexer? _multiplexer;
+    private bool _connectAttempted;
+
+    public async Task<IDatabase?> GetDatabaseAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(_connectionString))
+            return null;
+
+        if (_multiplexer is { IsConnected: true })
+            return _multiplexer.GetDatabase();
+
+        await _connectLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_multiplexer is { IsConnected: true })
+                return _multiplexer.GetDatabase();
+
+            if (_connectAttempted)
+                return null;
+
+            _connectAttempted = true;
+            try
+            {
+                _multiplexer = await multiplexerConnector.ConnectAsync(_connectionString, cancellationToken);
+                logger.LogInformation("Redis connected for connected-clients counters.");
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Redis unavailable; connected-clients counters will fall back to DB.");
+                _multiplexer = null;
+            }
+
+            return _multiplexer?.GetDatabase();
+        }
+        finally
+        {
+            _connectLock.Release();
+        }
+    }
+}

--- a/DataGateMonitor/Services/Cache/RedisConnectedClientsCounterStore.cs
+++ b/DataGateMonitor/Services/Cache/RedisConnectedClientsCounterStore.cs
@@ -3,18 +3,11 @@ using StackExchange.Redis;
 namespace DataGateMonitor.Services.Cache;
 
 public sealed class RedisConnectedClientsCounterStore(
-    IConfiguration configuration,
+    IRedisDatabaseProvider redisDatabaseProvider,
     ILogger<RedisConnectedClientsCounterStore> logger) : IConnectedClientsCounterStore
 {
-    private const string KeyPrefix = "vpn:connected-clients:";
-    private static readonly TimeSpan CounterTtl = TimeSpan.FromHours(2);
-    private readonly string? _connectionString =
-        configuration.GetConnectionString("Redis")
-        ?? configuration["Redis:ConnectionString"]
-        ?? configuration["REDIS_CONNECTION_STRING"];
-    private readonly SemaphoreSlim _connectLock = new(1, 1);
-    private IConnectionMultiplexer? _multiplexer;
-    private bool _connectAttempted;
+    internal const string KeyPrefix = "vpn:connected-clients:";
+    internal static readonly TimeSpan CounterTtl = TimeSpan.FromHours(2);
 
     public async Task<Dictionary<int, int>> GetManyAsync(IEnumerable<int> vpnServerIds, CancellationToken ct = default)
     {
@@ -22,7 +15,7 @@ public sealed class RedisConnectedClientsCounterStore(
         var result = new Dictionary<int, int>(ids.Length);
         if (ids.Length == 0) return result;
 
-        var db = await GetDatabaseOrNullAsync(ct);
+        var db = await redisDatabaseProvider.GetDatabaseAsync(ct);
         if (db is null) return result;
 
         try
@@ -48,54 +41,22 @@ public sealed class RedisConnectedClientsCounterStore(
     {
         if (vpnServerId <= 0) return;
 
-        var db = await GetDatabaseOrNullAsync(ct);
+        var db = await redisDatabaseProvider.GetDatabaseAsync(ct);
         if (db is null) return;
 
         try
         {
             var key = (RedisKey)$"{KeyPrefix}{vpnServerId}";
-            await db.StringSetAsync(key, Math.Max(0, connectedClientsCount), CounterTtl);
+            await db.StringSetAsync(
+                key,
+                Math.Max(0, connectedClientsCount),
+                CounterTtl,
+                When.Always,
+                CommandFlags.None);
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Redis write failed for VpnServerId={VpnServerId}", vpnServerId);
-        }
-    }
-
-    private async Task<IDatabase?> GetDatabaseOrNullAsync(CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(_connectionString))
-            return null;
-
-        if (_multiplexer is { IsConnected: true })
-            return _multiplexer.GetDatabase();
-
-        await _connectLock.WaitAsync(ct);
-        try
-        {
-            if (_multiplexer is { IsConnected: true })
-                return _multiplexer.GetDatabase();
-
-            if (_connectAttempted)
-                return null;
-
-            _connectAttempted = true;
-            try
-            {
-                _multiplexer = await ConnectionMultiplexer.ConnectAsync(_connectionString);
-                logger.LogInformation("Redis connected for connected-clients counters.");
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Redis unavailable; connected-clients counters will fall back to DB.");
-                _multiplexer = null;
-            }
-
-            return _multiplexer?.GetDatabase();
-        }
-        finally
-        {
-            _connectLock.Release();
         }
     }
 }

--- a/DataGateMonitor/Services/Cache/VpnServerConnectedCountOverlay.cs
+++ b/DataGateMonitor/Services/Cache/VpnServerConnectedCountOverlay.cs
@@ -1,0 +1,68 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.VpnServers.Dto;
+
+namespace DataGateMonitor.Services.Cache;
+
+/// <summary>
+/// Overlays live Redis connected-client counters onto status DTOs so HTTP cache
+/// can keep expensive session aggregates while connected counts stay fresh.
+/// </summary>
+public static class VpnServerConnectedCountOverlay
+{
+    public static async Task ApplyAsync(
+        IEnumerable<VpnServerWithStatusDto> items,
+        IConnectedClientsCounterStore store,
+        CancellationToken ct = default)
+    {
+        var list = items as IList<VpnServerWithStatusDto> ?? items.ToList();
+        if (list.Count == 0)
+            return;
+
+        var ids = list
+            .Select(x => x.VpnServerResponses?.VpnServer?.Id ?? 0)
+            .Where(id => id > 0)
+            .Distinct()
+            .ToArray();
+        if (ids.Length == 0)
+            return;
+
+        var map = await store.GetManyAsync(ids, ct);
+        if (map is null || map.Count == 0)
+            return;
+
+        foreach (var item in list)
+        {
+            var id = item.VpnServerResponses?.VpnServer?.Id ?? 0;
+            if (id > 0 && map.TryGetValue(id, out var count))
+                item.CountConnectedClients = count;
+        }
+    }
+
+    public static async Task ApplyAsync(
+        IEnumerable<VpnServerWithStatusV2Dto> items,
+        IConnectedClientsCounterStore store,
+        CancellationToken ct = default)
+    {
+        var list = items as IList<VpnServerWithStatusV2Dto> ?? items.ToList();
+        if (list.Count == 0)
+            return;
+
+        var ids = list
+            .Select(x => x.VpnServerResponses?.VpnServer?.Id ?? 0)
+            .Where(id => id > 0)
+            .Distinct()
+            .ToArray();
+        if (ids.Length == 0)
+            return;
+
+        var map = await store.GetManyAsync(ids, ct);
+        if (map is null || map.Count == 0)
+            return;
+
+        foreach (var item in list)
+        {
+            var id = item.VpnServerResponses?.VpnServer?.Id ?? 0;
+            if (id > 0 && map.TryGetValue(id, out var count))
+                item.CountConnectedClients = count;
+        }
+    }
+}

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
@@ -1,11 +1,7 @@
-﻿using System.Text.RegularExpressions;
-using Mapster;
-using DataGateMonitor.DataBase.Services.Command.Interfaces;
+﻿using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedOvpnFileTokenTable;
-using DataGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
 using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
-using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Models;
@@ -18,6 +14,8 @@ using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses.Dto;
 using DataGateMonitor.SharedModels.Enums;
+using Mapster;
+using System.Text.RegularExpressions;
 
 namespace DataGateMonitor.Services.DataGateOpenVpnManager;
 
@@ -30,8 +28,7 @@ public class OvpnFileApiService(
     IIssuedOvpnFileQueryService issuedOvpnFileQueryService,
     IIssuedOvpnFileTokenQueryService issuedOvpnFileTokenQueryService,
     IUserIdentityLinkQueryService userIdentityLinkQueryService,
-    IUserQuotaPlanQueryService userQuotaPlanQueryService,
-    IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService,
+    IVpnServerQuotaPlanAccessGuard vpnServerQuotaPlanAccessGuard,
     ICommandService<IssuedOvpnFile, int> issuedOvpnFileCommandService,
     ICommandService<IssuedOvpnFileToken, int> issuedOvpnFileTokenCommandService,
     IVpnServerQueryService openVpnServerQueryService,
@@ -405,29 +402,11 @@ public class OvpnFileApiService(
             userIdentityLinkQueryService,
             ct);
 
-    private async Task RequireTargetUserServerAccessAsync(AddFileRequest request, CancellationToken ct)
-    {
-        var externalId = request.ExternalId?.Trim();
-        if (string.IsNullOrWhiteSpace(externalId))
-            return;
-
-        var link = await userIdentityLinkQueryService.GetByExternalId(externalId, ct);
-        if (link is not { UserId: > 0 })
-            return;
-
-        var activePlan = await userQuotaPlanQueryService.GetActiveByUserId(link.UserId, ct);
-        if (activePlan is null)
-            return;
-
-        var allowed = await quotaPlanAllowedServerQueryService.GetByQuotaPlanIdAndServerId(
-            activePlan.QuotaPlanId,
+    private Task RequireTargetUserServerAccessAsync(AddFileRequest request, CancellationToken ct) =>
+        vpnServerQuotaPlanAccessGuard.EnsureTargetUserMayUseServerAsync(
+            request.ExternalId,
             request.VpnServerId,
             ct);
-        if (allowed is not null)
-            return;
-
-        throw new InvalidOperationException(VpnServerAccessErrorKeys.NotAllowedByQuotaPlan);
-    }
 
     private Task<IReadOnlyList<string>> ResolveVpnExternalIdQueryKeysAsync(string externalId, CancellationToken ct) =>
         UserIdentityLinkExternalIdResolver.ResolveVpnExternalIdQueryKeysAsync(

--- a/DataGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
+++ b/DataGateMonitor/Services/DataGateOpenVpnManager/OvpnFileApiService.cs
@@ -12,6 +12,7 @@ using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Users;
 using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
 using DataGateMonitor.Services.Others.Notifications.OvpnFileApi;
+using DataGateMonitor.Services.VpnAccess;
 using DataGateMonitor.SharedModels.DataGateOpenVpnManager.OvpnFile.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses;
@@ -425,8 +426,7 @@ public class OvpnFileApiService(
         if (allowed is not null)
             return;
 
-        throw new InvalidOperationException(
-            $"VPN server {request.VpnServerId} is not allowed for user {link.UserId}'s active quota plan {activePlan.QuotaPlanId}.");
+        throw new InvalidOperationException(VpnServerAccessErrorKeys.NotAllowedByQuotaPlan);
     }
 
     private Task<IReadOnlyList<string>> ResolveVpnExternalIdQueryKeysAsync(string externalId, CancellationToken ct) =>

--- a/DataGateMonitor/Services/DataGateXRayManager/ClientLinks/XrayClientLinkService.cs
+++ b/DataGateMonitor/Services/DataGateXRayManager/ClientLinks/XrayClientLinkService.cs
@@ -11,6 +11,7 @@ using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.Services.Api.Auth.Users;
 using DataGateMonitor.Services.Others.Notifications.OvpnFileApi;
+using DataGateMonitor.Services.VpnAccess;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses.Dto;
@@ -320,8 +321,7 @@ public sealed class XrayClientLinkService(
         if (allowed is not null)
             return;
 
-        throw new InvalidOperationException(
-            $"VPN server {request.VpnServerId} is not allowed for user {link.UserId}'s active quota plan {activePlan.QuotaPlanId}.");
+        throw new InvalidOperationException(VpnServerAccessErrorKeys.NotAllowedByQuotaPlan);
     }
 
     private Task<IReadOnlyList<string>> ResolveVpnExternalIdQueryKeysAsync(string externalId, CancellationToken ct) =>

--- a/DataGateMonitor/Services/DataGateXRayManager/ClientLinks/XrayClientLinkService.cs
+++ b/DataGateMonitor/Services/DataGateXRayManager/ClientLinks/XrayClientLinkService.cs
@@ -1,11 +1,7 @@
-using System.Text.RegularExpressions;
-using Mapster;
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
 using DataGateMonitor.DataBase.Services.Query.IssuedXrayClientLinkTable;
 using DataGateMonitor.DataBase.Services.Query.IssuedXrayClientLinkTokenTable;
-using DataGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
 using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
-using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerTable;
 using DataGateMonitor.Models;
@@ -16,6 +12,8 @@ using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Requests;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.OpenVpnFiles.Responses.Dto;
 using DataGateMonitor.SharedModels.Enums;
+using Mapster;
+using System.Text.RegularExpressions;
 
 namespace DataGateMonitor.Services.DataGateXRayManager.ClientLinks;
 
@@ -27,8 +25,7 @@ public sealed class XrayClientLinkService(
     IIssuedXrayClientLinkQueryService issuedXrayClientLinkQueryService,
     IIssuedXrayClientLinkTokenQueryService issuedXrayClientLinkTokenQueryService,
     IUserIdentityLinkQueryService userIdentityLinkQueryService,
-    IUserQuotaPlanQueryService userQuotaPlanQueryService,
-    IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService,
+    IVpnServerQuotaPlanAccessGuard vpnServerQuotaPlanAccessGuard,
     ICommandService<IssuedXrayClientLink, int> issuedXrayClientLinkCommandService,
     ICommandService<IssuedXrayClientLinkToken, int> issuedXrayClientLinkTokenCommandService,
     IVpnServerQueryService vpnServerQueryService,
@@ -300,29 +297,11 @@ public sealed class XrayClientLinkService(
             userIdentityLinkQueryService,
             ct);
 
-    private async Task RequireTargetUserServerAccessAsync(AddFileRequest request, CancellationToken ct)
-    {
-        var externalId = request.ExternalId?.Trim();
-        if (string.IsNullOrWhiteSpace(externalId))
-            return;
-
-        var link = await userIdentityLinkQueryService.GetByExternalId(externalId, ct);
-        if (link is not { UserId: > 0 })
-            return;
-
-        var activePlan = await userQuotaPlanQueryService.GetActiveByUserId(link.UserId, ct);
-        if (activePlan is null)
-            return;
-
-        var allowed = await quotaPlanAllowedServerQueryService.GetByQuotaPlanIdAndServerId(
-            activePlan.QuotaPlanId,
+    private Task RequireTargetUserServerAccessAsync(AddFileRequest request, CancellationToken ct) =>
+        vpnServerQuotaPlanAccessGuard.EnsureTargetUserMayUseServerAsync(
+            request.ExternalId,
             request.VpnServerId,
             ct);
-        if (allowed is not null)
-            return;
-
-        throw new InvalidOperationException(VpnServerAccessErrorKeys.NotAllowedByQuotaPlan);
-    }
 
     private Task<IReadOnlyList<string>> ResolveVpnExternalIdQueryKeysAsync(string externalId, CancellationToken ct) =>
         UserIdentityLinkExternalIdResolver.ResolveVpnExternalIdQueryKeysAsync(

--- a/DataGateMonitor/Services/EmailTemplates/ISystemTransactionalEmailService.cs
+++ b/DataGateMonitor/Services/EmailTemplates/ISystemTransactionalEmailService.cs
@@ -7,4 +7,7 @@ public interface ISystemTransactionalEmailService
     Task<(string Subject, string BodyHtml)> GetAdminPasswordResetAsync(string code, int ttlMinutes, CancellationToken ct);
 
     Task<(string Subject, string BodyHtml)> GetFreeTierGraceDisconnectedAsync(string planName, string requiredChannel, CancellationToken ct);
+
+    Task<(string Subject, string BodyHtml)> GetFreeTierChannelSubscribeReminderAsync(
+        string displayName, string requiredChannel, string channelUrl, CancellationToken ct);
 }

--- a/DataGateMonitor/Services/EmailTemplates/SystemTransactionalEmailService.cs
+++ b/DataGateMonitor/Services/EmailTemplates/SystemTransactionalEmailService.cs
@@ -69,4 +69,26 @@ public sealed class SystemTransactionalEmailService(IQueryService<EmailBroadcast
         return (TransactionalEmailHtml.DefaultFreeTierGraceDisconnectedSubject,
             TransactionalEmailHtml.BuildFreeTierGraceDisconnected(planName, requiredChannel));
     }
+
+    public async Task<(string Subject, string BodyHtml)> GetFreeTierChannelSubscribeReminderAsync(
+        string displayName, string requiredChannel, string channelUrl, CancellationToken ct)
+    {
+        var entity = await templateQuery.FirstOrDefault(
+            t => t.Name == SystemEmailTemplateNames.FreeTierChannelSubscribeReminder,
+            orderBy: q => q.OrderBy(t => t.Id),
+            asNoTracking: true,
+            ct: ct);
+
+        if (entity is { BodyHtml: { Length: > 0 } body })
+        {
+            var subject = string.IsNullOrWhiteSpace(entity.Subject)
+                ? TransactionalEmailHtml.DefaultFreeTierChannelSubscribeReminderSubject
+                : entity.Subject.Trim();
+            return (subject, TransactionalEmailHtml.ApplyFreeTierChannelSubscribeReminderPlaceholders(
+                body, displayName, requiredChannel, channelUrl));
+        }
+
+        return (TransactionalEmailHtml.DefaultFreeTierChannelSubscribeReminderSubject,
+            TransactionalEmailHtml.BuildFreeTierChannelSubscribeReminder(displayName, requiredChannel, channelUrl));
+    }
 }

--- a/DataGateMonitor/Services/Helpers/ExternalIpAddressService.cs
+++ b/DataGateMonitor/Services/Helpers/ExternalIpAddressService.cs
@@ -1,4 +1,6 @@
-﻿using DataGateMonitor.Services.Helpers.Interfaces;
+﻿using System.Net;
+using System.Net.Sockets;
+using DataGateMonitor.Services.Helpers.Interfaces;
 
 namespace DataGateMonitor.Services.Helpers;
 
@@ -24,11 +26,23 @@ public class ExternalIpAddressService(
         {
             try
             {
-                var ip = await httpClient.GetStringAsync(service, cancellationToken);
-                logger.LogInformation("Retrieved external IP: {Ip} from {Service}", ip.Trim(), service);
-                return ip.Trim();
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(TimeSpan.FromSeconds(5));
+                using var request = new HttpRequestMessage(HttpMethod.Get, service);
+                request.Headers.Accept.ParseAdd("text/plain");
+                using var response = await httpClient.SendAsync(request, timeoutCts.Token);
+                response.EnsureSuccessStatusCode();
+                var raw = (await response.Content.ReadAsStringAsync(timeoutCts.Token)).Trim();
+                if (!TryParsePublicIp(raw, out var ip))
+                {
+                    logger.LogWarning("Ignoring non-IP response from {Service}", service);
+                    continue;
+                }
+
+                logger.LogInformation("Retrieved external IP: {Ip} from {Service}", ip, service);
+                return ip;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 logger.LogWarning(ex, "Failed to get IP from {Service}", service);
             }
@@ -36,5 +50,25 @@ public class ExternalIpAddressService(
 
         logger.LogError("Unable to retrieve external IP from any configured service.");
         return "127.0.0.1";
+    }
+
+    internal static bool TryParsePublicIp(string? raw, out string ip)
+    {
+        ip = string.Empty;
+        if (string.IsNullOrWhiteSpace(raw))
+            return false;
+
+        var candidate = raw.Split(['\r', '\n', ' ', '\t'], StringSplitOptions.RemoveEmptyEntries)[0];
+        if (!IPAddress.TryParse(candidate, out var address))
+            return false;
+
+        if (address.AddressFamily is not (AddressFamily.InterNetwork or AddressFamily.InterNetworkV6))
+            return false;
+
+        if (IPAddress.IsLoopback(address) || address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
+            return false;
+
+        ip = address.ToString();
+        return true;
     }
 }

--- a/DataGateMonitor/Services/Helpers/OpenVpnDetectedSettingsHelper.cs
+++ b/DataGateMonitor/Services/Helpers/OpenVpnDetectedSettingsHelper.cs
@@ -1,0 +1,108 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using DataGateMonitor.Models;
+using DataGateMonitor.Serialization;
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.SharedModels.Enums;
+using Newtonsoft.Json.Linq;
+
+namespace DataGateMonitor.Services.Helpers;
+
+internal static class OpenVpnDetectedSettingsHelper
+{
+    public static readonly TimeSpan DefaultAutoDetectTimeout = TimeSpan.FromSeconds(5);
+
+    public static async Task TryApplyAsync(
+        int vpnServerId,
+        VpnServerOvpnFileConfig config,
+        IMicroserviceInfoService microserviceInfoService,
+        ILogger logger,
+        string logMessage,
+        CancellationToken ct,
+        TimeSpan? timeout = null)
+    {
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(timeout ?? DefaultAutoDetectTimeout);
+            var diagnostics = await microserviceInfoService.GetInfoAsync(vpnServerId, timeoutCts.Token);
+            if (diagnostics is null || diagnostics.ServerType != VpnServerType.OpenVpn || diagnostics.OpenVpn is null)
+                return;
+
+            if (!TryExtractPortProto(diagnostics.OpenVpn, out var port, out var proto))
+                return;
+
+            if (port is > 0 and <= 65535)
+                config.VpnServerPort = port.Value;
+
+            if (!string.IsNullOrWhiteSpace(proto))
+                config.ConfigTemplate = ReplaceProtoDirective(config.ConfigTemplate, proto);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, logMessage, vpnServerId);
+        }
+    }
+
+    public static bool TryExtractPortProto(object openVpnInfo, out int? port, out string? proto)
+    {
+        port = null;
+        proto = null;
+
+        var root = JObject.FromObject(openVpnInfo, Newtonsoft.Json.JsonSerializer.Create(ProjectJson.WebSettings));
+        if (TryGetPropertyIgnoreCase(root, "config", out var cfgToken) && cfgToken is JObject cfg)
+        {
+            if (TryGetPropertyIgnoreCase(cfg, "port", out var portToken))
+            {
+                if (portToken is { Type: JTokenType.Integer })
+                    port = portToken.Value<int>();
+                else if (portToken is { Type: JTokenType.String } &&
+                         int.TryParse(
+                             portToken.Value<string>(),
+                             NumberStyles.Integer,
+                             CultureInfo.InvariantCulture,
+                             out var parsedPort))
+                    port = parsedPort;
+            }
+
+            if (TryGetPropertyIgnoreCase(cfg, "proto", out var protoToken) && protoToken is { Type: JTokenType.String })
+            {
+                var p = protoToken.Value<string>()?.Trim().ToLowerInvariant();
+                if (p is "tcp" or "udp")
+                    proto = p;
+            }
+        }
+
+        return port.HasValue || !string.IsNullOrWhiteSpace(proto);
+    }
+
+    public static string ReplaceProtoDirective(string template, string proto)
+    {
+        if (string.IsNullOrWhiteSpace(template))
+            return template;
+
+        if (Regex.IsMatch(template, @"^\s*proto\s+\S+", RegexOptions.IgnoreCase | RegexOptions.Multiline))
+            return Regex.Replace(template, @"^\s*proto\s+\S+", $"proto {proto}", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+        return $"proto {proto}\n{template}";
+    }
+
+    private static bool TryGetPropertyIgnoreCase(JObject obj, string propertyName, out JToken? value)
+    {
+        foreach (var prop in obj.Properties())
+        {
+            if (string.Equals(prop.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = prop.Value;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+}

--- a/DataGateMonitor/Services/Helpers/OpenVpnDetectedSettingsHelper.cs
+++ b/DataGateMonitor/Services/Helpers/OpenVpnDetectedSettingsHelper.cs
@@ -29,6 +29,8 @@ internal static class OpenVpnDetectedSettingsHelper
             if (diagnostics is null || diagnostics.ServerType != VpnServerType.OpenVpn || diagnostics.OpenVpn is null)
                 return;
 
+            ApplyPublicIpIfEmpty(config, diagnostics.OpenVpn.PublicIp);
+
             if (!TryExtractPortProto(diagnostics.OpenVpn, out var port, out var proto))
                 return;
 
@@ -46,6 +48,19 @@ internal static class OpenVpnDetectedSettingsHelper
         {
             logger.LogDebug(ex, logMessage, vpnServerId);
         }
+    }
+
+    /// <summary>
+    /// Fills <see cref="VpnServerOvpnFileConfig.VpnServerIp"/> from the node <c>PublicIp</c> only when
+    /// the config IP is empty — never from the dashboard's outbound address.
+    /// </summary>
+    public static void ApplyPublicIpIfEmpty(VpnServerOvpnFileConfig config, string? publicIp)
+    {
+        if (!string.IsNullOrWhiteSpace(config.VpnServerIp))
+            return;
+        if (string.IsNullOrWhiteSpace(publicIp))
+            return;
+        config.VpnServerIp = publicIp.Trim();
     }
 
     public static bool TryExtractPortProto(object openVpnInfo, out int? port, out string? proto)

--- a/DataGateMonitor/Services/Helpers/VpnNodePublicIpLookup.cs
+++ b/DataGateMonitor/Services/Helpers/VpnNodePublicIpLookup.cs
@@ -1,0 +1,63 @@
+using DataGateMonitor.Services.DataGateOpenVpnManager.Interfaces;
+using DataGateMonitor.SharedModels.Enums;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DataGateMonitor.Services.Helpers;
+
+public interface IVpnNodePublicIpLookup
+{
+    /// <summary>
+    /// Best-effort public IP from the VPN node <c>/api/info</c>, cached to avoid polling every status cycle.
+    /// </summary>
+    Task<string?> GetAsync(int vpnServerId, VpnServerType serverType, CancellationToken cancellationToken);
+
+    /// <summary>Drop cached PublicIp for a server (e.g. after ApiUrl change or delete).</summary>
+    void Invalidate(int vpnServerId);
+}
+
+public sealed class VpnNodePublicIpLookup(
+    IMicroserviceInfoService microserviceInfoService,
+    IMemoryCache memoryCache,
+    ILogger<VpnNodePublicIpLookup> logger) : IVpnNodePublicIpLookup
+{
+    private static readonly TimeSpan PositiveTtl = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan NegativeTtl = TimeSpan.FromMinutes(2);
+
+    internal static string CacheKey(int vpnServerId) => $"vpn-node-public-ip:{vpnServerId}";
+
+    public async Task<string?> GetAsync(int vpnServerId, VpnServerType serverType, CancellationToken cancellationToken)
+    {
+        var cacheKey = CacheKey(vpnServerId);
+        if (memoryCache.TryGetValue(cacheKey, out string? cached))
+        {
+            // Empty string = resolved miss (old node / no PublicIp / transient failure).
+            return string.IsNullOrEmpty(cached) ? null : cached;
+        }
+
+        string? ip = null;
+        try
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(5));
+            var info = await microserviceInfoService.GetInfoAsync(vpnServerId, timeoutCts.Token);
+            ip = serverType == VpnServerType.Xray ? info.Xray?.PublicIp : info.OpenVpn?.PublicIp;
+            if (!string.IsNullOrWhiteSpace(ip))
+                ip = ip.Trim();
+            else
+                ip = null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "VpnServerId: {Id}. Could not load node PublicIp from /api/info.", vpnServerId);
+            ip = null;
+        }
+
+        memoryCache.Set(cacheKey, ip ?? string.Empty, ip is null ? NegativeTtl : PositiveTtl);
+        return ip;
+    }
+
+    public void Invalidate(int vpnServerId)
+    {
+        memoryCache.Remove(CacheKey(vpnServerId));
+    }
+}

--- a/DataGateMonitor/Services/Helpers/VpnServerApiUrlHelper.cs
+++ b/DataGateMonitor/Services/Helpers/VpnServerApiUrlHelper.cs
@@ -1,0 +1,50 @@
+using System.Net;
+
+namespace DataGateMonitor.Services.Helpers;
+
+internal static class VpnServerApiUrlHelper
+{
+    /// <summary>
+    /// Reported "remote" for status UI: node PublicIp from /api/info, then Config IP,
+    /// then host from ApiUrl. Never the dashboard WAN IP.
+    /// </summary>
+    public static string ResolveReportedRemoteIp(
+        string? nodePublicIp,
+        string? configVpnServerIp,
+        string? apiUrl)
+    {
+        if (IsUsableEndpoint(nodePublicIp))
+            return Truncate(nodePublicIp!.Trim());
+        if (IsUsableEndpoint(configVpnServerIp))
+            return Truncate(configVpnServerIp!.Trim());
+        return Truncate(TryHostFromApiUrl(apiUrl) ?? string.Empty);
+    }
+
+    public static string? TryHostFromApiUrl(string? apiUrl)
+    {
+        if (string.IsNullOrWhiteSpace(apiUrl))
+            return null;
+        if (!Uri.TryCreate(apiUrl.Trim(), UriKind.Absolute, out var uri))
+            return null;
+        return string.IsNullOrWhiteSpace(uri.Host) ? null : uri.Host;
+    }
+
+    private static bool IsUsableEndpoint(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+        var v = value.Trim();
+        if (v is "0.0.0.0" or "::" or "-" or "N/A")
+            return false;
+
+        // Reject loopback / unspecified placeholders often stored when IP detection fails.
+        if (IPAddress.TryParse(v, out var address) &&
+            (IPAddress.IsLoopback(address) || address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any)))
+            return false;
+
+        return true;
+    }
+
+    private static string Truncate(string value) =>
+        value.Length > 255 ? value[..255] : value;
+}

--- a/DataGateMonitor/Services/Helpers/VpnServerClientPresenceService.cs
+++ b/DataGateMonitor/Services/Helpers/VpnServerClientPresenceService.cs
@@ -1,0 +1,38 @@
+using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.Models;
+using DataGateMonitor.Services.Cache;
+
+namespace DataGateMonitor.Services.Helpers;
+
+public interface IVpnServerClientPresenceService
+{
+    /// <summary>
+    /// Marks all connected sessions for a VPN server as disconnected and zeroes the Redis counter.
+    /// Use when the node is unreachable, disabled, deleted, or otherwise no longer observed.
+    /// </summary>
+    Task MarkAllDisconnectedAsync(int vpnServerId, CancellationToken cancellationToken);
+}
+
+public sealed class VpnServerClientPresenceService(
+    ICommandService<VpnServerClient, int> vpnServerClientCommandService,
+    IConnectedClientsCounterStore connectedClientsCounterStore,
+    ILogger<VpnServerClientPresenceService> logger) : IVpnServerClientPresenceService
+{
+    public async Task MarkAllDisconnectedAsync(int vpnServerId, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var updated = await vpnServerClientCommandService.UpdateWhere(
+            x => x.VpnServerId == vpnServerId && x.IsConnected,
+            s => s
+                .SetProperty(c => c.IsConnected, false)
+                .SetProperty(c => c.DisconnectedAt, now)
+                .SetProperty(c => c.LastUpdate, now),
+            cancellationToken);
+
+        await connectedClientsCounterStore.SetAsync(vpnServerId, 0, cancellationToken);
+
+        logger.LogInformation(
+            "VpnServerId: {Id}. Marked {Count} connected client session(s) disconnected; Redis counter set to 0.",
+            vpnServerId, updated);
+    }
+}

--- a/DataGateMonitor/Services/Performance/IPerformanceSampleStore.cs
+++ b/DataGateMonitor/Services/Performance/IPerformanceSampleStore.cs
@@ -1,0 +1,18 @@
+namespace DataGateMonitor.Services.Performance;
+
+public interface IPerformanceSampleStore
+{
+    Task AppendHttpAsync(PerformanceHttpSample sample, CancellationToken ct = default);
+
+    Task AppendDbAsync(PerformanceDbSample sample, CancellationToken ct = default);
+
+    Task<IReadOnlyList<PerformanceHttpSample>> GetHttpLatestAsync(int limit, CancellationToken ct = default);
+
+    Task<IReadOnlyList<PerformanceDbSample>> GetDbLatestAsync(int limit, CancellationToken ct = default);
+
+    Task ClearHttpAsync(CancellationToken ct = default);
+
+    Task ClearDbAsync(CancellationToken ct = default);
+
+    Task ClearAllAsync(CancellationToken ct = default);
+}

--- a/DataGateMonitor/Services/Performance/PerformanceMonitoringOptions.cs
+++ b/DataGateMonitor/Services/Performance/PerformanceMonitoringOptions.cs
@@ -1,0 +1,18 @@
+namespace DataGateMonitor.Services.Performance;
+
+public sealed class PerformanceMonitoringOptions
+{
+    public const string SectionName = "PerformanceMonitoring";
+
+    /// <summary>HTTP samples at or above this duration (ms) are retained. Default 200.</summary>
+    public int HttpSlowMs { get; set; } = 200;
+
+    /// <summary>DB samples at or above this duration (ms) are retained. Default 100.</summary>
+    public int DbSlowMs { get; set; } = 100;
+
+    /// <summary>Max entries per ring (HTTP / DB). Default 500, capped at 2000.</summary>
+    public int MaxEntries { get; set; } = 500;
+
+    /// <summary>Max SQL characters stored (no parameter values). Default 2000.</summary>
+    public int SqlMaxLength { get; set; } = 2000;
+}

--- a/DataGateMonitor/Services/Performance/PerformanceRequestContext.cs
+++ b/DataGateMonitor/Services/Performance/PerformanceRequestContext.cs
@@ -1,0 +1,15 @@
+namespace DataGateMonitor.Services.Performance;
+
+/// <summary>
+/// Correlates EF command samples with the ambient HTTP request (set by timing middleware).
+/// </summary>
+public static class PerformanceRequestContext
+{
+    private static readonly AsyncLocal<string?> CurrentRequestId = new();
+
+    public static string? RequestId
+    {
+        get => CurrentRequestId.Value;
+        set => CurrentRequestId.Value = value;
+    }
+}

--- a/DataGateMonitor/Services/Performance/PerformanceSampleStore.cs
+++ b/DataGateMonitor/Services/Performance/PerformanceSampleStore.cs
@@ -1,0 +1,253 @@
+using System.Collections.Concurrent;
+using DataGateMonitor.Serialization;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace DataGateMonitor.Services.Performance;
+
+public sealed class PerformanceSampleStore : IPerformanceSampleStore
+{
+    private const string RedisHttpKey = "performance:http";
+    private const string RedisDbKey = "performance:db";
+    private const int MaxAllowedEntries = 2000;
+    private const int DefaultMaxEntries = 500;
+
+    private readonly ConcurrentQueue<PerformanceHttpSample> _httpMemory = new();
+    private readonly ConcurrentQueue<PerformanceDbSample> _dbMemory = new();
+    private readonly SemaphoreSlim _connectLock = new(1, 1);
+    private readonly ILogger<PerformanceSampleStore> _logger;
+    private readonly string? _connectionString;
+    private readonly int _maxEntries;
+    private IConnectionMultiplexer? _multiplexer;
+    private bool _connectAttempted;
+
+    public PerformanceSampleStore(
+        IConfiguration configuration,
+        IOptions<PerformanceMonitoringOptions> options,
+        ILogger<PerformanceSampleStore> logger)
+    {
+        _logger = logger;
+        _connectionString =
+            configuration.GetConnectionString("Redis")
+            ?? configuration["Redis:ConnectionString"]
+            ?? configuration["REDIS_CONNECTION_STRING"];
+        _maxEntries = ResolveMaxEntries(options.Value.MaxEntries, configuration);
+    }
+
+    public Task AppendHttpAsync(PerformanceHttpSample sample, CancellationToken ct = default) =>
+        AppendAsync(RedisHttpKey, _httpMemory, NormalizeHttp(sample), ct);
+
+    public Task AppendDbAsync(PerformanceDbSample sample, CancellationToken ct = default) =>
+        AppendAsync(RedisDbKey, _dbMemory, NormalizeDb(sample), ct);
+
+    public Task<IReadOnlyList<PerformanceHttpSample>> GetHttpLatestAsync(int limit, CancellationToken ct = default) =>
+        GetLatestAsync(RedisHttpKey, _httpMemory, limit, ct);
+
+    public Task<IReadOnlyList<PerformanceDbSample>> GetDbLatestAsync(int limit, CancellationToken ct = default) =>
+        GetLatestAsync(RedisDbKey, _dbMemory, limit, ct);
+
+    public Task ClearHttpAsync(CancellationToken ct = default) => ClearAsync(RedisHttpKey, _httpMemory, ct);
+
+    public Task ClearDbAsync(CancellationToken ct = default) => ClearAsync(RedisDbKey, _dbMemory, ct);
+
+    public async Task ClearAllAsync(CancellationToken ct = default)
+    {
+        await ClearHttpAsync(ct);
+        await ClearDbAsync(ct);
+    }
+
+    private async Task AppendAsync<T>(
+        string redisKey,
+        ConcurrentQueue<T> memory,
+        T sample,
+        CancellationToken ct)
+    {
+        EnqueueMemory(memory, sample);
+
+        var db = await GetDatabaseOrNullAsync(ct);
+        if (db is null)
+            return;
+
+        try
+        {
+            var redisValue = ProjectJson.Serialize(sample);
+            await db.ListLeftPushAsync(redisKey, redisValue);
+            await db.ListTrimAsync(redisKey, 0, _maxEntries - 1);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Redis write failed for performance samples ({Key})", redisKey);
+        }
+    }
+
+    private async Task<IReadOnlyList<T>> GetLatestAsync<T>(
+        string redisKey,
+        ConcurrentQueue<T> memory,
+        int limit,
+        CancellationToken ct)
+    {
+        var normalizedLimit = NormalizeLimit(limit);
+        var db = await GetDatabaseOrNullAsync(ct);
+        if (db is not null)
+        {
+            try
+            {
+                var values = await db.ListRangeAsync(redisKey, 0, normalizedLimit - 1);
+                if (values.Length > 0)
+                {
+                    var list = new List<T>(values.Length);
+                    foreach (var value in values)
+                    {
+                        if (!value.HasValue)
+                            continue;
+
+                        var raw = value.ToString();
+                        if (string.IsNullOrWhiteSpace(raw))
+                            continue;
+
+                        var parsed = ProjectJson.Deserialize<T>(raw);
+                        if (parsed is null)
+                            continue;
+
+                        list.Add(parsed);
+                    }
+
+                    if (list.Count > 0)
+                        return list;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Redis read failed for performance samples ({Key})", redisKey);
+            }
+        }
+
+        return GetMemorySnapshot(memory, normalizedLimit);
+    }
+
+    private async Task ClearAsync<T>(string redisKey, ConcurrentQueue<T> memory, CancellationToken ct)
+    {
+        while (memory.TryDequeue(out _))
+        {
+        }
+
+        var db = await GetDatabaseOrNullAsync(ct);
+        if (db is null)
+            return;
+
+        try
+        {
+            await db.KeyDeleteAsync(redisKey);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Redis delete failed for performance samples ({Key})", redisKey);
+        }
+    }
+
+    private void EnqueueMemory<T>(ConcurrentQueue<T> memory, T sample)
+    {
+        memory.Enqueue(sample);
+        while (memory.Count > _maxEntries && memory.TryDequeue(out _))
+        {
+        }
+    }
+
+    private static IReadOnlyList<T> GetMemorySnapshot<T>(ConcurrentQueue<T> memory, int limit)
+    {
+        var array = memory.ToArray();
+        if (array.Length == 0)
+            return [];
+
+        var take = Math.Min(limit, array.Length);
+        var start = array.Length - take;
+        var list = new List<T>(take);
+        for (var i = array.Length - 1; i >= start; i--)
+            list.Add(array[i]);
+
+        return list;
+    }
+
+    private static PerformanceHttpSample NormalizeHttp(PerformanceHttpSample sample) =>
+        new()
+        {
+            TimestampUtc = sample.TimestampUtc == default ? DateTimeOffset.UtcNow : sample.TimestampUtc,
+            RequestId = sample.RequestId ?? string.Empty,
+            Method = sample.Method ?? string.Empty,
+            Path = sample.Path ?? string.Empty,
+            StatusCode = sample.StatusCode,
+            DurationMs = sample.DurationMs,
+            UserName = sample.UserName,
+            TraceId = sample.TraceId
+        };
+
+    private static PerformanceDbSample NormalizeDb(PerformanceDbSample sample) =>
+        new()
+        {
+            TimestampUtc = sample.TimestampUtc == default ? DateTimeOffset.UtcNow : sample.TimestampUtc,
+            RequestId = sample.RequestId,
+            DurationMs = sample.DurationMs,
+            CommandType = sample.CommandType ?? string.Empty,
+            Sql = sample.Sql ?? string.Empty,
+            Succeeded = sample.Succeeded,
+            ExceptionMessage = sample.ExceptionMessage
+        };
+
+    private async Task<IDatabase?> GetDatabaseOrNullAsync(CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(_connectionString))
+            return null;
+
+        if (_multiplexer is { IsConnected: true })
+            return _multiplexer.GetDatabase();
+
+        await _connectLock.WaitAsync(ct);
+        try
+        {
+            if (_multiplexer is { IsConnected: true })
+                return _multiplexer.GetDatabase();
+
+            if (_connectAttempted)
+                return null;
+
+            _connectAttempted = true;
+            try
+            {
+                _multiplexer = await ConnectionMultiplexer.ConnectAsync(_connectionString);
+                _logger.LogInformation("Redis connected for performance samples.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Redis unavailable; performance samples will remain in memory.");
+                _multiplexer = null;
+            }
+
+            return _multiplexer?.GetDatabase();
+        }
+        finally
+        {
+            _connectLock.Release();
+        }
+    }
+
+    private static int ResolveMaxEntries(int fromOptions, IConfiguration configuration)
+    {
+        var configured =
+            configuration.GetValue<int?>("PerformanceMonitoring:MaxEntries")
+            ?? configuration.GetValue<int?>("PERFORMANCE_MONITORING_MAX_ENTRIES")
+            ?? (fromOptions > 0 ? fromOptions : DefaultMaxEntries);
+
+        if (configured <= 0)
+            return DefaultMaxEntries;
+
+        return Math.Min(configured, MaxAllowedEntries);
+    }
+
+    private int NormalizeLimit(int limit)
+    {
+        if (limit <= 0)
+            return _maxEntries;
+
+        return Math.Min(limit, _maxEntries);
+    }
+}

--- a/DataGateMonitor/Services/Performance/PerformanceSamples.cs
+++ b/DataGateMonitor/Services/Performance/PerformanceSamples.cs
@@ -1,0 +1,37 @@
+namespace DataGateMonitor.Services.Performance;
+
+public sealed class PerformanceHttpSample
+{
+    public DateTimeOffset TimestampUtc { get; set; }
+
+    public string RequestId { get; set; } = string.Empty;
+
+    public string Method { get; set; } = string.Empty;
+
+    public string Path { get; set; } = string.Empty;
+
+    public int StatusCode { get; set; }
+
+    public long DurationMs { get; set; }
+
+    public string? UserName { get; set; }
+
+    public string? TraceId { get; set; }
+}
+
+public sealed class PerformanceDbSample
+{
+    public DateTimeOffset TimestampUtc { get; set; }
+
+    public string? RequestId { get; set; }
+
+    public long DurationMs { get; set; }
+
+    public string CommandType { get; set; } = string.Empty;
+
+    public string Sql { get; set; } = string.Empty;
+
+    public bool Succeeded { get; set; }
+
+    public string? ExceptionMessage { get; set; }
+}

--- a/DataGateMonitor/Services/TelegramBot/Interfaces/ITelegramAdminAlertService.cs
+++ b/DataGateMonitor/Services/TelegramBot/Interfaces/ITelegramAdminAlertService.cs
@@ -1,0 +1,24 @@
+namespace DataGateMonitor.Services.TelegramBot.Interfaces;
+
+public interface ITelegramAdminAlertService
+{
+    /// <summary>
+    /// Notifies bot admins that a Telegram account was linked to a dashboard identity (Google/local).
+    /// Includes avatars when available. Never throws.
+    /// </summary>
+    Task NotifyAccountsLinkedAsync(TelegramAccountsLinkedAlert alert, CancellationToken ct = default);
+}
+
+public sealed class TelegramAccountsLinkedAlert
+{
+    public long TelegramId { get; init; }
+    public string? TelegramUsername { get; init; }
+    public string? TelegramDisplayName { get; init; }
+    public string LinkedProviderLabel { get; init; } = "Google";
+    public string? LinkedDisplayName { get; init; }
+    public string? LinkedEmail { get; init; }
+    public string? LinkedExternalId { get; init; }
+    public string? LinkedAvatarUrl { get; init; }
+    public int SurvivorUserId { get; init; }
+    public int MergedUserId { get; init; }
+}

--- a/DataGateMonitor/Services/TelegramBot/Interfaces/ITelegramDirectMessageSender.cs
+++ b/DataGateMonitor/Services/TelegramBot/Interfaces/ITelegramDirectMessageSender.cs
@@ -13,4 +13,21 @@ public interface ITelegramDirectMessageSender
     /// unconfigured), so callers can fall back to another channel.
     /// </summary>
     Task<bool> TrySendMessageAsync(long chatId, string text, CancellationToken ct = default);
+
+    /// <summary>
+    /// Attempts to send a photo with caption. Falls back to text-only when <paramref name="photoBytes"/>
+    /// is empty. Never throws.
+    /// </summary>
+    Task<bool> TrySendPhotoAsync(
+        long chatId,
+        byte[]? photoBytes,
+        string caption,
+        string fileName = "photo.jpg",
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Downloads the largest current Telegram profile photo for <paramref name="telegramUserId"/>.
+    /// Returns null when missing or inaccessible. Never throws.
+    /// </summary>
+    Task<byte[]?> TryDownloadUserProfilePhotoAsync(long telegramUserId, CancellationToken ct = default);
 }

--- a/DataGateMonitor/Services/TelegramBot/TelegramAdminAlertService.cs
+++ b/DataGateMonitor/Services/TelegramBot/TelegramAdminAlertService.cs
@@ -1,0 +1,157 @@
+using DataGateMonitor.Services.TelegramBot.Interfaces;
+
+namespace DataGateMonitor.Services.TelegramBot;
+
+public sealed class TelegramAdminAlertService(
+    ITelegramUserService telegramUserService,
+    ITelegramBotUserProfilePhotoService profilePhotoService,
+    ITelegramDirectMessageSender directMessageSender,
+    IHttpClientFactory httpClientFactory,
+    ILogger<TelegramAdminAlertService> logger) : ITelegramAdminAlertService
+{
+    private const int MaxRemoteAvatarBytes = 5 * 1024 * 1024;
+
+    public async Task NotifyAccountsLinkedAsync(TelegramAccountsLinkedAlert alert, CancellationToken ct = default)
+    {
+        try
+        {
+            var admins = await telegramUserService.GetAdminsAsync(ct);
+            if (admins.Count == 0)
+            {
+                logger.LogWarning("No Telegram bot admins configured; skipping accounts-linked alert.");
+                return;
+            }
+
+            var caption = BuildAccountsLinkedCaption(alert);
+            var telegramPhoto = await ResolveTelegramPhotoAsync(alert.TelegramId, ct);
+            var linkedPhoto = await TryDownloadRemoteAvatarAsync(alert.LinkedAvatarUrl, ct);
+
+            foreach (var admin in admins)
+            {
+                try
+                {
+                    if (telegramPhoto is { Length: > 0 } && linkedPhoto is { Length: > 0 })
+                    {
+                        await directMessageSender.TrySendPhotoAsync(
+                            admin.TelegramId,
+                            telegramPhoto,
+                            caption + "\n\n📷 Telegram avatar",
+                            "telegram-avatar.jpg",
+                            ct);
+                        await directMessageSender.TrySendPhotoAsync(
+                            admin.TelegramId,
+                            linkedPhoto,
+                            $"📷 {alert.LinkedProviderLabel} avatar",
+                            "linked-avatar.jpg",
+                            ct);
+                    }
+                    else if (telegramPhoto is { Length: > 0 })
+                    {
+                        await directMessageSender.TrySendPhotoAsync(
+                            admin.TelegramId,
+                            telegramPhoto,
+                            caption,
+                            "telegram-avatar.jpg",
+                            ct);
+                    }
+                    else if (linkedPhoto is { Length: > 0 })
+                    {
+                        await directMessageSender.TrySendPhotoAsync(
+                            admin.TelegramId,
+                            linkedPhoto,
+                            caption,
+                            "linked-avatar.jpg",
+                            ct);
+                    }
+                    else
+                    {
+                        await directMessageSender.TrySendMessageAsync(admin.TelegramId, caption, ct);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex,
+                        "Failed to send accounts-linked alert to admin TelegramId {TelegramId}",
+                        admin.TelegramId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to notify admins about accounts linked for TelegramId {TelegramId}",
+                alert.TelegramId);
+        }
+    }
+
+    private async Task<byte[]?> ResolveTelegramPhotoAsync(long telegramId, CancellationToken ct)
+    {
+        var live = await directMessageSender.TryDownloadUserProfilePhotoAsync(telegramId, ct);
+        if (live is { Length: > 0 })
+            return live;
+
+        var stored = await profilePhotoService.GetImageByTelegramIdAsync(telegramId, ct);
+        return stored?.Bytes is { Length: > 0 } ? stored.Value.Bytes : null;
+    }
+
+    private async Task<byte[]?> TryDownloadRemoteAvatarAsync(string? avatarUrl, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(avatarUrl)
+            || !Uri.TryCreate(avatarUrl, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return null;
+        }
+
+        try
+        {
+            var client = httpClientFactory.CreateClient();
+            using var response = await client.GetAsync(uri, ct);
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var bytes = await response.Content.ReadAsByteArrayAsync(ct);
+            if (bytes.Length == 0 || bytes.Length > MaxRemoteAvatarBytes)
+                return null;
+
+            return bytes;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to download linked-account avatar from {AvatarUrl}", avatarUrl);
+            return null;
+        }
+    }
+
+    internal static string BuildAccountsLinkedCaption(TelegramAccountsLinkedAlert alert)
+    {
+        var tgName = string.IsNullOrWhiteSpace(alert.TelegramDisplayName)
+            ? "Unnamed"
+            : alert.TelegramDisplayName.Trim();
+        var username = string.IsNullOrWhiteSpace(alert.TelegramUsername)
+            ? "@"
+            : "@" + alert.TelegramUsername.Trim().TrimStart('@');
+
+        var lines = new List<string>
+        {
+            "🔗 Accounts linked",
+            $"Telegram ID: `{alert.TelegramId}`",
+            $"Username: {username}",
+            $"Name: {tgName}",
+            "",
+            $"Linked: {alert.LinkedProviderLabel}",
+        };
+
+        if (!string.IsNullOrWhiteSpace(alert.LinkedDisplayName))
+            lines.Add($"Name: {alert.LinkedDisplayName.Trim()}");
+        if (!string.IsNullOrWhiteSpace(alert.LinkedEmail))
+            lines.Add($"Email: {alert.LinkedEmail.Trim()}");
+        if (!string.IsNullOrWhiteSpace(alert.LinkedExternalId))
+            lines.Add($"External ID: `{alert.LinkedExternalId.Trim()}`");
+
+        lines.Add("");
+        lines.Add($"Survivor user #: {alert.SurvivorUserId}");
+        lines.Add($"Merged user #: {alert.MergedUserId}");
+
+        return string.Join('\n', lines);
+    }
+}

--- a/DataGateMonitor/Services/TelegramBot/TelegramChannelMembershipChecker.cs
+++ b/DataGateMonitor/Services/TelegramBot/TelegramChannelMembershipChecker.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using DataGateMonitor.Models.Helpers;
 using DataGateMonitor.Services.TelegramBot.Interfaces;
@@ -9,8 +10,10 @@ namespace DataGateMonitor.Services.TelegramBot;
 public sealed class TelegramChannelMembershipChecker(
     IHttpClientFactory httpClientFactory,
     IOptions<TelegramChannelSettings> options,
+    IMemoryCache memoryCache,
     ILogger<TelegramChannelMembershipChecker> logger) : ITelegramChannelMembershipChecker
 {
+    private static readonly TimeSpan MembershipCacheTtl = TimeSpan.FromMinutes(2);
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     public async Task<bool> IsSubscribedAsync(long telegramUserId, CancellationToken ct)
@@ -27,6 +30,10 @@ public sealed class TelegramChannelMembershipChecker(
         if (telegramUserId <= 0)
             return false;
 
+        var cacheKey = BuildCacheKey(telegramUserId, settings.RequiredChannelChatId);
+        if (memoryCache.TryGetValue(cacheKey, out bool cached))
+            return cached;
+
         var chatId = settings.RequiredChannelChatId;
         var url =
             $"https://api.telegram.org/bot{settings.BotToken}/getChatMember?chat_id={Uri.EscapeDataString(chatId)}&user_id={telegramUserId}";
@@ -38,6 +45,7 @@ public sealed class TelegramChannelMembershipChecker(
             var errorBody = await response.Content.ReadAsStringAsync(ct);
             var telegramDescription = TryReadTelegramDescription(errorBody) ?? errorBody;
             LogGetChatMemberFailure(telegramUserId, chatId, (int)response.StatusCode, telegramDescription);
+            memoryCache.Set(cacheKey, false, MembershipCacheTtl);
             return false;
         }
 
@@ -45,11 +53,17 @@ public sealed class TelegramChannelMembershipChecker(
         if (payload is not { Ok: true, Result: not null })
         {
             LogGetChatMemberFailure(telegramUserId, chatId, statusCode: null, payload?.Description ?? "unknown");
+            memoryCache.Set(cacheKey, false, MembershipCacheTtl);
             return false;
         }
 
-        return IsActiveMemberStatus(payload.Result.Status);
+        var subscribed = IsActiveMemberStatus(payload.Result.Status);
+        memoryCache.Set(cacheKey, subscribed, MembershipCacheTtl);
+        return subscribed;
     }
+
+    internal static string BuildCacheKey(long telegramUserId, string chatId)
+        => $"tg-channel-member:{chatId}:{telegramUserId}";
 
     internal static bool IsActiveMemberStatus(string? status)
         => status?.ToLowerInvariant() switch

--- a/DataGateMonitor/Services/TelegramBot/TelegramChannelMembershipChecker.cs
+++ b/DataGateMonitor/Services/TelegramBot/TelegramChannelMembershipChecker.cs
@@ -36,25 +36,15 @@ public sealed class TelegramChannelMembershipChecker(
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await response.Content.ReadAsStringAsync(ct);
-            var telegramDescription = TryReadTelegramDescription(errorBody);
-
-            logger.LogWarning(
-                "Telegram getChatMember failed for user {TelegramUserId} in {ChatId}: HTTP {StatusCode}. Telegram: {TelegramDescription}",
-                telegramUserId,
-                chatId,
-                (int)response.StatusCode,
-                telegramDescription ?? errorBody);
+            var telegramDescription = TryReadTelegramDescription(errorBody) ?? errorBody;
+            LogGetChatMemberFailure(telegramUserId, chatId, (int)response.StatusCode, telegramDescription);
             return false;
         }
 
         var payload = await response.Content.ReadFromJsonAsync<TelegramApiResponse<TelegramChatMemberPayload>>(JsonOptions, ct);
         if (payload is not { Ok: true, Result: not null })
         {
-            logger.LogWarning(
-                "Telegram getChatMember returned error for user {TelegramUserId} in {ChatId}: {Description}",
-                telegramUserId,
-                chatId,
-                payload?.Description ?? "unknown");
+            LogGetChatMemberFailure(telegramUserId, chatId, statusCode: null, payload?.Description ?? "unknown");
             return false;
         }
 
@@ -67,6 +57,68 @@ public sealed class TelegramChannelMembershipChecker(
             "creator" or "administrator" or "member" or "restricted" => true,
             _ => false,
         };
+
+    /// <summary>
+    /// Telegram often returns these instead of a chat-member status when the user is unknown to the bot,
+    /// never joined, left, or deactivated. Treat as not subscribed — not as an operational incident.
+    /// </summary>
+    internal static bool IsExpectedNonMembershipDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return false;
+
+        var text = description.ToLowerInvariant();
+        return text.Contains("participant_id_invalid", StringComparison.Ordinal)
+               || text.Contains("user not found", StringComparison.Ordinal)
+               || text.Contains("member not found", StringComparison.Ordinal)
+               || text.Contains("user is deactivated", StringComparison.Ordinal)
+               || text.Contains("user_deactivated", StringComparison.Ordinal)
+               || text.Contains("peer_id_invalid", StringComparison.Ordinal);
+    }
+
+    private void LogGetChatMemberFailure(long telegramUserId, string chatId, int? statusCode, string description)
+    {
+        if (IsExpectedNonMembershipDescription(description))
+        {
+            if (statusCode is int code)
+            {
+                logger.LogDebug(
+                    "Telegram getChatMember: user {TelegramUserId} not a member of {ChatId} (HTTP {StatusCode}): {TelegramDescription}",
+                    telegramUserId,
+                    chatId,
+                    code,
+                    description);
+            }
+            else
+            {
+                logger.LogDebug(
+                    "Telegram getChatMember: user {TelegramUserId} not a member of {ChatId}: {TelegramDescription}",
+                    telegramUserId,
+                    chatId,
+                    description);
+            }
+
+            return;
+        }
+
+        if (statusCode is int httpCode)
+        {
+            logger.LogWarning(
+                "Telegram getChatMember failed for user {TelegramUserId} in {ChatId}: HTTP {StatusCode}. Telegram: {TelegramDescription}",
+                telegramUserId,
+                chatId,
+                httpCode,
+                description);
+        }
+        else
+        {
+            logger.LogWarning(
+                "Telegram getChatMember returned error for user {TelegramUserId} in {ChatId}: {Description}",
+                telegramUserId,
+                chatId,
+                description);
+        }
+    }
 
     private static string? TryReadTelegramDescription(string? json)
     {

--- a/DataGateMonitor/Services/TelegramBot/TelegramDirectMessageSender.cs
+++ b/DataGateMonitor/Services/TelegramBot/TelegramDirectMessageSender.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -12,6 +13,7 @@ public sealed class TelegramDirectMessageSender(
     IOptions<TelegramChannelSettings> options,
     ILogger<TelegramDirectMessageSender> logger) : ITelegramDirectMessageSender
 {
+    private const int MaxProfilePhotoBytes = 5 * 1024 * 1024;
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
     public async Task<bool> TrySendMessageAsync(long chatId, string text, CancellationToken ct = default)
@@ -37,34 +39,146 @@ public sealed class TelegramDirectMessageSender(
                 new TelegramSendMessageRequest { ChatId = chatId, Text = text },
                 ct);
 
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorBody = await response.Content.ReadAsStringAsync(ct);
-                logger.LogWarning(
-                    "Telegram sendMessage failed for {ChatId}: HTTP {StatusCode}. {ErrorBody}",
-                    chatId,
-                    (int)response.StatusCode,
-                    errorBody);
-                return false;
-            }
-
-            var payload = await response.Content.ReadFromJsonAsync<TelegramApiResponse>(JsonOptions, ct);
-            if (payload is not { Ok: true })
-            {
-                logger.LogWarning(
-                    "Telegram sendMessage returned error for {ChatId}: {Description}",
-                    chatId,
-                    payload?.Description ?? "unknown");
-                return false;
-            }
-
-            return true;
+            return await IsOkResponseAsync(response, chatId, "sendMessage", ct);
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to send Telegram direct message to {ChatId}", chatId);
             return false;
         }
+    }
+
+    public async Task<bool> TrySendPhotoAsync(
+        long chatId,
+        byte[]? photoBytes,
+        string caption,
+        string fileName = "photo.jpg",
+        CancellationToken ct = default)
+    {
+        if (photoBytes is not { Length: > 0 })
+            return await TrySendMessageAsync(chatId, caption, ct);
+
+        var settings = options.Value;
+        if (string.IsNullOrWhiteSpace(settings.BotToken))
+        {
+            logger.LogWarning(
+                "Telegram bot token is not configured; cannot send photo to {ChatId}",
+                chatId);
+            return false;
+        }
+
+        if (chatId <= 0)
+            return false;
+
+        try
+        {
+            var url = $"https://api.telegram.org/bot{settings.BotToken}/sendPhoto";
+            var client = httpClientFactory.CreateClient();
+            using var content = new MultipartFormDataContent();
+            content.Add(new StringContent(chatId.ToString()), "chat_id");
+            if (!string.IsNullOrWhiteSpace(caption))
+                content.Add(new StringContent(caption), "caption");
+
+            var photoContent = new ByteArrayContent(photoBytes);
+            photoContent.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+            content.Add(photoContent, "photo", string.IsNullOrWhiteSpace(fileName) ? "photo.jpg" : fileName);
+
+            using var response = await client.PostAsync(url, content, ct);
+            if (await IsOkResponseAsync(response, chatId, "sendPhoto", ct))
+                return true;
+
+            logger.LogWarning("Telegram sendPhoto failed for {ChatId}; falling back to text", chatId);
+            return await TrySendMessageAsync(chatId, caption, ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to send Telegram photo to {ChatId}; falling back to text", chatId);
+            return await TrySendMessageAsync(chatId, caption, ct);
+        }
+    }
+
+    public async Task<byte[]?> TryDownloadUserProfilePhotoAsync(long telegramUserId, CancellationToken ct = default)
+    {
+        var settings = options.Value;
+        if (string.IsNullOrWhiteSpace(settings.BotToken) || telegramUserId <= 0)
+            return null;
+
+        try
+        {
+            var client = httpClientFactory.CreateClient();
+            var photosUrl =
+                $"https://api.telegram.org/bot{settings.BotToken}/getUserProfilePhotos?user_id={telegramUserId}&limit=1";
+            using var photosResponse = await client.GetAsync(photosUrl, ct);
+            if (!photosResponse.IsSuccessStatusCode)
+                return null;
+
+            var photosPayload =
+                await photosResponse.Content.ReadFromJsonAsync<TelegramApiResponse<UserProfilePhotosResult>>(
+                    JsonOptions, ct);
+            if (photosPayload is not { Ok: true, Result: { TotalCount: > 0 } })
+                return null;
+
+            var sizes = photosPayload.Result.Photos?.LastOrDefault();
+            var biggest = sizes?.LastOrDefault();
+            if (biggest is null || string.IsNullOrWhiteSpace(biggest.FileId))
+                return null;
+
+            var fileUrl = $"https://api.telegram.org/bot{settings.BotToken}/getFile?file_id={Uri.EscapeDataString(biggest.FileId)}";
+            using var fileResponse = await client.GetAsync(fileUrl, ct);
+            if (!fileResponse.IsSuccessStatusCode)
+                return null;
+
+            var filePayload =
+                await fileResponse.Content.ReadFromJsonAsync<TelegramApiResponse<TelegramFileResult>>(JsonOptions, ct);
+            if (filePayload is not { Ok: true } || string.IsNullOrWhiteSpace(filePayload.Result?.FilePath))
+                return null;
+
+            var downloadUrl = $"https://api.telegram.org/file/bot{settings.BotToken}/{filePayload.Result.FilePath}";
+            using var downloadResponse = await client.GetAsync(downloadUrl, ct);
+            if (!downloadResponse.IsSuccessStatusCode)
+                return null;
+
+            var bytes = await downloadResponse.Content.ReadAsByteArrayAsync(ct);
+            if (bytes.Length == 0 || bytes.Length > MaxProfilePhotoBytes)
+                return null;
+
+            return bytes;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to download Telegram profile photo for {TelegramUserId}", telegramUserId);
+            return null;
+        }
+    }
+
+    private async Task<bool> IsOkResponseAsync(
+        HttpResponseMessage response,
+        long chatId,
+        string method,
+        CancellationToken ct)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            logger.LogWarning(
+                "Telegram {Method} failed for {ChatId}: HTTP {StatusCode}. {ErrorBody}",
+                method,
+                chatId,
+                (int)response.StatusCode,
+                errorBody);
+            return false;
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<TelegramApiResponse>(JsonOptions, ct);
+        if (payload is { Ok: true })
+            return true;
+
+        logger.LogWarning(
+            "Telegram {Method} returned error for {ChatId}: {Description}",
+            method,
+            chatId,
+            payload?.Description ?? "unknown");
+        return false;
     }
 
     private sealed class TelegramSendMessageRequest
@@ -80,5 +194,30 @@ public sealed class TelegramDirectMessageSender(
     {
         public bool Ok { get; set; }
         public string? Description { get; set; }
+    }
+
+    private sealed class TelegramApiResponse<T>
+    {
+        public bool Ok { get; set; }
+        public string? Description { get; set; }
+        public T? Result { get; set; }
+    }
+
+    private sealed class UserProfilePhotosResult
+    {
+        public int TotalCount { get; set; }
+        public List<List<TelegramPhotoSize>>? Photos { get; set; }
+    }
+
+    private sealed class TelegramPhotoSize
+    {
+        [JsonPropertyName("file_id")]
+        public string? FileId { get; set; }
+    }
+
+    private sealed class TelegramFileResult
+    {
+        [JsonPropertyName("file_path")]
+        public string? FilePath { get; set; }
     }
 }

--- a/DataGateMonitor/Services/Users/FreeTierAccessComplianceService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierAccessComplianceService.cs
@@ -18,6 +18,7 @@ public sealed class FreeTierAccessComplianceService(
     IQuotaPlanQueryService quotaPlanQueryService,
     IUserIdentityLinkQueryService userIdentityLinkQueryService,
     ITelegramChannelMembershipChecker telegramChannelMembershipChecker,
+    IFreeTierUnsubscribedUserReminderService unsubscribedUserReminderService,
     IAppNotificationFacade appNotificationFacade,
     ISettingsService settingsService,
     IMemoryCache memoryCache,
@@ -130,6 +131,14 @@ public sealed class FreeTierAccessComplianceService(
         var result = evaluation.Result;
         var links = evaluation.Links;
 
+        if (result is { IsApplicable: true, IsChannelSubscribed: false, TelegramId: > 0 })
+        {
+            await unsubscribedUserReminderService.TryRemindAsync(
+                result.TelegramId.Value,
+                context,
+                ct);
+        }
+
         if (!result.IsApplicable || result.IsCompliant)
             return (result, links);
 
@@ -168,10 +177,11 @@ public sealed class FreeTierAccessComplianceService(
         }
 
         logger.LogWarning(
-            "User {UserId} on plan {PlanName} is not merged and not subscribed to {Channel}. Context={Context}",
+            "User {UserId} on plan {PlanName} is not subscribed to {Channel}. Merged={IsMerged}. Context={Context}",
             userId,
             result.ActivePlanName,
             channelOptions.Value.RequiredChannelChatId,
+            result.IsMergedAccount,
             context);
 
         return (CopyResult(result, adminsNotified: true), links);
@@ -237,7 +247,9 @@ public sealed class FreeTierAccessComplianceService(
         if (channelSubscribed != true && telegramId is > 0)
             channelSubscribed = await telegramChannelMembershipChecker.IsSubscribedAsync(telegramId.Value, ct);
 
-        var isCompliant = isMerged || channelSubscribed == true;
+        // Free/Default always require an active Telegram channel subscription.
+        // Linking Telegram+Google/password does not exempt the user.
+        var isCompliant = channelSubscribed == true;
 
         return (
             new FreeTierAccessComplianceResult

--- a/DataGateMonitor/Services/Users/FreeTierAccessSettingsKeys.cs
+++ b/DataGateMonitor/Services/Users/FreeTierAccessSettingsKeys.cs
@@ -7,4 +7,10 @@ public static class FreeTierAccessSettingsKeys
     public const string EnforceOpenVpnSessions = "FreeTier_Enforce_OpenVpn_Sessions";
     public const string EnforcementIntervalMinutes = "FreeTier_Enforcement_Interval_Minutes";
     public const string RevokeOvpnOnEnforcement = "FreeTier_Revoke_Ovpn_On_Enforcement";
+
+    /// <summary>When true, DM Free/Default Telegram users who are not subscribed to the required channel.</summary>
+    public const string SendUnsubscribedUserReminders = "FreeTier_Send_Unsubscribed_User_Reminders";
+
+    /// <summary>When true, send bot admins a daily digest of Free/Default VPN users without channel subscription.</summary>
+    public const string DailyUnsubscribedAdminDigest = "FreeTier_Daily_Unsubscribed_Admin_Digest";
 }

--- a/DataGateMonitor/Services/Users/FreeTierEnforcementOverviewService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierEnforcementOverviewService.cs
@@ -28,7 +28,24 @@ public sealed class FreeTierEnforcementOverviewService(
     IQueryService<FreeTierDisconnectLog, int> disconnectLogQueryService,
     ILogger<FreeTierEnforcementOverviewService> logger) : IFreeTierEnforcementOverviewService
 {
-    public async Task<GetFreeTierEnforcementCandidatesResponse> GetCandidatesAsync(CancellationToken ct = default)
+    public Task<GetFreeTierEnforcementCandidatesResponse> GetCandidatesAsync(CancellationToken ct = default)
+        => CollectAsync(
+            include: result => result.IsApplicable && !result.IsCompliant,
+            connectedOnly: false,
+            ct);
+
+    public Task<GetFreeTierEnforcementCandidatesResponse> GetUnsubscribedConnectedAsync(
+        CancellationToken ct = default)
+        => CollectAsync(
+            // Include grace-period users: still not subscribed, but temporarily treated as compliant.
+            include: result => result.IsApplicable && !result.IsChannelSubscribed,
+            connectedOnly: true,
+            ct);
+
+    private async Task<GetFreeTierEnforcementCandidatesResponse> CollectAsync(
+        Func<FreeTierAccessComplianceResult, bool> include,
+        bool connectedOnly,
+        CancellationToken ct)
     {
         var plans = await quotaPlanQueryService.GetAll(ct);
         var freeDefaultPlanIds = plans
@@ -74,7 +91,7 @@ public sealed class FreeTierEnforcementOverviewService(
                 continue;
             }
 
-            if (!result.IsApplicable || result.IsCompliant)
+            if (!include(result))
                 continue;
 
             var user = await userQueryService.GetById(userId, ct);
@@ -90,6 +107,9 @@ public sealed class FreeTierEnforcementOverviewService(
             };
 
             await TryAttachConnectionAsync(dto, userId, connectedByServerAndCn, serverNameById, ct);
+            if (connectedOnly && !dto.IsConnected)
+                continue;
+
             candidates.Add(dto);
         }
 

--- a/DataGateMonitor/Services/Users/FreeTierEnforcementOverviewService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierEnforcementOverviewService.cs
@@ -36,33 +36,101 @@ public sealed class FreeTierEnforcementOverviewService(
 
     public Task<GetFreeTierEnforcementCandidatesResponse> GetUnsubscribedConnectedAsync(
         CancellationToken ct = default)
-        => CollectAsync(
-            // Include grace-period users: still not subscribed, but temporarily treated as compliant.
-            include: result => result.IsApplicable && !result.IsChannelSubscribed,
-            connectedOnly: true,
-            ct);
+        // Online digest: start from connected sessions so we do not call Telegram for every Free/Default user.
+        => CollectConnectedUnsubscribedAsync(ct);
+
+    private async Task<GetFreeTierEnforcementCandidatesResponse> CollectConnectedUnsubscribedAsync(
+        CancellationToken ct)
+    {
+        var freeTierUserIds = await GetFreeTierUserIdsAsync(ct);
+        if (freeTierUserIds.Count == 0)
+            return new GetFreeTierEnforcementCandidatesResponse();
+
+        var servers = await vpnServerQueryService.GetAll(ct: ct);
+        var serverNameById = servers.ToDictionary(s => s.Id, s => s.ServerName);
+
+        var connected = (await vpnServerClientQueryService.GetAllConnected(ct))
+            .Where(c => !string.IsNullOrWhiteSpace(c.CommonName))
+            .ToList();
+        if (connected.Count == 0)
+            return new GetFreeTierEnforcementCandidatesResponse();
+
+        var userIdByConnection = await ResolveConnectedUserIdsAsync(connected, ct);
+        var connectedByUserId = new Dictionary<int, VpnServerClient>();
+        foreach (var client in connected)
+        {
+            if (!userIdByConnection.TryGetValue(client, out var userId))
+                continue;
+            if (!freeTierUserIds.Contains(userId))
+                continue;
+            connectedByUserId.TryAdd(userId, client);
+        }
+
+        if (connectedByUserId.Count == 0)
+            return new GetFreeTierEnforcementCandidatesResponse();
+
+        var userIds = connectedByUserId.Keys.ToList();
+        var usersById = await userQueryService.GetByIds(userIds, ct);
+        var linksByUserId = await userIdentityLinkQueryService.GetListByUserIds(userIds, ct);
+
+        var candidates = new List<FreeTierEnforcementCandidateDto>(userIds.Count);
+        foreach (var userId in userIds)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            FreeTierAccessComplianceResult result;
+            try
+            {
+                result = await freeTierAccessComplianceService.EvaluateAccessForEnforcementAsync(userId, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to evaluate free-tier compliance for user {UserId}", userId);
+                continue;
+            }
+
+            if (!result.IsApplicable || result.IsChannelSubscribed)
+                continue;
+
+            usersById.TryGetValue(userId, out var user);
+            linksByUserId.TryGetValue(userId, out var links);
+            links ??= [];
+
+            var dto = new FreeTierEnforcementCandidateDto
+            {
+                UserId = userId,
+                DisplayName = user?.DisplayName ?? user?.Email ?? $"User #{userId}",
+                Email = string.IsNullOrWhiteSpace(user?.Email) ? null : user!.Email.Trim(),
+                TelegramId = result.TelegramId,
+                ActivePlanName = result.ActivePlanName,
+                IsMergedAccount = result.IsMergedAccount,
+                IsChannelSubscribed = result.IsChannelSubscribed,
+                IdentityProviders = FormatIdentityProviders(links),
+                IsConnected = true,
+            };
+
+            var session = connectedByUserId[userId];
+            dto.VpnServerId = session.VpnServerId;
+            dto.VpnServerName = serverNameById.GetValueOrDefault(session.VpnServerId);
+            dto.CommonName = session.CommonName;
+            dto.ConnectedSince = session.ConnectedSince;
+            candidates.Add(dto);
+        }
+
+        return new GetFreeTierEnforcementCandidatesResponse
+        {
+            Candidates = candidates,
+            TotalCount = candidates.Count,
+            ConnectedCount = candidates.Count,
+        };
+    }
 
     private async Task<GetFreeTierEnforcementCandidatesResponse> CollectAsync(
         Func<FreeTierAccessComplianceResult, bool> include,
         bool connectedOnly,
         CancellationToken ct)
     {
-        var plans = await quotaPlanQueryService.GetAll(ct);
-        var freeDefaultPlanIds = plans
-            .Where(p => QuotaPlanNames.IsFreeOrDefault(p.Name))
-            .Select(p => p.Id)
-            .ToHashSet();
-
-        if (freeDefaultPlanIds.Count == 0)
-            return new GetFreeTierEnforcementCandidatesResponse();
-
-        var activeAssignments = await userQuotaPlanQueryService.GetAllActive(ct);
-        var freeTierUserIds = activeAssignments
-            .Where(a => freeDefaultPlanIds.Contains(a.QuotaPlanId))
-            .Select(a => a.UserId)
-            .Distinct()
-            .ToList();
-
+        var freeTierUserIds = await GetFreeTierUserIdsAsync(ct);
         if (freeTierUserIds.Count == 0)
             return new GetFreeTierEnforcementCandidatesResponse();
 
@@ -73,6 +141,18 @@ public sealed class FreeTierEnforcementOverviewService(
             .Where(c => !string.IsNullOrWhiteSpace(c.CommonName))
             .GroupBy(c => (c.VpnServerId, c.CommonName!), StringPairComparer.Instance)
             .ToDictionary(g => g.Key, g => g.First(), StringPairComparer.Instance);
+
+        var usersById = await userQueryService.GetByIds(freeTierUserIds, ct);
+        var linksByUserId = await userIdentityLinkQueryService.GetListByUserIds(freeTierUserIds, ct);
+
+        var allExternalIds = linksByUserId.Values
+            .SelectMany(links => links)
+            .Select(l => l.ExternalId?.Trim())
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .Cast<string>()
+            .ToList();
+        var issuedByExternalId = await issuedOvpnFileQueryService.GetAllByExternalIds(allExternalIds, ct);
 
         var candidates = new List<FreeTierEnforcementCandidateDto>();
 
@@ -94,8 +174,10 @@ public sealed class FreeTierEnforcementOverviewService(
             if (!include(result))
                 continue;
 
-            var user = await userQueryService.GetById(userId, ct);
-            var links = await userIdentityLinkQueryService.GetListByUserId(userId, ct);
+            usersById.TryGetValue(userId, out var user);
+            linksByUserId.TryGetValue(userId, out var links);
+            links ??= [];
+
             var dto = new FreeTierEnforcementCandidateDto
             {
                 UserId = userId,
@@ -108,7 +190,7 @@ public sealed class FreeTierEnforcementOverviewService(
                 IdentityProviders = FormatIdentityProviders(links),
             };
 
-            await TryAttachConnectionAsync(dto, links, connectedByServerAndCn, serverNameById, ct);
+            TryAttachConnection(dto, links, issuedByExternalId, connectedByServerAndCn, serverNameById);
             if (connectedOnly && !dto.IsConnected)
                 continue;
 
@@ -121,6 +203,89 @@ public sealed class FreeTierEnforcementOverviewService(
             TotalCount = candidates.Count,
             ConnectedCount = candidates.Count(c => c.IsConnected),
         };
+    }
+
+    private async Task<HashSet<int>> GetFreeTierUserIdsAsync(CancellationToken ct)
+    {
+        var plans = await quotaPlanQueryService.GetAll(ct);
+        var freeDefaultPlanIds = plans
+            .Where(p => QuotaPlanNames.IsFreeOrDefault(p.Name))
+            .Select(p => p.Id)
+            .ToHashSet();
+
+        if (freeDefaultPlanIds.Count == 0)
+            return [];
+
+        var activeAssignments = await userQuotaPlanQueryService.GetAllActive(ct);
+        return activeAssignments
+            .Where(a => freeDefaultPlanIds.Contains(a.QuotaPlanId))
+            .Select(a => a.UserId)
+            .ToHashSet();
+    }
+
+    private async Task<Dictionary<VpnServerClient, int>> ResolveConnectedUserIdsAsync(
+        IReadOnlyList<VpnServerClient> connected,
+        CancellationToken ct)
+    {
+        var result = new Dictionary<VpnServerClient, int>(ReferenceEqualityComparer.Instance);
+
+        var externalIds = connected
+            .Select(c => c.ExternalId?.Trim())
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .Cast<string>()
+            .ToList();
+
+        var usersByExternalId = await userQueryService.GetByExternalIds(externalIds, ct);
+
+        var unresolved = new List<VpnServerClient>();
+        foreach (var client in connected)
+        {
+            if (client.UserId is > 0)
+            {
+                result[client] = client.UserId.Value;
+                continue;
+            }
+
+            var externalId = client.ExternalId?.Trim();
+            if (!string.IsNullOrWhiteSpace(externalId) &&
+                usersByExternalId.TryGetValue(externalId, out var user))
+            {
+                result[client] = user.Id;
+                continue;
+            }
+
+            unresolved.Add(client);
+        }
+
+        if (unresolved.Count == 0)
+            return result;
+
+        var pairs = unresolved
+            .Select(c => (c.VpnServerId, c.CommonName!))
+            .Distinct()
+            .ToList();
+        var issued = await issuedOvpnFileQueryService.GetActiveByServerAndCommonNames(pairs, ct);
+        var externalByPair = issued
+            .Where(f => !string.IsNullOrWhiteSpace(f.ExternalId) && !string.IsNullOrWhiteSpace(f.CommonName))
+            .GroupBy(f => (f.VpnServerId, f.CommonName!), StringPairComparer.Instance)
+            .ToDictionary(g => g.Key, g => g.First().ExternalId!, StringPairComparer.Instance);
+
+        var fallbackExternalIds = externalByPair.Values
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var fallbackUsers = await userQueryService.GetByExternalIds(fallbackExternalIds, ct);
+
+        foreach (var client in unresolved)
+        {
+            if (!externalByPair.TryGetValue((client.VpnServerId, client.CommonName!), out var externalId))
+                continue;
+            if (!fallbackUsers.TryGetValue(externalId, out var user))
+                continue;
+            result[client] = user.Id;
+        }
+
+        return result;
     }
 
     internal static List<string> FormatIdentityProviders(IEnumerable<UserIdentityLink> links)
@@ -141,24 +306,22 @@ public sealed class FreeTierEnforcementOverviewService(
             _ => 9,
         };
 
-    private async Task TryAttachConnectionAsync(
+    private static void TryAttachConnection(
         FreeTierEnforcementCandidateDto dto,
         IReadOnlyList<UserIdentityLink> links,
+        IReadOnlyDictionary<string, List<IssuedOvpnFile>> issuedByExternalId,
         IReadOnlyDictionary<(int VpnServerId, string CommonName), VpnServerClient> connectedByServerAndCn,
-        IReadOnlyDictionary<int, string> serverNameById,
-        CancellationToken ct)
+        IReadOnlyDictionary<int, string> serverNameById)
     {
         var externalIds = links
             .Select(l => l.ExternalId?.Trim())
             .Where(id => !string.IsNullOrWhiteSpace(id))
             .Distinct(StringComparer.Ordinal)
-            .Cast<string>()
-            .ToList();
+            .Cast<string>();
 
         foreach (var externalId in externalIds)
         {
-            var issuedFiles = await issuedOvpnFileQueryService.GetAllByExternalId(externalId, ct);
-            if (issuedFiles is null)
+            if (!issuedByExternalId.TryGetValue(externalId, out var issuedFiles))
                 continue;
 
             foreach (var file in issuedFiles)

--- a/DataGateMonitor/Services/Users/FreeTierEnforcementOverviewService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierEnforcementOverviewService.cs
@@ -95,18 +95,20 @@ public sealed class FreeTierEnforcementOverviewService(
                 continue;
 
             var user = await userQueryService.GetById(userId, ct);
+            var links = await userIdentityLinkQueryService.GetListByUserId(userId, ct);
             var dto = new FreeTierEnforcementCandidateDto
             {
                 UserId = userId,
                 DisplayName = user?.DisplayName ?? user?.Email ?? $"User #{userId}",
-                Email = user?.Email,
+                Email = string.IsNullOrWhiteSpace(user?.Email) ? null : user!.Email.Trim(),
                 TelegramId = result.TelegramId,
                 ActivePlanName = result.ActivePlanName,
                 IsMergedAccount = result.IsMergedAccount,
                 IsChannelSubscribed = result.IsChannelSubscribed,
+                IdentityProviders = FormatIdentityProviders(links),
             };
 
-            await TryAttachConnectionAsync(dto, userId, connectedByServerAndCn, serverNameById, ct);
+            await TryAttachConnectionAsync(dto, links, connectedByServerAndCn, serverNameById, ct);
             if (connectedOnly && !dto.IsConnected)
                 continue;
 
@@ -121,14 +123,31 @@ public sealed class FreeTierEnforcementOverviewService(
         };
     }
 
+    internal static List<string> FormatIdentityProviders(IEnumerable<UserIdentityLink> links)
+        => links
+            .Select(l => l.Provider?.Trim().ToLowerInvariant())
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(ProviderSortKey)
+            .Cast<string>()
+            .ToList();
+
+    private static int ProviderSortKey(string? provider)
+        => provider switch
+        {
+            "google" => 0,
+            "local" => 1,
+            "telegram" => 2,
+            _ => 9,
+        };
+
     private async Task TryAttachConnectionAsync(
         FreeTierEnforcementCandidateDto dto,
-        int userId,
+        IReadOnlyList<UserIdentityLink> links,
         IReadOnlyDictionary<(int VpnServerId, string CommonName), VpnServerClient> connectedByServerAndCn,
         IReadOnlyDictionary<int, string> serverNameById,
         CancellationToken ct)
     {
-        var links = await userIdentityLinkQueryService.GetListByUserId(userId, ct);
         var externalIds = links
             .Select(l => l.ExternalId?.Trim())
             .Where(id => !string.IsNullOrWhiteSpace(id))
@@ -139,6 +158,9 @@ public sealed class FreeTierEnforcementOverviewService(
         foreach (var externalId in externalIds)
         {
             var issuedFiles = await issuedOvpnFileQueryService.GetAllByExternalId(externalId, ct);
+            if (issuedFiles is null)
+                continue;
+
             foreach (var file in issuedFiles)
             {
                 if (string.IsNullOrWhiteSpace(file.CommonName))

--- a/DataGateMonitor/Services/Users/FreeTierGraceDisconnectNotifier.cs
+++ b/DataGateMonitor/Services/Users/FreeTierGraceDisconnectNotifier.cs
@@ -101,6 +101,6 @@ public sealed class FreeTierGraceDisconnectNotifier(
     }
 
     private static string BuildTelegramMessage(string requiredChannel)
-        => "⚠️ You were disconnected from the VPN. Your grace period ended and your account still isn't " +
-           $"compliant — subscribe to {requiredChannel} or link your account in the app, then reconnect.";
+        => "⚠️ You were disconnected from the VPN. Your grace period ended and you still are not " +
+           $"subscribed to {requiredChannel}. Please subscribe, then reconnect.";
 }

--- a/DataGateMonitor/Services/Users/FreeTierUnsubscribedUserReminderService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierUnsubscribedUserReminderService.cs
@@ -1,7 +1,14 @@
+using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.AdminEmail;
+using DataGateMonitor.Services.Api.Auth.EmailConfirmation;
+using DataGateMonitor.Services.EmailTemplates;
 using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.TelegramBot.Interfaces;
 using DataGateMonitor.Services.Users.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
@@ -10,10 +17,18 @@ namespace DataGateMonitor.Services.Users;
 public sealed class FreeTierUnsubscribedUserReminderService(
     ISettingsService settingsService,
     ITelegramDirectMessageSender telegramDirectMessageSender,
+    ILocalizationService localizationService,
+    IUserIdentityLinkQueryService identityLinkQueryService,
+    IUserQueryService userQueryService,
+    IEmailSenderService emailSenderService,
+    ISystemTransactionalEmailService systemTransactionalEmailService,
+    ISentEmailLogService sentEmailLogService,
     IMemoryCache memoryCache,
     IOptions<TelegramChannelSettings> channelOptions,
     ILogger<FreeTierUnsubscribedUserReminderService> logger) : IFreeTierUnsubscribedUserReminderService
 {
+    public const string LocalizationKey = "FreeTierChannelSubscribeReminder";
+
     /// <summary>Avoid spamming the same Telegram user with subscribe reminders.</summary>
     private static readonly TimeSpan ReminderCooldown = TimeSpan.FromHours(24);
 
@@ -31,12 +46,7 @@ public sealed class FreeTierUnsubscribedUserReminderService(
             if (memoryCache.TryGetValue(cooldownKey, out _))
                 return;
 
-            var channel = channelOptions.Value.RequiredChannelChatId;
-            var text =
-                $"📢 Please subscribe to {channel} to keep using Free/Default VPN access.\n\n" +
-                $"Подпишитесь на канал {channel}, чтобы продолжать пользоваться VPN на тарифе Free/Default.";
-
-            if (!await telegramDirectMessageSender.TrySendMessageAsync(telegramId, text, ct))
+            if (!await SendTelegramReminderAsync(telegramId, ct))
             {
                 logger.LogInformation(
                     "Could not send unsubscribed reminder to TelegramId {TelegramId}. Context={Context}",
@@ -59,6 +69,188 @@ public sealed class FreeTierUnsubscribedUserReminderService(
                 telegramId,
                 context);
         }
+    }
+
+    public async Task<FreeTierChannelSubscribeRemindResponse> ForceRemindAsync(
+        string target,
+        FreeTierChannelSubscribeRemindChannel channel,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            return FreeTierChannelSubscribeRemindResponse.Fail(
+                channel,
+                channel == FreeTierChannelSubscribeRemindChannel.Email
+                    ? "Usage: /remind_channel_email <userId>"
+                    : "Usage: /remind_channel_subscribe <userId|telegramId>");
+        }
+
+        target = target.Trim();
+        if (target.StartsWith("tg:", StringComparison.OrdinalIgnoreCase))
+            target = target["tg:".Length..].Trim();
+        if (target.StartsWith("#"))
+            target = target[1..].Trim();
+
+        if (!long.TryParse(target, out var id) || id <= 0)
+            return FreeTierChannelSubscribeRemindResponse.Fail(channel, "Invalid id. Use dashboard userId or Telegram id.");
+
+        return channel switch
+        {
+            FreeTierChannelSubscribeRemindChannel.Email => await ForceRemindEmailAsync(id, ct),
+            _ => await ForceRemindTelegramAsync(id, ct),
+        };
+    }
+
+    private async Task<FreeTierChannelSubscribeRemindResponse> ForceRemindTelegramAsync(long id, CancellationToken ct)
+    {
+        int? userId = null;
+        long telegramId;
+        string resolvedAs;
+
+        if (id <= int.MaxValue)
+        {
+            var links = await identityLinkQueryService.GetListByUserId((int)id, ct);
+            var fromUser = FreeTierAccessComplianceService.TryGetTelegramId(links);
+            if (fromUser is > 0)
+            {
+                userId = (int)id;
+                telegramId = fromUser.Value;
+                resolvedAs = $"user #{id} → TG:{telegramId}";
+            }
+            else
+            {
+                telegramId = id;
+                resolvedAs = $"TG:{telegramId}";
+            }
+        }
+        else
+        {
+            telegramId = id;
+            resolvedAs = $"TG:{telegramId}";
+        }
+
+        try
+        {
+            if (!await SendTelegramReminderAsync(telegramId, ct))
+            {
+                return FreeTierChannelSubscribeRemindResponse.Fail(
+                    FreeTierChannelSubscribeRemindChannel.Telegram,
+                    $"Could not deliver Telegram reminder to {resolvedAs}. User may have blocked the bot.");
+            }
+
+            memoryCache.Set(BuildCooldownKey(telegramId), true, ReminderCooldown);
+            logger.LogInformation("Admin forced Telegram channel-subscribe reminder to {ResolvedAs}", resolvedAs);
+            return FreeTierChannelSubscribeRemindResponse.Ok(
+                FreeTierChannelSubscribeRemindChannel.Telegram,
+                $"✅ Telegram reminder sent to {resolvedAs}",
+                userId,
+                telegramId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Force Telegram channel-subscribe reminder failed for {ResolvedAs}", resolvedAs);
+            return FreeTierChannelSubscribeRemindResponse.Fail(
+                FreeTierChannelSubscribeRemindChannel.Telegram,
+                $"Failed to send Telegram reminder to {resolvedAs}.");
+        }
+    }
+
+    private async Task<FreeTierChannelSubscribeRemindResponse> ForceRemindEmailAsync(long id, CancellationToken ct)
+    {
+        if (id is <= 0 or > int.MaxValue)
+        {
+            return FreeTierChannelSubscribeRemindResponse.Fail(
+                FreeTierChannelSubscribeRemindChannel.Email,
+                "Email remind requires a dashboard userId.");
+        }
+
+        var userId = (int)id;
+        var user = await userQueryService.GetById(userId, ct);
+        if (user is null)
+        {
+            return FreeTierChannelSubscribeRemindResponse.Fail(
+                FreeTierChannelSubscribeRemindChannel.Email,
+                $"User #{userId} not found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            return FreeTierChannelSubscribeRemindResponse.Fail(
+                FreeTierChannelSubscribeRemindChannel.Email,
+                $"User #{userId} has no email on file.");
+        }
+
+        var email = user.Email.Trim();
+        var channelChat = channelOptions.Value.RequiredChannelChatId;
+        var channelUrl = channelOptions.Value.RequiredChannelUrl;
+        var displayName = string.IsNullOrWhiteSpace(user.DisplayName) ? $"User #{userId}" : user.DisplayName.Trim();
+
+        try
+        {
+            var (subject, bodyHtml) = await systemTransactionalEmailService.GetFreeTierChannelSubscribeReminderAsync(
+                displayName, channelChat, channelUrl, ct);
+
+            string? sendError = null;
+            try
+            {
+                await emailSenderService.SendAsync(email, subject, bodyHtml, ct);
+            }
+            catch (Exception ex)
+            {
+                sendError = ex.Message.Length > 4000 ? ex.Message[..4000] : ex.Message;
+                logger.LogWarning(ex, "Failed to send channel-subscribe reminder email to user {UserId}", userId);
+            }
+
+            try
+            {
+                await sentEmailLogService.LogAsync(
+                    userId, email, subject, bodyHtml, sendError is null, sendError, null, ct);
+            }
+            catch (Exception logEx)
+            {
+                logger.LogWarning(logEx, "Failed to write SentEmailLog for channel-subscribe reminder user {UserId}", userId);
+            }
+
+            if (sendError is not null)
+            {
+                return FreeTierChannelSubscribeRemindResponse.Fail(
+                    FreeTierChannelSubscribeRemindChannel.Email,
+                    $"Failed to send email to {email}.");
+            }
+
+            logger.LogInformation("Admin forced email channel-subscribe reminder to user {UserId} ({Email})", userId, email);
+            return FreeTierChannelSubscribeRemindResponse.Ok(
+                FreeTierChannelSubscribeRemindChannel.Email,
+                $"✅ Email reminder sent to user #{userId} ({email})",
+                userId,
+                email: email);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Force email channel-subscribe reminder failed for user {UserId}", userId);
+            return FreeTierChannelSubscribeRemindResponse.Fail(
+                FreeTierChannelSubscribeRemindChannel.Email,
+                $"Failed to send email reminder to user #{userId}.");
+        }
+    }
+
+    internal async Task<string> BuildLocalizedReminderTextAsync(long telegramId, CancellationToken ct)
+    {
+        var channel = channelOptions.Value.RequiredChannelChatId;
+        var channelUrl = channelOptions.Value.RequiredChannelUrl;
+        var template = await localizationService.GetTextForTelegramUser(LocalizationKey, telegramId, ct);
+        return ApplyPlaceholders(template, channel, channelUrl);
+    }
+
+    internal static string ApplyPlaceholders(string template, string channel, string channelUrl)
+        => template
+            .Replace("{channel}", channel, StringComparison.Ordinal)
+            .Replace("{channelUrl}", channelUrl, StringComparison.Ordinal);
+
+    private async Task<bool> SendTelegramReminderAsync(long telegramId, CancellationToken ct)
+    {
+        var text = await BuildLocalizedReminderTextAsync(telegramId, ct);
+        return await telegramDirectMessageSender.TrySendMessageAsync(telegramId, text, ct);
     }
 
     private async Task<bool> IsEnabledAsync(CancellationToken ct)

--- a/DataGateMonitor/Services/Users/FreeTierUnsubscribedUserReminderService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierUnsubscribedUserReminderService.cs
@@ -1,0 +1,77 @@
+using DataGateMonitor.Models.Helpers;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.TelegramBot.Interfaces;
+using DataGateMonitor.Services.Users.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace DataGateMonitor.Services.Users;
+
+public sealed class FreeTierUnsubscribedUserReminderService(
+    ISettingsService settingsService,
+    ITelegramDirectMessageSender telegramDirectMessageSender,
+    IMemoryCache memoryCache,
+    IOptions<TelegramChannelSettings> channelOptions,
+    ILogger<FreeTierUnsubscribedUserReminderService> logger) : IFreeTierUnsubscribedUserReminderService
+{
+    /// <summary>Avoid spamming the same Telegram user with subscribe reminders.</summary>
+    private static readonly TimeSpan ReminderCooldown = TimeSpan.FromHours(24);
+
+    public async Task TryRemindAsync(long telegramId, string context, CancellationToken ct = default)
+    {
+        if (telegramId <= 0)
+            return;
+
+        try
+        {
+            if (!await IsEnabledAsync(ct))
+                return;
+
+            var cooldownKey = BuildCooldownKey(telegramId);
+            if (memoryCache.TryGetValue(cooldownKey, out _))
+                return;
+
+            var channel = channelOptions.Value.RequiredChannelChatId;
+            var text =
+                $"📢 Please subscribe to {channel} to keep using Free/Default VPN access.\n\n" +
+                $"Подпишитесь на канал {channel}, чтобы продолжать пользоваться VPN на тарифе Free/Default.";
+
+            if (!await telegramDirectMessageSender.TrySendMessageAsync(telegramId, text, ct))
+            {
+                logger.LogInformation(
+                    "Could not send unsubscribed reminder to TelegramId {TelegramId}. Context={Context}",
+                    telegramId,
+                    context);
+                return;
+            }
+
+            memoryCache.Set(cooldownKey, true, ReminderCooldown);
+            logger.LogInformation(
+                "Sent channel-subscribe reminder to TelegramId {TelegramId}. Context={Context}",
+                telegramId,
+                context);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to send unsubscribed reminder to TelegramId {TelegramId}. Context={Context}",
+                telegramId,
+                context);
+        }
+    }
+
+    private async Task<bool> IsEnabledAsync(CancellationToken ct)
+    {
+        var typeKey = $"{FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders}_Type";
+        var type = await settingsService.GetValueAsync<string>(typeKey, ct);
+        if (!string.Equals(type, "bool", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return await settingsService.GetValueAsync<bool>(
+            FreeTierAccessSettingsKeys.SendUnsubscribedUserReminders,
+            ct);
+    }
+
+    internal static string BuildCooldownKey(long telegramId) => $"free-tier-unsub-reminder:{telegramId}";
+}

--- a/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using DataGateMonitor.Services.Others;
+using DataGateMonitor.Services.TelegramBot.Interfaces;
+using DataGateMonitor.Services.Users.Interfaces;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DataGateMonitor.Services.Users;
+
+public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
+    ISettingsService settingsService,
+    IFreeTierEnforcementOverviewService overviewService,
+    ITelegramUserService telegramUserService,
+    ITelegramDirectMessageSender telegramDirectMessageSender,
+    IMemoryCache memoryCache,
+    ILogger<FreeTierUnsubscribedVpnUsersDailyDigestService> logger)
+    : IFreeTierUnsubscribedVpnUsersDailyDigestService
+{
+    private const string LastSentUtcDateCacheKey = "free-tier-unsub-admin-digest:last-utc-date";
+
+    public async Task TrySendDailyDigestAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            if (!await IsEnabledAsync(ct))
+            {
+                logger.LogDebug("Daily unsubscribed VPN-users admin digest is disabled.");
+                return;
+            }
+
+            var todayUtc = DateOnly.FromDateTime(DateTime.UtcNow);
+            if (memoryCache.TryGetValue(LastSentUtcDateCacheKey, out DateOnly lastSent) && lastSent == todayUtc)
+                return;
+
+            var message = await BuildDigestTextAsync(ct);
+
+            var admins = await telegramUserService.GetAdminsAsync(ct);
+            if (admins.Count == 0)
+            {
+                logger.LogWarning("No Telegram bot admins configured; skipping unsubscribed VPN digest.");
+                return;
+            }
+
+            var anySent = false;
+            foreach (var admin in admins)
+            {
+                if (await telegramDirectMessageSender.TrySendMessageAsync(admin.TelegramId, message, ct))
+                    anySent = true;
+            }
+
+            if (!anySent)
+            {
+                logger.LogWarning("Failed to deliver unsubscribed VPN digest to any admin.");
+                return;
+            }
+
+            var untilTomorrow = todayUtc.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - DateTime.UtcNow;
+            if (untilTomorrow < TimeSpan.FromMinutes(1))
+                untilTomorrow = TimeSpan.FromMinutes(1);
+
+            memoryCache.Set(LastSentUtcDateCacheKey, todayUtc, untilTomorrow);
+            logger.LogInformation("Sent daily unsubscribed VPN digest to admins.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to send daily unsubscribed VPN-users admin digest.");
+        }
+    }
+
+    public async Task<string> BuildDigestTextAsync(CancellationToken ct = default)
+    {
+        var todayUtc = DateOnly.FromDateTime(DateTime.UtcNow);
+        var overview = await overviewService.GetUnsubscribedConnectedAsync(ct);
+        var connectedUnsubscribed = overview.Candidates
+            .OrderBy(c => c.DisplayName)
+            .ToList();
+
+        return BuildDigestMessage(todayUtc, connectedUnsubscribed.Count, connectedUnsubscribed);
+    }
+
+    internal static string BuildDigestMessage(
+        DateOnly dayUtc,
+        int totalConnected,
+        IReadOnlyList<FreeTierEnforcementCandidateDto> users)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("📋 Free/Default VPN without Telegram channel subscription");
+        sb.AppendLine($"Date (UTC): {dayUtc:yyyy-MM-dd}");
+        sb.AppendLine($"Currently online: {totalConnected}");
+
+        if (totalConnected == 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("No connected Free/Default users without channel subscription.");
+            return sb.ToString();
+        }
+
+        sb.AppendLine();
+        const int maxLines = 40;
+        var shown = 0;
+        foreach (var user in users)
+        {
+            if (shown >= maxLines)
+            {
+                sb.AppendLine($"… and {totalConnected - maxLines} more");
+                break;
+            }
+
+            var tg = user.TelegramId is > 0 ? user.TelegramId.ToString() : "—";
+            var server = string.IsNullOrWhiteSpace(user.VpnServerName) ? "?" : user.VpnServerName;
+            var merged = user.IsMergedAccount ? "merged" : "not-merged";
+            sb.AppendLine($"• #{user.UserId} {user.DisplayName} | TG:{tg} | {server} | {merged}");
+            shown++;
+        }
+
+        return sb.ToString();
+    }
+
+    private async Task<bool> IsEnabledAsync(CancellationToken ct)
+    {
+        var typeKey = $"{FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest}_Type";
+        var type = await settingsService.GetValueAsync<string>(typeKey, ct);
+        if (!string.Equals(type, "bool", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return await settingsService.GetValueAsync<bool>(
+            FreeTierAccessSettingsKeys.DailyUnsubscribedAdminDigest,
+            ct);
+    }
+}

--- a/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
@@ -18,6 +18,8 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
     : IFreeTierUnsubscribedVpnUsersDailyDigestService
 {
     private const string LastSentUtcDateCacheKey = "free-tier-unsub-admin-digest:last-utc-date";
+    private const string DigestResultCacheKey = "free-tier-unsub-admin-digest:result";
+    private static readonly TimeSpan DigestResultTtl = TimeSpan.FromSeconds(30);
 
     public async Task TrySendDailyDigestAsync(CancellationToken ct = default)
     {
@@ -70,17 +72,25 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
 
     public async Task<FreeTierUnsubscribedVpnDigestResponse> BuildDigestAsync(CancellationToken ct = default)
     {
+        if (memoryCache.TryGetValue(DigestResultCacheKey, out FreeTierUnsubscribedVpnDigestResponse? cached) &&
+            cached is not null)
+        {
+            return cached;
+        }
+
         var todayUtc = DateOnly.FromDateTime(DateTime.UtcNow);
         var overview = await overviewService.GetUnsubscribedConnectedAsync(ct);
         var candidates = overview.Candidates
             .OrderBy(c => c.DisplayName)
             .ToList();
 
-        return new FreeTierUnsubscribedVpnDigestResponse
+        var result = new FreeTierUnsubscribedVpnDigestResponse
         {
             Text = BuildDigestMessage(todayUtc, candidates),
             Candidates = candidates,
         };
+        memoryCache.Set(DigestResultCacheKey, result, DigestResultTtl);
+        return result;
     }
 
     /// <summary>

--- a/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
@@ -3,6 +3,7 @@ using DataGateMonitor.Services.Others;
 using DataGateMonitor.Services.TelegramBot.Interfaces;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Dto;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace DataGateMonitor.Services.Users;
@@ -32,7 +33,8 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
             if (memoryCache.TryGetValue(LastSentUtcDateCacheKey, out DateOnly lastSent) && lastSent == todayUtc)
                 return;
 
-            var message = await BuildDigestTextAsync(ct);
+            var digest = await BuildDigestAsync(ct);
+            var message = digest.Text;
 
             var admins = await telegramUserService.GetAdminsAsync(ct);
             if (admins.Count == 0)
@@ -68,25 +70,38 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
     }
 
     public async Task<string> BuildDigestTextAsync(CancellationToken ct = default)
+        => (await BuildDigestAsync(ct)).Text;
+
+    public async Task<FreeTierUnsubscribedVpnDigestResponse> BuildDigestAsync(CancellationToken ct = default)
     {
         var todayUtc = DateOnly.FromDateTime(DateTime.UtcNow);
         var overview = await overviewService.GetUnsubscribedConnectedAsync(ct);
-        var connectedUnsubscribed = overview.Candidates
+        var candidates = overview.Candidates
             .OrderBy(c => c.DisplayName)
             .ToList();
 
-        return BuildDigestMessage(todayUtc, connectedUnsubscribed.Count, connectedUnsubscribed);
+        return new FreeTierUnsubscribedVpnDigestResponse
+        {
+            Text = BuildDigestMessage(todayUtc, candidates),
+            Candidates = candidates,
+        };
     }
 
     internal static string BuildDigestMessage(
         DateOnly dayUtc,
-        int totalConnected,
         IReadOnlyList<FreeTierEnforcementCandidateDto> users)
     {
+        var merged = users.Where(u => u.IsMergedAccount).OrderBy(u => u.DisplayName).ToList();
+        var notMerged = users.Where(u => !u.IsMergedAccount).OrderBy(u => u.DisplayName).ToList();
+        var totalConnected = users.Count;
+
         var sb = new StringBuilder();
+        sb.AppendLine("📅 Daily digest");
         sb.AppendLine("📋 Free/Default VPN without Telegram channel subscription");
         sb.AppendLine($"Date (UTC): {dayUtc:yyyy-MM-dd}");
         sb.AppendLine($"Currently online: {totalConnected}");
+        sb.AppendLine($"Merged (linked): {merged.Count}");
+        sb.AppendLine($"Not merged: {notMerged.Count}");
 
         if (totalConnected == 0)
         {
@@ -95,25 +110,61 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
             return sb.ToString();
         }
 
+        AppendUserSection(sb, "🔗 Merged (linked accounts)", merged);
+        AppendUserSection(sb, "👤 Not merged", notMerged);
+
         sb.AppendLine();
+        sb.AppendLine("Remind TG: /remind_channel_subscribe <userId|telegramId>");
+        sb.AppendLine("Remind email: tap Email #id below or /remind_channel_email <userId>");
+
+        return sb.ToString();
+    }
+
+    internal static string FormatUserLine(FreeTierEnforcementCandidateDto user)
+    {
+        var tg = user.TelegramId is > 0 ? user.TelegramId.ToString() : "—";
+        var server = string.IsNullOrWhiteSpace(user.VpnServerName) ? "?" : user.VpnServerName;
+        var accountType = user.IdentityProviders is { Count: > 0 }
+            ? string.Join("+", user.IdentityProviders)
+            : "unknown";
+        var parts = new List<string>
+        {
+            $"#{user.UserId} {user.DisplayName}",
+            accountType,
+        };
+        if (!string.IsNullOrWhiteSpace(user.Email))
+            parts.Add(user.Email.Trim());
+        parts.Add($"TG:{tg}");
+        parts.Add(server);
+        return "• " + string.Join(" | ", parts);
+    }
+
+    private static void AppendUserSection(
+        StringBuilder sb,
+        string title,
+        IReadOnlyList<FreeTierEnforcementCandidateDto> users)
+    {
+        sb.AppendLine();
+        sb.AppendLine(title);
+        if (users.Count == 0)
+        {
+            sb.AppendLine("— none —");
+            return;
+        }
+
         const int maxLines = 40;
         var shown = 0;
         foreach (var user in users)
         {
             if (shown >= maxLines)
             {
-                sb.AppendLine($"… and {totalConnected - maxLines} more");
+                sb.AppendLine($"… and {users.Count - maxLines} more");
                 break;
             }
 
-            var tg = user.TelegramId is > 0 ? user.TelegramId.ToString() : "—";
-            var server = string.IsNullOrWhiteSpace(user.VpnServerName) ? "?" : user.VpnServerName;
-            var merged = user.IsMergedAccount ? "merged" : "not-merged";
-            sb.AppendLine($"• #{user.UserId} {user.DisplayName} | TG:{tg} | {server} | {merged}");
+            sb.AppendLine(FormatUserLine(user));
             shown++;
         }
-
-        return sb.ToString();
     }
 
     private async Task<bool> IsEnabledAsync(CancellationToken ct)

--- a/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
+++ b/DataGateMonitor/Services/Users/FreeTierUnsubscribedVpnUsersDailyDigestService.cs
@@ -30,7 +30,7 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
             }
 
             var todayUtc = DateOnly.FromDateTime(DateTime.UtcNow);
-            if (memoryCache.TryGetValue(LastSentUtcDateCacheKey, out DateOnly lastSent) && lastSent == todayUtc)
+            if (WasDailyDigestAlreadySent(todayUtc))
                 return;
 
             var digest = await BuildDigestAsync(ct);
@@ -56,11 +56,7 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
                 return;
             }
 
-            var untilTomorrow = todayUtc.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - DateTime.UtcNow;
-            if (untilTomorrow < TimeSpan.FromMinutes(1))
-                untilTomorrow = TimeSpan.FromMinutes(1);
-
-            memoryCache.Set(LastSentUtcDateCacheKey, todayUtc, untilTomorrow);
+            MarkDailyDigestSent(todayUtc);
             logger.LogInformation("Sent daily unsubscribed VPN digest to admins.");
         }
         catch (Exception ex)
@@ -85,6 +81,25 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
             Text = BuildDigestMessage(todayUtc, candidates),
             Candidates = candidates,
         };
+    }
+
+    /// <summary>
+    /// Treat a live admin digest fetch as the once-per-UTC-day delivery so the background job
+    /// does not re-send the same list after a deploy / process restart.
+    /// </summary>
+    public void MarkDailyDigestSatisfiedForToday()
+        => MarkDailyDigestSent(DateOnly.FromDateTime(DateTime.UtcNow));
+
+    private bool WasDailyDigestAlreadySent(DateOnly todayUtc)
+        => memoryCache.TryGetValue(LastSentUtcDateCacheKey, out DateOnly lastSent) && lastSent == todayUtc;
+
+    private void MarkDailyDigestSent(DateOnly todayUtc)
+    {
+        var untilTomorrow = todayUtc.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - DateTime.UtcNow;
+        if (untilTomorrow < TimeSpan.FromMinutes(1))
+            untilTomorrow = TimeSpan.FromMinutes(1);
+
+        memoryCache.Set(LastSentUtcDateCacheKey, todayUtc, untilTomorrow);
     }
 
     internal static string BuildDigestMessage(
@@ -114,8 +129,7 @@ public sealed class FreeTierUnsubscribedVpnUsersDailyDigestService(
         AppendUserSection(sb, "👤 Not merged", notMerged);
 
         sb.AppendLine();
-        sb.AppendLine("Remind TG: /remind_channel_subscribe <userId|telegramId>");
-        sb.AppendLine("Remind email: tap Email #id below or /remind_channel_email <userId>");
+        sb.AppendLine("Remind: tap TG #id / Email #id below, or /remind_channel_subscribe|/remind_channel_email");
 
         return sb.ToString();
     }

--- a/DataGateMonitor/Services/Users/Interfaces/IFreeTierEnforcementOverviewService.cs
+++ b/DataGateMonitor/Services/Users/Interfaces/IFreeTierEnforcementOverviewService.cs
@@ -6,10 +6,18 @@ namespace DataGateMonitor.Services.Users.Interfaces;
 public interface IFreeTierEnforcementOverviewService
 {
     /// <summary>
-    /// Every Free/Default user who is not compliant (not merged, not channel-subscribed) — i.e. every
-    /// user the enforcement job would kill on its next run, whether or not they are connected right now.
+    /// Free/Default users who are not compliant right now (channel subscription missing and no active
+    /// grace) — i.e. everyone the enforcement job would kill on its next run, whether or not they are
+    /// connected.
     /// </summary>
     Task<GetFreeTierEnforcementCandidatesResponse> GetCandidatesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Free/Default users who are currently online and not subscribed to the required channel.
+    /// Includes grace-period users (still unsubscribed). Used by the admin digest.
+    /// </summary>
+    Task<GetFreeTierEnforcementCandidatesResponse> GetUnsubscribedConnectedAsync(
+        CancellationToken ct = default);
 
     Task<GetFreeTierDisconnectLogResponse> GetDisconnectLogAsync(
         GetFreeTierDisconnectLogRequest request, CancellationToken ct = default);

--- a/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedUserReminderService.cs
+++ b/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedUserReminderService.cs
@@ -1,3 +1,6 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Enums;
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+
 namespace DataGateMonitor.Services.Users.Interfaces;
 
 public interface IFreeTierUnsubscribedUserReminderService
@@ -7,4 +10,12 @@ public interface IFreeTierUnsubscribedUserReminderService
     /// is enabled and the per-user cooldown has elapsed. Never throws.
     /// </summary>
     Task TryRemindAsync(long telegramId, string context, CancellationToken ct = default);
+
+    /// <summary>
+    /// Admin-triggered remind via Telegram DM or email. Ignores the enable flag.
+    /// </summary>
+    Task<FreeTierChannelSubscribeRemindResponse> ForceRemindAsync(
+        string target,
+        FreeTierChannelSubscribeRemindChannel channel,
+        CancellationToken ct = default);
 }

--- a/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedUserReminderService.cs
+++ b/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedUserReminderService.cs
@@ -1,0 +1,10 @@
+namespace DataGateMonitor.Services.Users.Interfaces;
+
+public interface IFreeTierUnsubscribedUserReminderService
+{
+    /// <summary>
+    /// Sends a Telegram DM asking the user to subscribe to the required channel, when the setting
+    /// is enabled and the per-user cooldown has elapsed. Never throws.
+    /// </summary>
+    Task TryRemindAsync(long telegramId, string context, CancellationToken ct = default);
+}

--- a/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedVpnUsersDailyDigestService.cs
+++ b/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedVpnUsersDailyDigestService.cs
@@ -19,4 +19,9 @@ public interface IFreeTierUnsubscribedVpnUsersDailyDigestService
     /// Live digest text plus structured candidates (for admin bot inline buttons).
     /// </summary>
     Task<FreeTierUnsubscribedVpnDigestResponse> BuildDigestAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks the once-per-UTC-day daily digest as already satisfied (e.g. after a live admin fetch).
+    /// </summary>
+    void MarkDailyDigestSatisfiedForToday();
 }

--- a/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedVpnUsersDailyDigestService.cs
+++ b/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedVpnUsersDailyDigestService.cs
@@ -1,3 +1,5 @@
+using DataGateMonitor.SharedModels.DataGateMonitor.FreeTierEnforcement.Responses;
+
 namespace DataGateMonitor.Services.Users.Interfaces;
 
 public interface IFreeTierUnsubscribedVpnUsersDailyDigestService
@@ -10,7 +12,11 @@ public interface IFreeTierUnsubscribedVpnUsersDailyDigestService
 
     /// <summary>
     /// Builds the current digest text (online Free/Default users without channel subscription).
-    /// Used by the daily job and by on-demand admin requests. Always evaluates live candidates.
     /// </summary>
     Task<string> BuildDigestTextAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Live digest text plus structured candidates (for admin bot inline buttons).
+    /// </summary>
+    Task<FreeTierUnsubscribedVpnDigestResponse> BuildDigestAsync(CancellationToken ct = default);
 }

--- a/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedVpnUsersDailyDigestService.cs
+++ b/DataGateMonitor/Services/Users/Interfaces/IFreeTierUnsubscribedVpnUsersDailyDigestService.cs
@@ -1,0 +1,16 @@
+namespace DataGateMonitor.Services.Users.Interfaces;
+
+public interface IFreeTierUnsubscribedVpnUsersDailyDigestService
+{
+    /// <summary>
+    /// When enabled, sends bot admins a digest of Free/Default users currently on VPN without
+    /// channel subscription. At most once per UTC day. Never throws.
+    /// </summary>
+    Task TrySendDailyDigestAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Builds the current digest text (online Free/Default users without channel subscription).
+    /// Used by the daily job and by on-demand admin requests. Always evaluates live candidates.
+    /// </summary>
+    Task<string> BuildDigestTextAsync(CancellationToken ct = default);
+}

--- a/DataGateMonitor/Services/Users/TelegramAccountLinkService.cs
+++ b/DataGateMonitor/Services/Users/TelegramAccountLinkService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Caching.Memory;
 using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
 using DataGateMonitor.DataBase.Services.Query.UserTable;
 using DataGateMonitor.Models;
+using DataGateMonitor.Services.TelegramBot.Interfaces;
 using DataGateMonitor.Services.Users.Interfaces;
 using DataGateMonitor.SharedModels.DataGateMonitor.Auth.Responses;
 using DataGateMonitor.SharedModels.DataGateMonitor.User.Requests;
@@ -15,6 +16,8 @@ public sealed class TelegramAccountLinkService(
     IUserQueryService userQueryService,
     IUserIdentityLinkQueryService userIdentityLinkQueryService,
     IUserMergeService userMergeService,
+    ITelegramUserService telegramUserService,
+    ITelegramAdminAlertService telegramAdminAlertService,
     IConfiguration configuration,
     ILogger<TelegramAccountLinkService> logger) : ITelegramAccountLinkService
 {
@@ -291,6 +294,14 @@ public sealed class TelegramAccountLinkService(
 
             RemoveCode(normalizedCode, dashboardUserId, telegramId);
 
+            await TryNotifyAdminsAccountsLinkedAsync(
+                telegramId,
+                dashboardUser,
+                dashboardLinks,
+                hasGoogle,
+                merge,
+                ct);
+
             return new CompleteTelegramAccountLinkResponse
             {
                 Success = true,
@@ -318,6 +329,50 @@ public sealed class TelegramAccountLinkService(
                 dashboardUserId);
 
             return Fail("Account link failed. Please try again or request a new code.");
+        }
+    }
+
+    private async Task TryNotifyAdminsAccountsLinkedAsync(
+        long telegramId,
+        User dashboardUser,
+        IReadOnlyList<UserIdentityLink> dashboardLinks,
+        bool hasGoogle,
+        MergeTelegramGoogleUsersResponse merge,
+        CancellationToken ct)
+    {
+        try
+        {
+            var tgBotUser = await telegramUserService.GetUserByTelegramIdAsync(telegramId, ct);
+            var tgFullName = $"{tgBotUser?.FirstName} {tgBotUser?.LastName}".Trim();
+            var providerLabel = hasGoogle ? "Google" : "Password";
+            var linkedExternalId = dashboardLinks.FirstOrDefault(l =>
+                    string.Equals(
+                        l.Provider,
+                        hasGoogle ? GoogleProvider : LocalProvider,
+                        StringComparison.OrdinalIgnoreCase))
+                ?.ExternalId;
+
+            await telegramAdminAlertService.NotifyAccountsLinkedAsync(
+                new TelegramAccountsLinkedAlert
+                {
+                    TelegramId = telegramId,
+                    TelegramUsername = tgBotUser?.Username,
+                    TelegramDisplayName = string.IsNullOrWhiteSpace(tgFullName) ? null : tgFullName,
+                    LinkedProviderLabel = providerLabel,
+                    LinkedDisplayName = dashboardUser.DisplayName,
+                    LinkedEmail = dashboardUser.Email,
+                    LinkedExternalId = linkedExternalId,
+                    LinkedAvatarUrl = dashboardUser.AvatarUrl,
+                    SurvivorUserId = merge.SurvivorUserId,
+                    MergedUserId = merge.MergedUserId,
+                },
+                ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Accounts-linked admin alert failed for TelegramId={TelegramId}",
+                telegramId);
         }
     }
 

--- a/DataGateMonitor/Services/Users/UserService.cs
+++ b/DataGateMonitor/Services/Users/UserService.cs
@@ -223,11 +223,14 @@ public class UserService(
 
         var paged = await userQueryService.GetPage(request, cancellationToken);
 
+        var userIds = paged.Items.Select(u => u.Id).ToList();
+        var linksByUserId = await userIdentityLinkQueryService.GetFirstByUserIds(userIds, cancellationToken);
+
         var dtos = new List<UserDto>(paged.Items.Count);
         foreach (var u in paged.Items)
         {
-            var dto = await BuildUserDtoAsync(u, cancellationToken);
-            dtos.Add(dto);
+            linksByUserId.TryGetValue(u.Id, out var link);
+            dtos.Add(BuildUserDto(u, link));
         }
 
         return new GetAllUsersResponse
@@ -318,12 +321,13 @@ public class UserService(
 
     private async Task<UserDto> BuildUserDtoAsync(User user, CancellationToken ct)
     {
-        // Map base fields
-        var dto = user.Adapt<UserDto>();
-
-        // Try enrich with identity link (first link if multiple)
-        // Requires IUserIdentityLinkQueryService.GetByUserIdAsync(int userId, CancellationToken ct)
         var link = await userIdentityLinkQueryService.GetByUserId(user.Id, ct);
+        return BuildUserDto(user, link);
+    }
+
+    private static UserDto BuildUserDto(User user, UserIdentityLink? link)
+    {
+        var dto = user.Adapt<UserDto>();
 
         if (link != null)
         {
@@ -333,7 +337,6 @@ public class UserService(
         }
         else
         {
-            // No link found — keep provider-related fields empty/neutral
             dto.Provider = string.Empty;
             dto.ExternalId = string.Empty;
             dto.ProviderRowId = null;

--- a/DataGateMonitor/Services/VpnAccess/VpnServerAccessErrorKeys.cs
+++ b/DataGateMonitor/Services/VpnAccess/VpnServerAccessErrorKeys.cs
@@ -1,0 +1,10 @@
+namespace DataGateMonitor.Services.VpnAccess;
+
+/// <summary>
+/// Machine keys returned in API error messages for bot/frontend localization via LocalizationTexts.
+/// </summary>
+public static class VpnServerAccessErrorKeys
+{
+    /// <summary>Bot key: <c>VpnServerNotAllowedByQuotaPlan</c>.</summary>
+    public const string NotAllowedByQuotaPlan = "VpnServerNotAllowedByQuotaPlan";
+}

--- a/DataGateMonitor/Services/VpnAccess/VpnServerQuotaPlanAccessGuard.cs
+++ b/DataGateMonitor/Services/VpnAccess/VpnServerQuotaPlanAccessGuard.cs
@@ -1,0 +1,50 @@
+using DataGateMonitor.DataBase.Services.Query.QuotaPlanAllowedServerTable;
+using DataGateMonitor.DataBase.Services.Query.UserIdentityLinkTable;
+using DataGateMonitor.DataBase.Services.Query.UserQuotaPlanTable;
+using DataGateMonitor.DataBase.Services.Query.UserTable;
+
+namespace DataGateMonitor.Services.VpnAccess;
+
+public interface IVpnServerQuotaPlanAccessGuard
+{
+    /// <summary>
+    /// Ensures the dashboard user linked to <paramref name="externalId"/> may use <paramref name="vpnServerId"/>.
+    /// Dashboard admins bypass the quota-plan allowlist. Users without a link or without an active plan are allowed.
+    /// </summary>
+    Task EnsureTargetUserMayUseServerAsync(string? externalId, int vpnServerId, CancellationToken ct);
+}
+
+public sealed class VpnServerQuotaPlanAccessGuard(
+    IUserIdentityLinkQueryService userIdentityLinkQueryService,
+    IUserQuotaPlanQueryService userQuotaPlanQueryService,
+    IQuotaPlanAllowedServerQueryService quotaPlanAllowedServerQueryService,
+    IUserQueryService userQueryService) : IVpnServerQuotaPlanAccessGuard
+{
+    public async Task EnsureTargetUserMayUseServerAsync(string? externalId, int vpnServerId, CancellationToken ct)
+    {
+        var trimmed = externalId?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmed))
+            return;
+
+        var link = await userIdentityLinkQueryService.GetByExternalId(trimmed, ct);
+        if (link is not { UserId: > 0 })
+            return;
+
+        var user = await userQueryService.GetById(link.UserId, ct);
+        if (user is { IsAdmin: true })
+            return;
+
+        var activePlan = await userQuotaPlanQueryService.GetActiveByUserId(link.UserId, ct);
+        if (activePlan is null)
+            return;
+
+        var allowed = await quotaPlanAllowedServerQueryService.GetByQuotaPlanIdAndServerId(
+            activePlan.QuotaPlanId,
+            vpnServerId,
+            ct);
+        if (allowed is not null)
+            return;
+
+        throw new InvalidOperationException(VpnServerAccessErrorKeys.NotAllowedByQuotaPlan);
+    }
+}

--- a/DataGateMonitor/Services/XrayNode/XrayVpnServerStatusLogService.cs
+++ b/DataGateMonitor/Services/XrayNode/XrayVpnServerStatusLogService.cs
@@ -1,15 +1,17 @@
 using DataGateMonitor.DataBase.Services.Command.Interfaces;
+using DataGateMonitor.DataBase.Services.Query.VpnServerOvpnFileConfigTable;
 using DataGateMonitor.DataBase.Services.Query.VpnServerStatusLogTable;
 using DataGateMonitor.Models;
 using DataGateMonitor.Models.XrayNode;
 using DataGateMonitor.Services.Helpers;
-using DataGateMonitor.Services.Helpers.Interfaces;
+using DataGateMonitor.SharedModels.Enums;
 
 namespace DataGateMonitor.Services.XrayNode;
 
 public sealed class XrayVpnServerStatusLogService(
     ILogger<XrayVpnServerStatusLogService> logger,
-    IExternalIpAddressService externalIpAddressService,
+    IVpnServerOvpnFileConfigQueryService vpnServerOvpnFileConfigQueryService,
+    IVpnNodePublicIpLookup vpnNodePublicIpLookup,
     IVpnServerStatusLogQueryService vpnServerStatusLogQueryService,
     ICommandService<VpnServerStatusLog, int> vpnServerStatusLogCommandService) : IXrayVpnServerStatusLogService
 {
@@ -59,9 +61,16 @@ public sealed class XrayVpnServerStatusLogService(
         if (localIp.Length > 255)
             localIp = localIp[..255];
 
-        var remoteIp = await externalIpAddressService.GetRemoteIpAddress(cancellationToken);
-        if (remoteIp.Length > 255)
-            remoteIp = remoteIp[..255];
+        var ovpnConfig = await vpnServerOvpnFileConfigQueryService.GetByVpnServerIdId(
+            server.Id, cancellationToken);
+        var nodePublicIp = await vpnNodePublicIpLookup.GetAsync(
+            server.Id, VpnServerType.Xray, cancellationToken);
+        var remoteIp = VpnServerApiUrlHelper.ResolveReportedRemoteIp(
+            nodePublicIp,
+            ovpnConfig?.VpnServerIp,
+            server.ApiUrl);
+        if (string.IsNullOrEmpty(remoteIp))
+            remoteIp = "-";
 
         var sessionId = VpnSessionIdGenerator.FromCommonNameRemoteConnectedSince(
             $"{server.Id}", "xray-node-status", StatusLogAnchorTime);

--- a/DataGateMonitor/example.appsettings.json
+++ b/DataGateMonitor/example.appsettings.json
@@ -16,6 +16,10 @@
     "Secret": "super-secret-key-should-be-at-least-16-characters",
     "RefreshPepper": "your-refresh-pepper"
   },
+  "Auth": {
+    "PublicWebBaseUrl": "https://dash.datagateapp.com",
+    "TvLoginSessionMinutes": 5
+  },
   "EmailSender": {
     "Provider": "smtp",
     "FromEmail": "noreply@datagateapp.com",

--- a/DataGateMonitor/example.appsettings.json
+++ b/DataGateMonitor/example.appsettings.json
@@ -17,7 +17,7 @@
     "RefreshPepper": "your-refresh-pepper"
   },
   "Auth": {
-    "PublicWebBaseUrl": "https://dash.datagateapp.com",
+    "PublicWebBaseUrl": "https://YOUR_PUBLIC_WEB_HOST",
     "TvLoginSessionMinutes": 5
   },
   "EmailSender": {

--- a/Schems/swagger.json
+++ b/Schems/swagger.json
@@ -441,6 +441,29 @@
         "tags": [
           "Applications"
         ],
+        "parameters": [
+          {
+            "name": "Name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ClientId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "IsRevoked",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -756,6 +779,303 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Api.Auth.Responses.RegisterUserResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/telegram/request-account-link-code": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/telegram/request-account-link-code-for-bot": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeForBotRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeForBotRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeForBotRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.RequestTelegramAccountLinkCodeForBotRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/telegram/complete-account-link": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CompleteTelegramAccountLinkFromAppRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CompleteTelegramAccountLinkFromAppRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CompleteTelegramAccountLinkFromAppRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CompleteTelegramAccountLinkFromAppRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/free-tier-access/status": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.FreeTierAccessStatusResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.FreeTierAccessStatusResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.FreeTierAccessStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/free-tier-access/connect": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.FreeTierAccessStatusResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.FreeTierAccessStatusResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.FreeTierAccessStatusResponse"
                 }
               }
             }
@@ -1094,6 +1414,284 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Api.Auth.Responses.LoginResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/tv/session": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CreateTvLoginSessionRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CreateTvLoginSessionRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CreateTvLoginSessionRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.CreateTvLoginSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.CreateTvLoginSessionResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.CreateTvLoginSessionResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.CreateTvLoginSessionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/tv/session/{sessionId}": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionPollResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionPollResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionPollResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/tv/session/by-code/{userCode}": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "parameters": [
+          {
+            "name": "userCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionPreviewResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionPreviewResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionPreviewResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/tv/session/approve": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.ApproveTvLoginSessionRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.ApproveTvLoginSessionRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.ApproveTvLoginSessionRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.ApproveTvLoginSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionActionResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionActionResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionActionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/tv/session/deny": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.DenyTvLoginSessionRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.DenyTvLoginSessionRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.DenyTvLoginSessionRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Auth.Requests.DenyTvLoginSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionActionResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionActionResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.TvLoginSessionActionResponse"
                 }
               }
             }
@@ -2014,6 +2612,144 @@
       "get": {
         "tags": [
           "CertExpiry"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/free-tier-enforcement/candidates": {
+      "get": {
+        "tags": [
+          "FreeTierEnforcement"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.FreeTierEnforcement.Responses.GetFreeTierEnforcementCandidatesResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.FreeTierEnforcement.Responses.GetFreeTierEnforcementCandidatesResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.FreeTierEnforcement.Responses.GetFreeTierEnforcementCandidatesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/free-tier-enforcement/disconnect-log": {
+      "get": {
+        "tags": [
+          "FreeTierEnforcement"
+        ],
+        "parameters": [
+          {
+            "name": "Page",
+            "in": "query",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.FreeTierEnforcement.Responses.GetFreeTierDisconnectLogResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.FreeTierEnforcement.Responses.GetFreeTierDisconnectLogResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.FreeTierEnforcement.Responses.GetFreeTierDisconnectLogResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/free-tier-enforcement/healthcheck": {
+      "get": {
+        "tags": [
+          "FreeTierEnforcement"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/free-tier-enforcement/healthcheck-with-jwt": {
+      "get": {
+        "tags": [
+          "FreeTierEnforcement"
         ],
         "responses": {
           "200": {
@@ -4687,6 +5423,28 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "TelegramId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Username",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5222,6 +5980,44 @@
         "tags": [
           "TelegramBotUser"
         ],
+        "parameters": [
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "TelegramId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "Username",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "IsAdmin",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "IsBlocked",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -5661,6 +6457,168 @@
         }
       }
     },
+    "/api/admin/tv-login-sessions": {
+      "get": {
+        "tags": [
+          "TvLoginSessionsAdmin"
+        ],
+        "parameters": [
+          {
+            "name": "approvedUserId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.GetAdminTvLoginSessionsResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.GetAdminTvLoginSessionsResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.GetAdminTvLoginSessionsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/tv-login-sessions/by-user/{userId}/summary": {
+      "get": {
+        "tags": [
+          "TvLoginSessionsAdmin"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.UserTvLoginSummaryResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.UserTvLoginSummaryResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.Auth.Responses.UserTvLoginSummaryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/tv-login-sessions/healthcheck": {
+      "get": {
+        "tags": [
+          "TvLoginSessionsAdmin"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/tv-login-sessions/healthcheck-with-jwt": {
+      "get": {
+        "tags": [
+          "TvLoginSessionsAdmin"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.String"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/users/register-from-tgbot": {
       "post": {
         "tags": [
@@ -5738,6 +6696,41 @@
               "minimum": 1,
               "type": "integer",
               "format": "int32"
+            }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Provider",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "IsAdmin",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "IsBlocked",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -5970,6 +6963,266 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Api.User.Responses.MergeTelegramGoogleUsersResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/merge-telegram-google/by-link-code": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.CompleteTelegramAccountLinkRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.CompleteTelegramAccountLinkRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.CompleteTelegramAccountLinkRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.CompleteTelegramAccountLinkRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.CompleteTelegramAccountLinkResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/audit-free-tier-access/by-telegram/{telegramId}": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "parameters": [
+          {
+            "name": "telegramId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "channelSubscribed",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "context",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.Boolean"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.Boolean"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.System.Boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/{id}/password-history": {
+      "get": {
+        "tags": [
+          "User"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.GetUserPasswordHistoryResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.GetUserPasswordHistoryResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.GetUserPasswordHistoryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/{id}/set-password": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.AdminSetUserPasswordRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.AdminSetUserPasswordRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.AdminSetUserPasswordRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/User.Requests.AdminSetUserPasswordRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.AdminSetUserPasswordResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.AdminSetUserPasswordResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.AdminSetUserPasswordResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/{id}/password-history/{historyId}/restore": {
+      "post": {
+        "tags": [
+          "User"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "historyId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.RestoreUserPasswordResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.RestoreUserPasswordResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.User.Responses.RestoreUserPasswordResponse"
                 }
               }
             }
@@ -7255,6 +8508,112 @@
         }
       }
     },
+    "/api/open-vpn-clients/kill": {
+      "post": {
+        "tags": [
+          "VpnServerClients"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.VpnServerClients.Responses.KillOpenVpnClientResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.VpnServerClients.Responses.KillOpenVpnClientResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.VpnServerClients.Responses.KillOpenVpnClientResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/vpn-sessions/kill": {
+      "post": {
+        "tags": [
+          "VpnServerClients"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpnServerClients.Requests.KillOpenVpnClientRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.VpnServerClients.Responses.KillOpenVpnClientResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.VpnServerClients.Responses.KillOpenVpnClientResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Api.VpnServerClients.Responses.KillOpenVpnClientResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/open-vpn-clients/get-all-connected": {
       "get": {
         "tags": [
@@ -7290,6 +8649,27 @@
               "minimum": 1,
               "type": "integer",
               "format": "int32"
+            }
+          },
+          {
+            "name": "CommonName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -7353,6 +8733,27 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "CommonName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7415,6 +8816,27 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "CommonName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7476,6 +8898,27 @@
               "minimum": 1,
               "type": "integer",
               "format": "int32"
+            }
+          },
+          {
+            "name": "CommonName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Search",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -7953,6 +9396,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "DisplayName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8013,6 +9463,13 @@
           },
           {
             "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "DisplayName",
             "in": "query",
             "schema": {
               "type": "string"
@@ -8450,21 +9907,30 @@
             }
           },
           {
-            "name": "page",
+            "name": "Page",
             "in": "query",
             "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
               "type": "integer",
-              "format": "int32",
-              "default": 1
+              "format": "int32"
             }
           },
           {
-            "name": "pageSize",
+            "name": "PageSize",
             "in": "query",
             "schema": {
+              "maximum": 2147483647,
+              "minimum": 1,
               "type": "integer",
-              "format": "int32",
-              "default": 20
+              "format": "int32"
+            }
+          },
+          {
+            "name": "RequestUrl",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -8645,6 +10111,13 @@
           },
           {
             "name": "ExternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "EventType",
             "in": "query",
             "schema": {
               "type": "string"
@@ -11447,6 +12920,54 @@
         },
         "additionalProperties": false
       },
+      "Api.Auth.Responses.CreateTvLoginSessionResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.CreateTvLoginSessionResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.Auth.Responses.FreeTierAccessStatusResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.FreeTierAccessStatusResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.Auth.Responses.GetAdminTvLoginSessionsResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.GetAdminTvLoginSessionsResponse"
+          }
+        },
+        "additionalProperties": false
+      },
       "Api.Auth.Responses.GetUserSessionsResponse": {
         "type": "object",
         "properties": {
@@ -11527,6 +13048,22 @@
         },
         "additionalProperties": false
       },
+      "Api.Auth.Responses.RequestTelegramAccountLinkCodeResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.RequestTelegramAccountLinkCodeResponse"
+          }
+        },
+        "additionalProperties": false
+      },
       "Api.Auth.Responses.TelegramRequestLoginCodeResponse": {
         "type": "object",
         "properties": {
@@ -11587,6 +13124,70 @@
           },
           "data": {
             "$ref": "#/components/schemas/Auth.Responses.TotpStatusResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.Auth.Responses.TvLoginSessionActionResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.TvLoginSessionActionResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.Auth.Responses.TvLoginSessionPollResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.TvLoginSessionPollResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.Auth.Responses.TvLoginSessionPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.TvLoginSessionPreviewResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.Auth.Responses.UserTvLoginSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/Auth.Responses.UserTvLoginSummaryResponse"
           }
         },
         "additionalProperties": false
@@ -11699,6 +13300,38 @@
           },
           "data": {
             "$ref": "#/components/schemas/EmailBroadcast.Responses.SendAdminEmailResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.FreeTierEnforcement.Responses.GetFreeTierDisconnectLogResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/FreeTierEnforcement.Responses.GetFreeTierDisconnectLogResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.FreeTierEnforcement.Responses.GetFreeTierEnforcementCandidatesResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/FreeTierEnforcement.Responses.GetFreeTierEnforcementCandidatesResponse"
           }
         },
         "additionalProperties": false
@@ -12369,6 +14002,38 @@
         },
         "additionalProperties": false
       },
+      "Api.User.Responses.AdminSetUserPasswordResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/User.Responses.AdminSetUserPasswordResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.User.Responses.CompleteTelegramAccountLinkResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/User.Responses.CompleteTelegramAccountLinkResponse"
+          }
+        },
+        "additionalProperties": false
+      },
       "Api.User.Responses.ConfirmUserEmailResponse": {
         "type": "object",
         "properties": {
@@ -12417,6 +14082,22 @@
         },
         "additionalProperties": false
       },
+      "Api.User.Responses.GetUserPasswordHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/User.Responses.GetUserPasswordHistoryResponse"
+          }
+        },
+        "additionalProperties": false
+      },
       "Api.User.Responses.MergeTelegramGoogleUsersResponse": {
         "type": "object",
         "properties": {
@@ -12429,6 +14110,22 @@
           },
           "data": {
             "$ref": "#/components/schemas/User.Responses.MergeTelegramGoogleUsersResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.User.Responses.RestoreUserPasswordResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/User.Responses.RestoreUserPasswordResponse"
           }
         },
         "additionalProperties": false
@@ -12637,6 +14334,22 @@
           },
           "data": {
             "$ref": "#/components/schemas/VpnServerClients.Responses.ConnectedClientsResponse"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Api.VpnServerClients.Responses.KillOpenVpnClientResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/VpnServerClients.Responses.KillOpenVpnClientResponse"
           }
         },
         "additionalProperties": false
@@ -13222,6 +14935,35 @@
         },
         "additionalProperties": false
       },
+      "Auth.Requests.ApproveTvLoginSessionRequest": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "userCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Requests.CompleteTelegramAccountLinkFromAppRequest": {
+        "required": [
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "code": {
+            "maxLength": 32,
+            "minLength": 4,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "Auth.Requests.ConfirmEmailRequest": {
         "type": "object",
         "properties": {
@@ -13230,6 +14972,35 @@
             "nullable": true
           },
           "code": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Requests.CreateTvLoginSessionRequest": {
+        "type": "object",
+        "properties": {
+          "deviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "client": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Requests.DenyTvLoginSessionRequest": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "userCode": {
             "type": "string",
             "nullable": true
           }
@@ -13327,6 +15098,31 @@
         "properties": {
           "email": {
             "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Requests.RequestTelegramAccountLinkCodeForBotRequest": {
+        "type": "object",
+        "properties": {
+          "telegramId": {
+            "maximum": 9.223372036854776E+18,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Requests.RequestTelegramAccountLinkCodeRequest": {
+        "type": "object",
+        "properties": {
+          "telegramId": {
+            "maximum": 9.223372036854776E+18,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           }
         },
@@ -13437,6 +15233,66 @@
         },
         "additionalProperties": false
       },
+      "Auth.Responses.AdminTvLoginSessionDto": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "client": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceId": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAgent": {
+            "type": "string",
+            "nullable": true
+          },
+          "approvedUserId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "approvedUserEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "approvedUserDisplayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "createDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "Auth.Responses.AuthSessionPolicyResponse": {
         "type": "object",
         "properties": {
@@ -13456,6 +15312,97 @@
           "message": {
             "type": "string",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Responses.CreateTvLoginSessionResponse": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "verificationUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "qrPayload": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pollIntervalSeconds": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "signalRHubPath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Responses.FreeTierAccessStatusResponse": {
+        "type": "object",
+        "properties": {
+          "isApplicable": {
+            "type": "boolean"
+          },
+          "isCompliant": {
+            "type": "boolean"
+          },
+          "isMergedAccount": {
+            "type": "boolean"
+          },
+          "isChannelSubscribed": {
+            "type": "boolean"
+          },
+          "isGracePeriod": {
+            "type": "boolean"
+          },
+          "graceExpiresAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isLinkedToTelegram": {
+            "type": "boolean"
+          },
+          "canRequestAccountLinkCode": {
+            "type": "boolean"
+          },
+          "activePlanName": {
+            "type": "string",
+            "nullable": true
+          },
+          "requiredChannel": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Responses.GetAdminTvLoginSessionsResponse": {
+        "type": "object",
+        "properties": {
+          "sessions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Auth.Responses.AdminTvLoginSessionDto"
+            },
+            "nullable": true
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -13614,6 +15561,20 @@
         },
         "additionalProperties": false
       },
+      "Auth.Responses.RequestTelegramAccountLinkCodeResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiresInSeconds": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
       "Auth.Responses.TelegramRequestLoginCodeResponse": {
         "type": "object",
         "properties": {
@@ -13679,6 +15640,95 @@
         },
         "additionalProperties": false
       },
+      "Auth.Responses.TvLoginSessionActionResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Responses.TvLoginSessionPollResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "userId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "token": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "refreshToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "refreshExpiration": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "requiresTotp": {
+            "type": "boolean"
+          },
+          "loginChallengeId": {
+            "type": "string",
+            "nullable": true
+          },
+          "requiresTotpSetup": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Responses.TvLoginSessionPreviewResponse": {
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "Auth.Responses.UserSessionDto": {
         "type": "object",
         "properties": {
@@ -13704,6 +15754,32 @@
           },
           "isCurrent": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Auth.Responses.UserTvLoginSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "hasUsedTvLogin": {
+            "type": "boolean"
+          },
+          "approvedOrConsumedCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lastUsedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastDeviceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastClient": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -14560,6 +16636,14 @@
         "type": "integer",
         "format": "int32"
       },
+      "Enums.DisconnectReason": {
+        "enum": [
+          0,
+          1
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
       "Enums.Language": {
         "enum": [
           1,
@@ -14617,6 +16701,151 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "FreeTierEnforcement.Dto.FreeTierDisconnectLogEntryDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "userId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "userDisplayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "vpnServerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "vpnServerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "commonName": {
+            "type": "string",
+            "nullable": true
+          },
+          "reason": {
+            "$ref": "#/components/schemas/Enums.DisconnectReason"
+          },
+          "initiatedByUserId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "initiatedByDisplayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "revokeRequested": {
+            "type": "boolean"
+          },
+          "revokeSucceeded": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "killSucceeded": {
+            "type": "boolean"
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FreeTierEnforcement.Dto.FreeTierEnforcementCandidateDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "telegramId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "activePlanName": {
+            "type": "string",
+            "nullable": true
+          },
+          "isMergedAccount": {
+            "type": "boolean"
+          },
+          "isChannelSubscribed": {
+            "type": "boolean"
+          },
+          "isConnected": {
+            "type": "boolean"
+          },
+          "vpnServerId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "vpnServerName": {
+            "type": "string",
+            "nullable": true
+          },
+          "commonName": {
+            "type": "string",
+            "nullable": true
+          },
+          "connectedSince": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "FreeTierEnforcement.Responses.GetFreeTierDisconnectLogResponse": {
+        "type": "object",
+        "properties": {
+          "entries": {
+            "$ref": "#/components/schemas/Paged.FreeTierEnforcement.Dto.FreeTierDisconnectLogEntryDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FreeTierEnforcement.Responses.GetFreeTierEnforcementCandidatesResponse": {
+        "type": "object",
+        "properties": {
+          "candidates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FreeTierEnforcement.Dto.FreeTierEnforcementCandidateDto"
+            },
+            "nullable": true
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "connectedCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
       },
       "GeoLite.Dto.OpenVpnGeoInfo": {
         "type": "object",
@@ -15290,6 +17519,44 @@
               "$ref": "#/components/schemas/OpenVpnFiles.Responses.Dto.IssuedOvpnFileTokenDto"
             },
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Paged.FreeTierEnforcement.Dto.FreeTierDisconnectLogEntryDto": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FreeTierEnforcement.Dto.FreeTierDisconnectLogEntryDto"
+            },
+            "nullable": true
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "hasNext": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "hasPrev": {
+            "type": "boolean",
+            "readOnly": true
           }
         },
         "additionalProperties": false
@@ -16077,6 +18344,94 @@
         },
         "additionalProperties": false
       },
+      "User.Dto.UserPasswordHistoryItemDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "userId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "passwordAlgo": {
+            "type": "string",
+            "nullable": true
+          },
+          "recordedAtUtc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "setByActor": {
+            "$ref": "#/components/schemas/User.PasswordSetActorKind"
+          },
+          "setByUserId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "setByDisplayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "isCurrent": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "User.PasswordSetActorKind": {
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "User.Requests.AdminSetUserPasswordRequest": {
+        "required": [
+          "newPassword"
+        ],
+        "type": "object",
+        "properties": {
+          "newPassword": {
+            "minLength": 8,
+            "type": "string"
+          },
+          "reason": {
+            "maxLength": 256,
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "User.Requests.CompleteTelegramAccountLinkRequest": {
+        "required": [
+          "code"
+        ],
+        "type": "object",
+        "properties": {
+          "code": {
+            "maxLength": 32,
+            "minLength": 4,
+            "type": "string"
+          },
+          "telegramId": {
+            "maximum": 9.223372036854776E+18,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
       "User.Requests.MergeTelegramGoogleUsersRequest": {
         "required": [
           "googleUserId",
@@ -16136,6 +18491,35 @@
           "isPremium": {
             "type": "boolean",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "User.Responses.AdminSetUserPasswordResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "User.Responses.CompleteTelegramAccountLinkResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "merge": {
+            "$ref": "#/components/schemas/User.Responses.MergeTelegramGoogleUsersResponse"
           }
         },
         "additionalProperties": false
@@ -16231,6 +18615,19 @@
         "properties": {
           "isEmailConfirmed": {
             "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "User.Responses.GetUserPasswordHistoryResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User.Dto.UserPasswordHistoryItemDto"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -16361,6 +18758,19 @@
           "emailBroadcastTemplatesUpdated": {
             "type": "integer",
             "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "User.Responses.RestoreUserPasswordResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -17106,6 +19516,34 @@
         },
         "additionalProperties": false
       },
+      "VpnServerClients.Requests.KillOpenVpnClientRequest": {
+        "required": [
+          "commonName",
+          "vpnServerId"
+        ],
+        "type": "object",
+        "properties": {
+          "vpnServerId": {
+            "maximum": 2147483647,
+            "minimum": 1,
+            "type": "integer",
+            "format": "int32"
+          },
+          "commonName": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "managementClientId": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "revokeCertificate": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "VpnServerClients.Responses.ConnectedClientsResponse": {
         "type": "object",
         "properties": {
@@ -17118,6 +19556,26 @@
             "items": {
               "$ref": "#/components/schemas/VpnServers.Dto.VpnClientInfoDto"
             },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "VpnServerClients.Responses.KillOpenVpnClientResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "revokeAttempted": {
+            "type": "boolean"
+          },
+          "revokeSucceeded": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
             "nullable": true
           }
         },
@@ -18679,6 +21137,9 @@
       "name": "CertExpiry"
     },
     {
+      "name": "FreeTierEnforcement"
+    },
+    {
       "name": "GeoLite"
     },
     {
@@ -18713,6 +21174,9 @@
     },
     {
       "name": "TelegramBotUser"
+    },
+    {
+      "name": "TvLoginSessionsAdmin"
     },
     {
       "name": "User"

--- a/scripts/test-coverage.sh
+++ b/scripts/test-coverage.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Collect Cobertura coverage for DataGateMonitor.Tests (excludes nothing by default;
+# interpret Main API % separately from DataGateMonitor.DataBase/Migrations).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-/tmp/datagatemonitor-coverage}"
+mkdir -p "$OUT"
+dotnet test "$ROOT/DataGateMonitor.Tests/DataGateMonitor.Tests.csproj" \
+  --collect:"XPlat Code Coverage" \
+  --results-directory "$OUT" \
+  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+echo "Coverage results under: $OUT"
+find "$OUT" -name 'coverage.cobertura.xml' -print


### PR DESCRIPTION
## Summary
- Report node PublicIp / online presence and admin TV linking/auth hardening.
- Add Free/Default channel subscription enforcement, unsubscribed VPN digest, and email/TG remind flows (SharedModels through 1.0.50).
- Speed overview/status hot paths with caching and query improvements; expand test coverage (through 1.0.3.94).

## Test plan
- [ ] Verify `/api/info` exposes PublicIp for VPN nodes
- [ ] Confirm free-tier unsubscribed digest + remind endpoints and daily digest dedupe
- [ ] Smoke overview/users/status endpoints for latency and unchanged response shapes
- [ ] Run backend unit/integration tests and coverage scripts